### PR TITLE
Migrate from TensorBoard to Weights & Biases logging

### DIFF
--- a/scripts/ci/apply_sweep_best.py
+++ b/scripts/ci/apply_sweep_best.py
@@ -148,7 +148,7 @@ def main():
         sys.exit(1)
 
     metric_cfg = sweep.config.get("metric", {})
-    metric_name = metric_cfg.get("name", "moving_avg/curriculum_score")
+    metric_name = metric_cfg.get("name", "curriculum/score")
     metric_goal = metric_cfg.get("goal", "maximize")
     reverse = metric_goal == "maximize"
 

--- a/scripts/ci/baseline.json
+++ b/scripts/ci/baseline.json
@@ -1,11 +1,11 @@
 {
-    "losses/value_loss": {
+    "losses/value": {
         "max": 100.0,
         "direction": "lower",
         "required": true,
         "_comment": "Sanity check: value loss should not explode"
     },
-    "losses/policy_loss": {
+    "losses/policy": {
         "max": 10.0,
         "direction": "lower",
         "required": true,
@@ -17,12 +17,12 @@
         "required": false,
         "_comment": "Entropy should stay positive (agent is still exploring)"
     },
-    "charts/learning_rate": {
+    "optim/lr": {
         "min": 0.0,
         "required": false,
         "_comment": "Learning rate should remain non-negative"
     },
-    "moving_avg/throughput": {
+    "curriculum/throughput_avg": {
         "min": 0.6724,
         "direction": "higher",
         "required": false,

--- a/scripts/ci/sweep_report.py
+++ b/scripts/ci/sweep_report.py
@@ -53,7 +53,7 @@ def main():
         sys.exit(1)
 
     metric_cfg = sweep.config.get("metric", {})
-    metric_name = metric_cfg.get("name", "moving_avg/throughput")
+    metric_name = metric_cfg.get("name", "curriculum/throughput_avg")
     metric_goal = metric_cfg.get("goal", "maximize")
     sweep_params = sweep.config.get("parameters", {})
     reverse = metric_goal == "maximize"

--- a/sweep.yaml
+++ b/sweep.yaml
@@ -3,7 +3,7 @@
 method: bayes
 run_cap: 20
 metric:
-  name: "moving_avg/curriculum_score"
+  name: "curriculum/score"
   goal: maximize
 
 parameters:


### PR DESCRIPTION
## Summary
This PR migrates the experiment logging infrastructure from TensorBoard (`SummaryWriter`) to Weights & Biases (W&B), improving metric organization and reducing logging overhead.

## Key Changes

- **Removed TensorBoard dependency**: Deleted `SummaryWriter` import and all `writer.add_scalar()` calls throughout the training loop
- **Implemented W&B metric definitions**: Added `wandb.define_metric()` calls to organize metrics into logical groups (episode, shaping, curriculum, losses, optim, perf) with appropriate summary aggregation strategies
- **Refactored episode metric collection**: Introduced `_record_episode()` and `_flush_episode_means()` helper functions to accumulate episode-level metrics during rollouts and log aggregated means once per iteration, replacing individual scalar writes
- **Consolidated per-iteration logging**: Replaced scattered `writer.add_scalar()` calls with a single `wandb.log()` call per iteration, improving efficiency and consistency
- **Removed performance timing instrumentation**: Deleted timing measurements for `get_action_for_rollout`, `get_action_for_optim`, and `backward_and_step` operations that were being logged as per-second metrics
- **Cleaned up W&B initialization**: Removed deprecated parameters (`sync_tensorboard`, `monitor_gym`) from `wandb.init()`
- **Updated metric naming**: Standardized metric names across the codebase (e.g., `losses/value_loss` → `losses/value`, `moving_avg/throughput` → `curriculum/throughput_avg`)
- **Updated CI/sweep configurations**: Updated baseline.json and sweep scripts to reference new metric names

## Implementation Details

- Episode metrics are now accumulated in a dictionary during the rollout phase and flushed at the end of each iteration, reducing logging calls and improving organization
- Curriculum metrics (level, score, throughput_avg) are preserved with their original moving average logic
- All metrics are logged with `global_step` as the step metric for consistent x-axis alignment in W&B
- Removed the global `global_num_optimiser_steps` counter as it's no longer needed

https://claude.ai/code/session_01QQvW5iWoBioqnC7Md2q2Vr