### PR TITLE
Handle RunPod API uptime field changes and add creation timestamp fallback

### DIFF
--- a/scripts/ci/runpod_create.py
+++ b/scripts/ci/runpod_create.py
@@ -104,6 +104,7 @@ def create_pod(gpu_type: str, name_prefix: str = "ci", timeout: int = POD_START_
                 "ssh_port": ssh_port,
                 "gpu_type": status.get("machine", {}).get("gpuDisplayName", "unknown"),
                 "status": "running",
+                "created_at": time.time(),
             }
 
         print(f"  Waiting... ({elapsed}s, desired={desired})", flush=True)


### PR DESCRIPTION
## Summary
Updates the RunPod pod cost calculation logic to handle API changes where the top-level `uptimeSeconds` field is deprecated and returns 0. The code now prefers the newer `runtime.uptimeInSeconds` field and falls back to computing elapsed time from a pod creation timestamp when neither uptime field is available.

## Key Changes
- **Updated `query_pod_cost()` function** to implement a three-tier fallback strategy for uptime calculation:
  1. Prefer `runtime.uptimeInSeconds` (current API)
  2. Fall back to legacy `uptimeSeconds` field
  3. Compute from `created_at` timestamp if both API fields return 0
  
- **Added `created_at` parameter** to `query_pod_cost()` to support timestamp-based fallback calculation

- **Updated `runpod_create.py`** to capture and store the pod creation timestamp (`time.time()`) in the pod info JSON, enabling the fallback mechanism

- **Updated `runpod_destroy.py`** to read and pass the `created_at` timestamp from pod info to the cost calculation function

- **Added comprehensive test coverage** with three test cases:
  - `test_cost_from_runtime_uptime_in_seconds`: Validates preference for current API field
  - `test_cost_from_legacy_uptime_seconds`: Validates fallback to legacy field
  - `test_cost_from_created_at_fallback`: Validates timestamp-based fallback calculation

- **Added type hints** with `from __future__ import annotations` for better code clarity

## Implementation Details
The uptime resolution logic uses Python's `or` operator to gracefully handle zero/None values:
```python
uptime_seconds = runtime.get("uptimeInSeconds") or pod.get("uptimeSeconds") or 0
if not uptime_seconds and created_at is not None:
    uptime_seconds = max(0, time.time() - created_at)
```

This ensures backward compatibility while supporting the API transition and providing a reliable fallback mechanism for accurate cost reporting.

https://claude.ai/code/session_016ojFhE2SsQFBdh1CxVVEpn