### PR TITLE
Fix PR comment permission for GPU smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ on:
         default: "20000"
         type: string
 
+permissions:
+  pull-requests: write
+
 env:
   WANDB_CI_PROJECT: factorion
   PYTHON_VERSION: "3.11"


### PR DESCRIPTION
## Summary
- Adds `permissions: pull-requests: write` to the CI workflow so the `GITHUB_TOKEN` can post smoke test results as PR comments via `gh pr comment`

## Test plan
- [ ] Add `gpu-test` label to this PR and verify the comment gets posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)