### PR TITLE
Fix CI benchmark comparing PR branch against itself instead of main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,8 +384,8 @@ jobs:
           SSH_HOST=$(python -c "import json; print(json.load(open('/tmp/pod_info.json'))['ssh_host'])")
           SSH_PORT=$(python -c "import json; print(json.load(open('/tmp/pod_info.json'))['ssh_port'])")
 
+          # Include .git so the benchmark script can checkout main for baseline
           tar czf /tmp/factorion.tar.gz \
-            --exclude='.git' \
             --exclude='artifacts' \
             --exclude='wandb' \
             --exclude='runs' \

--- a/scripts/ci/gpu_benchmark.sh
+++ b/scripts/ci/gpu_benchmark.sh
@@ -160,10 +160,14 @@ else
         fi
         cp -r "$WORK_DIR" "$MAIN_WORK_DIR"
         cd "$MAIN_WORK_DIR"
-        git checkout main -- . 2>/dev/null || git checkout master -- . 2>/dev/null || {
-            echo ">>> WARNING: Could not checkout main/master. Using current code as baseline."
-            cd "$WORK_DIR"
-        }
+
+        if ! git checkout main -- . 2>/dev/null && ! git checkout master -- . 2>/dev/null; then
+            echo ">>> ERROR: Could not checkout main/master for baseline comparison."
+            echo ">>> Ensure .git is included in the tarball transfer (fetch-depth: 0 required)."
+            echo ">>> Refusing to compare PR against itself."
+            exit 1
+        fi
+        echo ">>> Successfully checked out main branch for baseline"
 
         # Rebuild Rust extension for baseline
         if [ -f factorion_rs/Cargo.toml ]; then


### PR DESCRIPTION
The gpu-benchmark job excluded .git from the tarball transferred to
RunPod, making `git checkout main` always fail. The fallback silently
used the PR code as the baseline, so every benchmark compared the PR
against itself and always reported "No significant difference."

Two fixes:
- Remove --exclude='.git' from the benchmark tarball so main branch
  history is available on the pod (fetch-depth: 0 was already set)
- Replace the silent fallback with a hard error so this class of bug
  is caught immediately

https://claude.ai/code/session_01LaVSAiP9hxLYpNk76w9dLm