### PR TITLE
Update sweep config for 5M-step runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ on:
       sweep_agents_per_pod:
         description: "Parallel wandb agents per pod (GPU time-slicing)"
         required: false
-        default: "5"
+        default: "3"
         type: string
 
 permissions:
@@ -624,7 +624,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.sweep-setup.outputs.matrix) }}
     runs-on: ubuntu-latest
-    timeout-minutes: 240
+    timeout-minutes: 480
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ on:
       sweep_agents_per_pod:
         description: "Parallel wandb agents per pod (GPU time-slicing)"
         required: false
-        default: "5"
+        default: "10"
         type: string
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ on:
       sweep_agents_per_pod:
         description: "Parallel wandb agents per pod (GPU time-slicing)"
         required: false
-        default: "3"
+        default: "5"
         type: string
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -624,7 +624,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.sweep-setup.outputs.matrix) }}
     runs-on: ubuntu-latest
-    timeout-minutes: 480
+    timeout-minutes: 360
     steps:
       - uses: actions/checkout@v4
         with:
@@ -647,6 +647,8 @@ jobs:
           Host *
             StrictHostKeyChecking no
             UserKnownHostsFile /dev/null
+            ServerAliveInterval 15
+            ServerAliveCountMax 12
             LogLevel ERROR
           EOF
 
@@ -719,18 +721,45 @@ jobs:
             scripts/ci/gpu_sweep.sh \
             root@"$SSH_HOST":/workspace/gpu_sweep.sh
 
-          ssh -i ~/.ssh/runpod_ci -p "$SSH_PORT" root@"$SSH_HOST" \
-            WANDB_API_KEY="$WANDB_API_KEY" \
-            WANDB_PROJECT="${{ env.WANDB_CI_PROJECT }}" \
-            SWEEP_ID="$SWEEP_PATH" \
-            SWEEP_COUNT="$COUNT_PER_AGENT" \
-            AGENTS_PER_POD="$AGENTS_PER_POD" \
-            AGENT_ID="$AGENT_ID" \
-            PR_NUMBER="$PR_NUMBER" \
-            COMMIT_SHA="$GITHUB_SHA" \
-            RUNPOD_API_KEY="$RUNPOD_API_KEY" \
-            RUNPOD_POD_ID="$POD_ID" \
-            bash /workspace/gpu_sweep.sh
+          # Launch sweep detached from SSH session so it survives disconnects.
+          # The script writes its exit code to /workspace/sweep_done when finished.
+          ssh -i ~/.ssh/runpod_ci -p "$SSH_PORT" root@"$SSH_HOST" bash -c "'
+            export WANDB_API_KEY=\"$WANDB_API_KEY\"
+            export WANDB_PROJECT=\"${{ env.WANDB_CI_PROJECT }}\"
+            export SWEEP_ID=\"$SWEEP_PATH\"
+            export SWEEP_COUNT=\"$COUNT_PER_AGENT\"
+            export AGENTS_PER_POD=\"$AGENTS_PER_POD\"
+            export AGENT_ID=\"$AGENT_ID\"
+            export PR_NUMBER=\"$PR_NUMBER\"
+            export COMMIT_SHA=\"$GITHUB_SHA\"
+            export RUNPOD_API_KEY=\"$RUNPOD_API_KEY\"
+            export RUNPOD_POD_ID=\"$POD_ID\"
+            nohup bash -c \"bash /workspace/gpu_sweep.sh; echo \\\$? > /workspace/sweep_done\" \
+              > /workspace/sweep_stdout.log 2>&1 &
+            echo \$!
+          '"
+
+          echo ">>> Sweep launched in background on pod, polling for completion..."
+
+          # Poll every 60s until /workspace/sweep_done exists
+          while true; do
+            DONE=$(ssh -i ~/.ssh/runpod_ci -p "$SSH_PORT" -o ConnectTimeout=10 \
+              root@"$SSH_HOST" "cat /workspace/sweep_done 2>/dev/null" 2>/dev/null || echo "")
+            if [ -n "$DONE" ]; then
+              echo ">>> Sweep finished with exit code: $DONE"
+              # Dump tail of logs
+              ssh -i ~/.ssh/runpod_ci -p "$SSH_PORT" root@"$SSH_HOST" \
+                "tail -50 /workspace/sweep_stdout.log" 2>/dev/null || true
+              if [ "$DONE" != "0" ]; then
+                echo "ERROR: Sweep failed"
+                exit 1
+              fi
+              break
+            fi
+            # Print a heartbeat with timestamp
+            echo "  [$(date -u +%H:%M:%S)] Sweep still running..."
+            sleep 60
+          done
 
       - name: Destroy RunPod instance
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ on:
       sweep_agents_per_pod:
         description: "Parallel wandb agents per pod (GPU time-slicing)"
         required: false
-        default: "10"
+        default: "5"
         type: string
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ on:
       sweep_count:
         description: "Total number of sweep iterations"
         required: false
-        default: "20"
+        default: "30"
         type: string
       sweep_agents:
         description: "Number of parallel sweep agents (RunPod pods)"
@@ -577,9 +577,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           SWEEP_URL="${{ steps.create.outputs.sweep_url }}"
-          SWEEP_COUNT="${{ inputs.sweep_count || '20' }}"
+          SWEEP_COUNT="${{ inputs.sweep_count || '30' }}"
           SWEEP_PODS="${{ inputs.sweep_agents || '1' }}"
-          AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '5' }}"
+          AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '10' }}"
           TOTAL_AGENTS=$(( SWEEP_PODS * AGENTS_PER_POD ))
           gh pr comment "${{ github.event.pull_request.number }}" --body "$(cat <<EOF
           **W&B Sweep started** — ${SWEEP_COUNT} iterations across ${SWEEP_PODS} pod(s) x ${AGENTS_PER_POD} agents/pod (${TOTAL_AGENTS} total agents)
@@ -592,8 +592,8 @@ jobs:
         id: matrix
         run: |
           NUM_PODS="${{ inputs.sweep_agents || '1' }}"
-          AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '5' }}"
-          TOTAL_COUNT="${{ inputs.sweep_count || '20' }}"
+          AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '10' }}"
+          TOTAL_COUNT="${{ inputs.sweep_count || '30' }}"
           TOTAL_AGENTS=$(( NUM_PODS * AGENTS_PER_POD ))
           COUNT_PER=$(( TOTAL_COUNT / TOTAL_AGENTS ))
 

--- a/docs/EXPERIMENTS.md
+++ b/docs/EXPERIMENTS.md
@@ -8,6 +8,7 @@ significance level 0.05.
 
 ## Table of Contents
 
+- [Sweep 0r1udi17: 3M-step hyperparameter sweep](#sweep-0r1udi17-3m-step-hyperparameter-sweep)
 - [PR #18: Delta-based reward shaping (PBRS)](#pr-18-delta-based-reward-shaping-pbrs)
 - [PR #16: Spatial per-tile action prediction](#pr-16-spatial-per-tile-action-prediction)
 - [PR #13: Eliminate difficulty-0 episodes](#pr-13-eliminate-difficulty-0-episodes)
@@ -15,6 +16,158 @@ significance level 0.05.
 - [PR #11: Scale max_steps dynamically](#pr-11-scale-max_steps-dynamically)
 - [Proposed experiments (not yet benchmarked)](#proposed-experiments-not-yet-benchmarked)
 - [Historical logbook](#historical-logbook)
+
+---
+
+## Sweep 0r1udi17: 3M-step hyperparameter sweep
+
+**Sweep:** [0r1udi17](https://wandb.ai/beyarkay/factorion/sweeps/0r1udi17)
+| **PR:** [#29](https://github.com/beyarkay/factorion/pull/29)
+| **Date:** 2026-03-06
+| **Status:** Completed (CI timed out after 6h, but runs continued on W&B)
+
+### Setup
+
+First large-scale hyperparameter sweep after the major architectural changes (spatial
+per-tile prediction, delta-based PBRS, entropy scheduling, torch.compile). Bayesian
+optimization over 15 parameters, 3M timesteps per run, 19 runs completed (~1.8M steps
+each before the CI SSH timeout killed the pod).
+
+**Sweep config:** `run_cap=30`, Bayesian method, `curriculum/score` (maximize),
+Hyperband early termination (`eta=3`, `min_iter=10`). Runs executed on a single
+A100 80GB pod with 5 parallel agents via CUDA time-slicing.
+
+### Results
+
+6 of 19 runs reached curriculum level 4+. The best run (`n4ub5hsv`) reached
+**level 5** with a score of 4.95 in only ~1.8M steps — the first time an 8×8
+model has progressed this far in the curriculum.
+
+| Run | Score | Level | Throughput | Steps | `ent_coef_start` | `coeff_throughput` | `coeff_shaping_dir` | `clip_coef` | `flat_dim` |
+|-----|-------|-------|------------|-------|------------------|--------------------|---------------------|-------------|------------|
+| **n4ub5hsv** | **4.95** | **5** | 0.926 | 1.8M | **0.015** | 0.630 | 3.77 | 0.300 | 64 |
+| 58t4pbmb | 4.00 | 4 | 0.918 | 1.8M | 0.022 | 0.598 | 9.19 | 0.296 | 64 |
+| 0gf51a4p | 3.96 | 4 | 0.928 | 1.8M | 0.028 | 0.680 | 1.30 | 0.280 | 256 |
+| sr5brgmd | 3.96 | 4 | 0.930 | 1.7M | 0.026 | 0.846 | 0.74 | 0.344 | 128 |
+| hp86918n | 3.95 | 4 | 0.866 | 1.8M | 0.044 | 0.793 | 0.64 | 0.342 | 128 |
+| vl6gkxed | 3.95 | 4 | 0.852 | 1.8M | 0.013 | 0.505 | 1.32 | 0.187 | 128 |
+| q4j1e6p7 | 1.95 | 2 | 0.726 | 1.8M | 0.060 | 0.815 | 6.43 | 0.255 | 64 |
+| pvil1hnn | 1.95 | 2 | 0.888 | 1.8M | 0.034 | 0.684 | 2.01 | 0.175 | 64 |
+| xbp22rx1 | 1.95 | 2 | 0.940 | 1.8M | 0.048 | 0.540 | 7.85 | 0.305 | 128 |
+| ubhm2s5f | 1.95 | 2 | 0.584 | 2.1M | 0.069 | 0.678 | 7.43 | 0.231 | 128 |
+| *9 runs* | 0.83–0.95 | 1 | 0.42–0.90 | 1.8–2.1M | 0.036–0.267 | 0.60–0.97 | 0.65–9.87 | 0.19–0.33 | 64–256 |
+
+### Parameter importance (from W&B, descending)
+
+1. **`ent_coef_start`** — by far the most important
+2. `coeff_throughput`
+3. `coeff_shaping_direction`
+4. `clip_coef`
+5. `coeff_shaping_location`
+6. `tile_head_std`
+7. `max_grad_norm`
+8. `ent_coef_end`
+9. `gamma`
+10. `adam_epsilon`
+
+### Key finding: `ent_coef_start` is critical
+
+The clearest signal from the sweep: **low initial entropy is essential for
+curriculum progression.**
+
+| Group | Runs | Avg `ent_coef_start` |
+|-------|------|----------------------|
+| Level ≥ 4 | 6 | **0.025** |
+| Level ≤ 1 | 9 | 0.116 |
+
+Every run that reached level 4+ had `ent_coef_start < 0.045`. Every run stuck
+at level 1 had `ent_coef_start > 0.035` (mostly 0.08–0.27).
+
+**Why this matters:** The curriculum starts with difficulty-0 episodes where the
+agent must learn "don't break what's already correct." High initial entropy
+prevents the agent from exploiting this lesson — it keeps exploring randomly
+instead of consolidating the "preserve the factory" behavior. Without that
+foundation, it can never learn to fix things at higher difficulty levels.
+
+This is consistent with the PR #13 finding that difficulty-0 episodes are
+essential scaffolding. The entropy coefficient controls how quickly the agent
+can internalize that scaffolding.
+
+### Pattern analysis: top runs (level ≥ 4) vs bottom runs (level ≤ 1)
+
+| Parameter | Top avg | Bottom avg | Signal |
+|-----------|---------|------------|--------|
+| `ent_coef_start` | 0.025 | 0.116 | **Top much lower** |
+| `coeff_shaping_direction` | 2.8 | 4.3 | Top lower |
+| `coeff_shaping_location` | 1.3 | 2.6 | Top lower |
+| `coeff_shaping_entity` | 2.7 | 3.5 | Top lower |
+| `tile_head_std` | 0.024 | 0.012 | Top higher |
+| `adam_epsilon` | 4.3e-5 | 2.7e-5 | Top higher |
+| `clip_coef` | 0.291 | 0.264 | ~similar |
+| `learning_rate` | 4.5e-4 | 4.3e-4 | ~similar |
+| `gamma` | 0.984 | 0.981 | ~similar |
+| `flat_dim` | 128 | 149 | ~similar |
+| `gae_lambda` | 0.853 | 0.866 | ~similar |
+| `vf_coef` | 0.721 | 0.761 | ~similar |
+| `max_grad_norm` | 1.717 | 1.868 | ~similar |
+
+The shaping coefficients show a mild "less is more" pattern — moderate shaping
+(1–3×) outperforms aggressive shaping (5–10×). This makes sense: PBRS deltas
+are additive, so very large coefficients can dominate the throughput reward
+signal and destabilize training.
+
+### Best run config (`n4ub5hsv`)
+
+```
+ent_coef_start:           0.0151
+ent_coef_end:             0.00161
+coeff_throughput:         0.630
+coeff_shaping_direction:  3.77
+coeff_shaping_location:   1.28
+coeff_shaping_entity:     0.72
+clip_coef:                0.300
+learning_rate:            0.000442
+flat_dim:                 64
+gamma:                    0.978
+gae_lambda:               0.864
+vf_coef:                  0.852
+max_grad_norm:            0.560
+adam_epsilon:              1.29e-5
+tile_head_std:            0.012
+```
+
+### Range edge analysis
+
+Several swept parameters had their best/top values clustered at the edge of
+the search range, suggesting the range was too narrow:
+
+| Parameter | Sweep range | Best value | Top runs near edge | Action |
+|-----------|-------------|------------|-------------------|--------|
+| `ent_coef_start` | [0.01, 0.3] | **0.015** | 6/6 near min | **Extend min to 0.005** — the most important parameter is pinned near the floor |
+| `coeff_shaping_location` | [0.5, 10] | **1.28** | 6/6 near min | **Extend min to 0.1** — all top runs clustered in [0.68, 1.74] |
+| `coeff_shaping_entity` | [0.5, 10] | **0.72** | 3/6 near min | **Extend min to 0.1** — best run nearly at floor |
+| `coeff_shaping_direction` | [0.5, 10] | 3.77 | 4/6 near min | Keep — wide spread in top runs (0.6–9.2) |
+| `max_grad_norm` | [0.5, 3.0] | **0.56** | best near min | **Extend min to 0.25** |
+| `tile_head_std` | [0.001, 0.1] | 0.012 | 4/6 near min | Keep — min already at 0.001 |
+| `adam_epsilon` | [1e-6, 2e-4] | 1.3e-5 | 4/6 near min | Keep — range is wide enough |
+| `clip_coef` | [0.15, 0.35] | 0.30 | 2/6 near max | Keep — spread is reasonable |
+| `vf_coef` | [0.5, 0.9] | 0.85 | best near max | Could extend max to 1.0 |
+
+Parameters with no edge issues (values well within range): `learning_rate`,
+`gamma`, `gae_lambda`, `coeff_throughput`, `ent_coef_end`, `flat_dim`.
+
+### Infrastructure notes
+
+- All runs show as "crashed" in W&B because the CI job's SSH connection to
+  RunPod broke after ~6h (GitHub Actions timeout). The wandb agents were still
+  running on the pod when it was terminated. This was fixed in a follow-up
+  commit by adding SSH keepalive settings and a detached execution pattern
+  (nohup + poll).
+- The sweep used 5 parallel agents on a single A100 80GB pod. The model is
+  small (~135K params), so 10 agents would have been feasible.
+- Runs completed ~1.8M of the target 3M steps before termination. Despite
+  this, the results are informative — the top runs had already plateaued at
+  their curriculum level by ~1.5M steps.
 
 ---
 

--- a/ppo.py
+++ b/ppo.py
@@ -1360,4 +1360,7 @@ if __name__ == "__main__":
         json.dump(summary, f, indent=2)
     print(f"Summary written to {summary_path}")
 
+    if args.track:
+        wandb.finish()
+
 

--- a/ppo.py
+++ b/ppo.py
@@ -127,6 +127,8 @@ class Args:
     """Output size of the fully connected layer after the encoder"""
     tile_head_std: float = 0.01201
     """Initialization std for the tile selection conv head (smaller = more uniform initial exploration)"""
+    promotion_threshold: float = 0.95
+    """throughput moving average required to advance to the next curriculum level"""
     size: int = 8
     """The width and height of the factory"""
     summary_path: Optional[str] = None
@@ -1236,7 +1238,7 @@ if __name__ == "__main__":
         if len(end_of_episode_thputs) > 0:
             final_thputs_100ma = sum(end_of_episode_thputs) / len(end_of_episode_thputs)
             if len(end_of_episode_thputs) > int(moving_average_length * 0.9):
-                if final_thputs_100ma > 0.95 and iteration - iteration_of_last_increase > 10:
+                if final_thputs_100ma > args.promotion_threshold and iteration - iteration_of_last_increase > 10:
                     iteration_of_last_increase = iteration
                     end_of_episode_thputs.clear()
                     for _ in range(moving_average_length):

--- a/ppo.py
+++ b/ppo.py
@@ -64,7 +64,7 @@ class Args:
     """the id of the environment"""
     total_timesteps: int = 500000
     """total timesteps of the experiments"""
-    learning_rate: float = 5.86e-4
+    learning_rate: float = 4.423e-4
     """the learning rate of the optimizer"""
     num_envs: int = 16
     """the number of parallel game environments. More envs -> less likely to fit on GPU"""
@@ -72,9 +72,9 @@ class Args:
     """the number of steps to run in each environment per policy rollout"""
     anneal_lr: bool = True
     """Toggle learning rate annealing for policy and value networks"""
-    gamma: float = 0.9857
+    gamma: float = 0.9782
     """the discount factor gamma"""
-    gae_lambda: float = 0.8014
+    gae_lambda: float = 0.8641
     """the lambda for the general advantage estimation"""
     num_minibatches: int = 32
     """the number of mini-batches. more minibatches -> smaller minibatch size -> more likely to fit on GPU"""
@@ -82,18 +82,18 @@ class Args:
     """the K epochs to update the policy"""
     norm_adv: bool = True
     """Toggles advantages normalization"""
-    clip_coef: float = 0.2746
+    clip_coef: float = 0.2999
     """the surrogate clipping coefficient"""
     clip_vloss: bool = True
     """Toggles whether or not to use a clipped loss for the value function, as per the paper."""
 
-    ent_coef_start: float = 0.02041
+    ent_coef_start: float = 0.01514
     """entropy coefficient at the start of training (high = more exploration)"""
-    ent_coef_end: float = 0.0004576
+    ent_coef_end: float = 0.001605
     """entropy coefficient at the end of training (low = more exploitation)"""
-    vf_coef: float = 0.7426
+    vf_coef: float = 0.8518
     """coefficient of the value function"""
-    coeff_throughput: float = 0.8785
+    coeff_throughput: float = 0.6302
     """coefficient of the throughput when calculating reward"""
     coeff_frac_reachable: float = 0.01
     """coefficient of the fraction of unreachable nodes when calculating reward"""
@@ -105,17 +105,17 @@ class Args:
     """coefficient of reward given to the cost of materials used to solve the problem"""
     coeff_validity: float = 0.01
     """coefficient of reward given to the action being valid"""
-    coeff_shaping_location: float = 1.0
+    coeff_shaping_location: float = 1.277
     """delta reward shaping: reward for placing entities at correct positions (solution-nonempty tiles only)"""
-    coeff_shaping_entity: float = 1.0
+    coeff_shaping_entity: float = 0.7247
     """delta reward shaping: reward for correct entity types (solution-nonempty tiles only)"""
-    coeff_shaping_direction: float = 1.0
+    coeff_shaping_direction: float = 3.768
     """delta reward shaping: reward for correct directions (solution-nonempty tiles only)"""
-    max_grad_norm: float = 1.979
+    max_grad_norm: float = 0.5602
     """the maximum norm for the gradient clipping"""
     target_kl: Optional[float] = None
     """the target KL divergence threshold"""
-    adam_epsilon: float = 6.866e-06
+    adam_epsilon: float = 1.290e-05
     """The epsilon parameter for Adam"""
     chan1: int = 48
     """Number of channels in the first layer of the CNN encoder"""
@@ -123,9 +123,9 @@ class Args:
     """Number of channels in the second layer of the CNN encoder"""
     chan3: int = 48
     """Number of channels in the third layer of the CNN encoder"""
-    flat_dim: int = 128
+    flat_dim: int = 64
     """Output size of the fully connected layer after the encoder"""
-    tile_head_std: float = 0.06503
+    tile_head_std: float = 0.01201
     """Initialization std for the tile selection conv head (smaller = more uniform initial exploration)"""
     size: int = 8
     """The width and height of the factory"""

--- a/scripts/ci/apply_sweep_best.py
+++ b/scripts/ci/apply_sweep_best.py
@@ -42,6 +42,7 @@ TUNABLE_PARAMS = {
     "gamma": "float",
     "learning_rate": "float",
     "max_grad_norm": "float",
+    "promotion_threshold": "float",
     "tile_head_std": "float",
     "vf_coef": "float",
 }
@@ -152,13 +153,39 @@ def main():
     metric_goal = metric_cfg.get("goal", "maximize")
     reverse = metric_goal == "maximize"
 
-    runs = [r for r in sweep.runs if r.state == "finished"]
+    def extract_metric(run):
+        """Extract a scalar metric from a run summary.
+
+        wandb.define_metric(..., summary="max") stores the value as a
+        SummarySubDict like {'max': 4.95} instead of a plain float.
+        """
+        val = run.summary.get(metric_name)
+        if val is None:
+            return None
+        if isinstance(val, (int, float)):
+            return float(val)
+        if hasattr(val, 'get'):
+            for key in ('max', 'last', 'min'):
+                v = val.get(key)
+                if v is not None:
+                    return float(v)
+            for v in val.values():
+                if isinstance(v, (int, float)):
+                    return float(v)
+        return None
+
+    # Include crashed runs that logged the metric (pod killed after training)
+    runs = [
+        r for r in sweep.runs
+        if r.state == "finished"
+        or (r.state == "crashed" and extract_metric(r) is not None)
+    ]
     if not runs:
-        print("No finished runs in sweep. Skipping.")
+        print("No runs with metric data in sweep. Skipping.")
         sys.exit(0)
 
     def get_metric(run):
-        val = run.summary.get(metric_name)
+        val = extract_metric(run)
         if val is None:
             return float("-inf") if reverse else float("inf")
         return val

--- a/scripts/ci/gpu_sweep.sh
+++ b/scripts/ci/gpu_sweep.sh
@@ -50,9 +50,9 @@ echo "============================================"
 
 # ── Safety net: self-terminate after 8 hours if cleanup fails ─────
 if [ -n "${RUNPOD_POD_ID:-}" ] && [ -n "${RUNPOD_API_KEY:-}" ]; then
-    echo ">>> Starting self-terminate watchdog (8h timeout)..."
+    echo ">>> Starting self-terminate watchdog (6h timeout)..."
     nohup bash -c "
-      sleep 28800
+      sleep 21600
       curl -s 'https://api.runpod.io/graphql?api_key=${RUNPOD_API_KEY}' \
         -H 'Content-Type: application/json' \
         -d '{\"query\": \"mutation { podTerminate(input: {podId: \\\"${RUNPOD_POD_ID}\\\"}) }\"}'

--- a/scripts/ci/gpu_sweep.sh
+++ b/scripts/ci/gpu_sweep.sh
@@ -124,6 +124,13 @@ for i in "${!PIDS[@]}"; do
     fi
 done
 
+# ── Grace period for W&B uploads ──────────────────────────────
+# wandb.finish() in ppo.py may still be uploading when the agent process
+# exits. Give it time to flush before the pod is terminated.
+echo ""
+echo ">>> Waiting 30s for W&B uploads to flush..."
+sleep 30
+
 echo ""
 echo "============================================"
 echo "  Sweep pod ${AGENT_ID} completed"

--- a/scripts/ci/gpu_sweep.sh
+++ b/scripts/ci/gpu_sweep.sh
@@ -48,11 +48,11 @@ echo "  PR:              ${PR_NUMBER}"
 echo "  Commit:          ${COMMIT_SHA}"
 echo "============================================"
 
-# ── Safety net: self-terminate after 4 hours if cleanup fails ─────
+# ── Safety net: self-terminate after 8 hours if cleanup fails ─────
 if [ -n "${RUNPOD_POD_ID:-}" ] && [ -n "${RUNPOD_API_KEY:-}" ]; then
-    echo ">>> Starting self-terminate watchdog (4h timeout)..."
+    echo ">>> Starting self-terminate watchdog (8h timeout)..."
     nohup bash -c "
-      sleep 14400
+      sleep 28800
       curl -s 'https://api.runpod.io/graphql?api_key=${RUNPOD_API_KEY}' \
         -H 'Content-Type: application/json' \
         -d '{\"query\": \"mutation { podTerminate(input: {podId: \\\"${RUNPOD_POD_ID}\\\"}) }\"}'

--- a/scripts/ci/sweep_report.py
+++ b/scripts/ci/sweep_report.py
@@ -58,6 +58,30 @@ def main():
     sweep_params = sweep.config.get("parameters", {})
     reverse = metric_goal == "maximize"
 
+    def extract_metric(run):
+        """Extract a scalar metric from a run summary.
+
+        wandb.define_metric(..., summary="max") stores the value as a
+        SummarySubDict like {'max': 4.95} instead of a plain float.
+        This helper unwraps it.
+        """
+        val = run.summary.get(metric_name)
+        if val is None:
+            return None
+        if isinstance(val, (int, float)):
+            return float(val)
+        # SummarySubDict — try 'max' then 'last' then first value
+        if hasattr(val, 'get'):
+            for key in ('max', 'last', 'min'):
+                v = val.get(key)
+                if v is not None:
+                    return float(v)
+            # Fallback: grab first numeric value
+            for v in val.values():
+                if isinstance(v, (int, float)):
+                    return float(v)
+        return None
+
     # Fetch all runs that finished or crashed-but-logged-the-metric.
     # Runs killed by the watchdog / SSH timeout after training completed often
     # show state="crashed" even though they logged all their metrics.
@@ -65,7 +89,7 @@ def main():
         r
         for r in sweep.runs
         if r.state == "finished"
-        or (r.state == "crashed" and r.summary.get(metric_name) is not None)
+        or (r.state == "crashed" and extract_metric(r) is not None)
     ]
 
     # sweep_path is entity/project/sweep_id — W&B URLs need /sweeps/ before the ID
@@ -87,7 +111,7 @@ def main():
 
     # Sort runs by the sweep metric
     def get_metric(run):
-        val = run.summary.get(metric_name)
+        val = extract_metric(run)
         if val is None:
             return float("-inf") if reverse else float("inf")
         return val

--- a/scripts/ci/sweep_report.py
+++ b/scripts/ci/sweep_report.py
@@ -58,8 +58,15 @@ def main():
     sweep_params = sweep.config.get("parameters", {})
     reverse = metric_goal == "maximize"
 
-    # Fetch all runs, keep only finished ones
-    runs = [r for r in sweep.runs if r.state == "finished"]
+    # Fetch all runs that finished or crashed-but-logged-the-metric.
+    # Runs killed by the watchdog / SSH timeout after training completed often
+    # show state="crashed" even though they logged all their metrics.
+    runs = [
+        r
+        for r in sweep.runs
+        if r.state == "finished"
+        or (r.state == "crashed" and r.summary.get(metric_name) is not None)
+    ]
 
     # sweep_path is entity/project/sweep_id — W&B URLs need /sweeps/ before the ID
     parts = args.sweep_path.split("/")

--- a/sweep.yaml
+++ b/sweep.yaml
@@ -1,4 +1,4 @@
-# sweep.yaml — 5M-step hyperparameter sweep
+# sweep.yaml — 3M-step hyperparameter sweep
 #
 # Focus: reward shaping coefficients (never tuned with delta-based PBRS)
 # and entropy schedule (critical for long runs). PPO core params are
@@ -10,6 +10,17 @@ run_cap: 30
 metric:
   name: "curriculum/score"
   goal: maximize
+
+# Early termination via Hyperband: kill runs that fall behind the top
+# performers. eta=3 means only the top 1/3 of runs survive each bracket.
+# min_iter=10 avoids killing runs before they've had a chance to warm up
+# (10 logged steps of curriculum/score ≈ ~300K training steps).
+# Note: W&B early_terminate has known quirks (wandb/wandb#7156) but is
+# worth trying — worst case it doesn't trigger and we lose nothing.
+early_terminate:
+  type: hyperband
+  min_iter: 10
+  eta: 3
 
 parameters:
   # ── Reward shaping (high priority — never tuned with PBRS) ──────
@@ -95,6 +106,6 @@ command:
   - bash
   - run_sweep.sh
   - --total-timesteps
-  - "5_000_000"
+  - "3_000_000"
   - --track
   - ${args}

--- a/sweep.yaml
+++ b/sweep.yaml
@@ -1,12 +1,13 @@
-# sweep.yaml — 3M-step hyperparameter sweep (follow-up to 0r1udi17)
+# sweep.yaml — 3M-step hyperparameter sweep (follow-up to 0r1udi17 + wcv9tge3)
 #
-# Narrowed from sweep 0r1udi17 based on edge analysis and parameter
-# importance. Key changes:
-#   - ent_coef_start: min 0.01 → 0.005, max 0.3 → 0.1 (most important param, all top runs < 0.045)
-#   - coeff_shaping_location/entity: min 0.5 → 0.1, max 10 → 5 (top runs clustered low)
-#   - max_grad_norm: min 0.5 → 0.25 (best run was at floor)
-#   - vf_coef: max 0.9 → 1.0 (best run near ceiling)
-#   - Dropped flat_dim (64 won decisively — best run + 2 other top runs)
+# Narrowed from 24 scored runs across sweeps 0r1udi17 and wcv9tge3.
+# Top-5 runs (score > 3.9) analysis:
+#   - ent_coef_start: all top runs 0.015–0.044 (tighten to 0.01–0.05)
+#   - coeff_shaping_location: all top runs 1.1–1.7 (tighten to 0.5–2.0)
+#   - learning_rate: all top runs 2.4e-4–5.1e-4 (tighten to 2e-4–5e-4)
+#   - clip_coef: top runs 0.28–0.34 (tighten to 0.25–0.35)
+#   - tile_head_std: best run 0.012, most top runs < 0.01 (tighten to 0.003–0.015)
+#   - flat_dim: 64 won decisively (dropped from sweep)
 
 method: bayes
 # NOTE: Also update the sweep_count default in .github/workflows/ci.yml
@@ -22,53 +23,53 @@ early_terminate:
   eta: 3
 
 parameters:
-  # ── Reward shaping (narrowed — top runs clustered low) ──────────
+  # ── Reward shaping (location tightened, others kept wide) ───────
   coeff_shaping_location:
     distribution: log_uniform_values
-    min: 0.1
-    max: 5.0
+    min: 0.5
+    max: 2.0
 
   coeff_shaping_entity:
     distribution: log_uniform_values
-    min: 0.1
+    min: 0.5
     max: 5.0
 
   coeff_shaping_direction:
     distribution: log_uniform_values
-    min: 0.1
+    min: 0.5
     max: 10.0
 
   coeff_throughput:
     distribution: uniform
-    min: 0.5
-    max: 0.99
+    min: 0.55
+    max: 0.85
 
-  # ── Entropy schedule (most important — extend floor, narrow ceiling) ─
+  # ── Entropy schedule (tightened around top-run cluster) ─────────
   ent_coef_start:
     distribution: log_uniform_values
-    min: 0.005
-    max: 0.1
+    min: 0.01
+    max: 0.05
 
   ent_coef_end:
     distribution: log_uniform_values
     min: 1e-5
-    max: 0.005
+    max: 0.004
 
-  # ── PPO core (narrowed around known-good defaults) ──────────────
+  # ── PPO core (tightened around top-run values) ──────────────────
   learning_rate:
     distribution: log_uniform_values
     min: 2e-4
-    max: 1e-3
+    max: 5e-4
 
   clip_coef:
     distribution: uniform
-    min: 0.15
+    min: 0.25
     max: 0.35
 
   gamma:
     distribution: uniform
     min: 0.97
-    max: 0.999
+    max: 0.99
 
   gae_lambda:
     distribution: uniform
@@ -78,23 +79,29 @@ parameters:
   vf_coef:
     distribution: uniform
     min: 0.5
-    max: 1.0
+    max: 0.9
 
   max_grad_norm:
     distribution: uniform
-    min: 0.25
-    max: 3.0
+    min: 0.5
+    max: 2.5
 
   adam_epsilon:
     distribution: log_uniform_values
     min: 1e-6
-    max: 2e-4
+    max: 1.5e-4
+
+  # ── Curriculum ──────────────────────────────────────────────────
+  promotion_threshold:
+    distribution: uniform
+    min: 0.8
+    max: 0.99
 
   # ── Architecture ────────────────────────────────────────────────
   tile_head_std:
     distribution: log_uniform_values
-    min: 0.001
-    max: 0.1
+    min: 0.003
+    max: 0.015
 
 program: ppo.py
 

--- a/sweep.yaml
+++ b/sweep.yaml
@@ -1,42 +1,41 @@
-# sweep.yaml — 3M-step hyperparameter sweep
+# sweep.yaml — 3M-step hyperparameter sweep (follow-up to 0r1udi17)
 #
-# Focus: reward shaping coefficients (never tuned with delta-based PBRS)
-# and entropy schedule (critical for long runs). PPO core params are
-# narrowed around known-good defaults. CNN architecture (chan1/2/3)
-# removed to reduce search space — current 48/48/48 is well-established.
+# Narrowed from sweep 0r1udi17 based on edge analysis and parameter
+# importance. Key changes:
+#   - ent_coef_start: min 0.01 → 0.005, max 0.3 → 0.1 (most important param, all top runs < 0.045)
+#   - coeff_shaping_location/entity: min 0.5 → 0.1, max 10 → 5 (top runs clustered low)
+#   - max_grad_norm: min 0.5 → 0.25 (best run was at floor)
+#   - vf_coef: max 0.9 → 1.0 (best run near ceiling)
+#   - Dropped flat_dim (64 won decisively — best run + 2 other top runs)
 
 method: bayes
+# NOTE: Also update the sweep_count default in .github/workflows/ci.yml
+# to match this value, otherwise CI will launch fewer runs than expected.
 run_cap: 30
 metric:
   name: "curriculum/score"
   goal: maximize
 
-# Early termination via Hyperband: kill runs that fall behind the top
-# performers. eta=3 means only the top 1/3 of runs survive each bracket.
-# min_iter=10 avoids killing runs before they've had a chance to warm up
-# (10 logged steps of curriculum/score ≈ ~300K training steps).
-# Note: W&B early_terminate has known quirks (wandb/wandb#7156) but is
-# worth trying — worst case it doesn't trigger and we lose nothing.
 early_terminate:
   type: hyperband
   min_iter: 10
   eta: 3
 
 parameters:
-  # ── Reward shaping (high priority — never tuned with PBRS) ──────
+  # ── Reward shaping (narrowed — top runs clustered low) ──────────
   coeff_shaping_location:
     distribution: log_uniform_values
-    min: 0.5
-    max: 10.0
+    min: 0.1
+    max: 5.0
 
   coeff_shaping_entity:
     distribution: log_uniform_values
-    min: 0.5
-    max: 10.0
+    min: 0.1
+    max: 5.0
 
   coeff_shaping_direction:
     distribution: log_uniform_values
-    min: 0.5
+    min: 0.1
     max: 10.0
 
   coeff_throughput:
@@ -44,11 +43,11 @@ parameters:
     min: 0.5
     max: 0.99
 
-  # ── Entropy schedule (high priority — drives exploration vs exploitation) ─
+  # ── Entropy schedule (most important — extend floor, narrow ceiling) ─
   ent_coef_start:
     distribution: log_uniform_values
-    min: 0.01
-    max: 0.3
+    min: 0.005
+    max: 0.1
 
   ent_coef_end:
     distribution: log_uniform_values
@@ -79,11 +78,11 @@ parameters:
   vf_coef:
     distribution: uniform
     min: 0.5
-    max: 0.9
+    max: 1.0
 
   max_grad_norm:
     distribution: uniform
-    min: 0.5
+    min: 0.25
     max: 3.0
 
   adam_epsilon:
@@ -91,14 +90,11 @@ parameters:
     min: 1e-6
     max: 2e-4
 
-  # ── Architecture (small search, high impact) ────────────────────
+  # ── Architecture ────────────────────────────────────────────────
   tile_head_std:
     distribution: log_uniform_values
     min: 0.001
     max: 0.1
-
-  flat_dim:
-    values: [64, 128, 256]
 
 program: ppo.py
 

--- a/sweep.yaml
+++ b/sweep.yaml
@@ -1,75 +1,69 @@
-# sweep.yaml — Delta-based reward shaping sweep
+# sweep.yaml — 5M-step hyperparameter sweep
+#
+# Focus: reward shaping coefficients (never tuned with delta-based PBRS)
+# and entropy schedule (critical for long runs). PPO core params are
+# narrowed around known-good defaults. CNN architecture (chan1/2/3)
+# removed to reduce search space — current 48/48/48 is well-established.
 
 method: bayes
-run_cap: 20
+run_cap: 30
 metric:
   name: "curriculum/score"
   goal: maximize
 
 parameters:
+  # ── Reward shaping (high priority — never tuned with PBRS) ──────
   coeff_shaping_location:
     distribution: log_uniform_values
-    min: 0.1
-    max: 5.0
+    min: 0.5
+    max: 10.0
 
   coeff_shaping_entity:
     distribution: log_uniform_values
-    min: 0.1
-    max: 5.0
+    min: 0.5
+    max: 10.0
 
   coeff_shaping_direction:
     distribution: log_uniform_values
-    min: 0.1
-    max: 5.0
+    min: 0.5
+    max: 10.0
 
   coeff_throughput:
     distribution: uniform
     min: 0.5
     max: 0.99
 
+  # ── Entropy schedule (high priority — drives exploration vs exploitation) ─
   ent_coef_start:
     distribution: log_uniform_values
-    min: 0.005
-    max: 0.2
+    min: 0.01
+    max: 0.3
 
   ent_coef_end:
     distribution: log_uniform_values
-    min: 1e-4
-    max: 0.01
+    min: 1e-5
+    max: 0.005
 
+  # ── PPO core (narrowed around known-good defaults) ──────────────
   learning_rate:
     distribution: log_uniform_values
-    min: 5e-5
+    min: 2e-4
     max: 1e-3
-
-  chan1:
-    values: [32, 48, 64]
-
-  chan2:
-    values: [48, 64]
-
-  chan3:
-    values: [48, 64]
 
   clip_coef:
     distribution: uniform
-    min: 0.18
-    max: 0.32
+    min: 0.15
+    max: 0.35
 
   gamma:
     distribution: uniform
-    min: 0.95
+    min: 0.97
     max: 0.999
 
   gae_lambda:
     distribution: uniform
-    min: 0.8
-    max: 0.975
-
-  tile_head_std:
-    distribution: log_uniform_values
-    min: 0.001
-    max: 0.1
+    min: 0.75
+    max: 0.95
 
   vf_coef:
     distribution: uniform
@@ -78,13 +72,22 @@ parameters:
 
   max_grad_norm:
     distribution: uniform
-    min: 0.75
-    max: 2.5
+    min: 0.5
+    max: 3.0
 
   adam_epsilon:
     distribution: log_uniform_values
     min: 1e-6
     max: 2e-4
+
+  # ── Architecture (small search, high impact) ────────────────────
+  tile_head_std:
+    distribution: log_uniform_values
+    min: 0.001
+    max: 0.1
+
+  flat_dim:
+    values: [64, 128, 256]
 
 program: ppo.py
 
@@ -92,6 +95,6 @@ command:
   - bash
   - run_sweep.sh
   - --total-timesteps
-  - 250_000
+  - "5_000_000"
   - --track
   - ${args}


### PR DESCRIPTION
Restructure sweep.yaml for 5M-step hyperparameter search (up from 250K)
Focus sweep on reward shaping coefficients (never tuned with delta-based PBRS) and entropy schedule
Narrow PPO core params around known-good defaults, drop CNN channel search (well-established at 48/48/48), add flat_dim
Increase run_cap 20→30, agents_per_pod 5→10, CI timeout 240→480min, watchdog 4h→8h