### PR TITLE
Fix PR comment permission: add pull-requests: write

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ on:
         type: string
 
 permissions:
+  contents: read
   pull-requests: write
 
 env:


### PR DESCRIPTION
The GITHUB_TOKEN needs explicit pull-requests: write permission
to post comments via gh pr comment.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>