### PR TITLE
Switch to AsyncVectorEnv and add performance sweep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,9 @@ on:
         default: "1"
         type: string
       sweep_agents_per_pod:
-        description: "Parallel wandb agents per pod (GPU time-slicing)"
+        description: "Sequential wandb agents per pod"
         required: false
-        default: "5"
+        default: "1"
         type: string
 
 permissions:
@@ -579,7 +579,7 @@ jobs:
           SWEEP_URL="${{ steps.create.outputs.sweep_url }}"
           SWEEP_COUNT="${{ inputs.sweep_count || '20' }}"
           SWEEP_PODS="${{ inputs.sweep_agents || '1' }}"
-          AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '5' }}"
+          AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '1' }}"
           TOTAL_AGENTS=$(( SWEEP_PODS * AGENTS_PER_POD ))
           gh pr comment "${{ github.event.pull_request.number }}" --body "$(cat <<EOF
           **W&B Sweep started** — ${SWEEP_COUNT} iterations across ${SWEEP_PODS} pod(s) x ${AGENTS_PER_POD} agents/pod (${TOTAL_AGENTS} total agents)
@@ -592,7 +592,7 @@ jobs:
         id: matrix
         run: |
           NUM_PODS="${{ inputs.sweep_agents || '1' }}"
-          AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '5' }}"
+          AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '1' }}"
           TOTAL_COUNT="${{ inputs.sweep_count || '20' }}"
           TOTAL_AGENTS=$(( NUM_PODS * AGENTS_PER_POD ))
           COUNT_PER=$(( TOTAL_COUNT / TOTAL_AGENTS ))

--- a/docs/PERFORMANCE_IMPROVEMENTS.md
+++ b/docs/PERFORMANCE_IMPROVEMENTS.md
@@ -97,9 +97,9 @@ Also documented as P5 in `docs/EXPERIMENTS.md`.
 ### H3: Move the entire env to Rust (vectorized)
 
 **Estimated impact:** Very high | **Complexity:** High
+| **Status:** Feasibility confirmed (PyO3 proof-of-concept built and tested)
 
-The nuclear option with the highest performance ceiling. Currently each
-`step()` call involves:
+The highest-ceiling optimization. Currently each `step()` call involves:
 
 1. Python dict unpacking and 8+ validity checks in Python
 2. Torch tensor mutations (`_world_CWH[channel, x, y] = value`)
@@ -107,34 +107,276 @@ The nuclear option with the highest performance ceiling. Currently each
 4. Rust FFI call to `simulate_throughput`
 5. Python reward computation with multiple tensor operations
 6. Solution match computation (`_compute_solution_match`)
+7. Python info dict construction (~20 keys)
 
-If the full `step()` — action validation, world mutation, throughput simulation,
-reward computation — were moved into Rust and exposed as a **batched** interface,
-all of this overhead disappears:
+With AsyncVectorEnv (H2), each subprocess still runs all this Python. The
+subprocess IPC overhead (serializing obs/actions/rewards) adds further latency.
+
+A Rust vectorized env eliminates all of it:
 
 ```python
-# Hypothetical API:
-obs, rewards, dones, infos = rust_env.step_batch(actions)  # actions: (N, 6)
+# Python side (ppo.py) — replaces AsyncVectorEnv entirely:
+env = factorion_rs.VecFactorioEnv(num_envs=256, size=8, max_steps=16)
+obs = env.reset(seed=1)                 # returns numpy (256, 5, 8, 8)
+obs, rewards, dones, infos = env.step(actions)  # actions: numpy (256, 6)
+env.set_max_missing(3)                  # curriculum update, instant
 ```
 
-This eliminates:
+| Overhead | Current (Python + AsyncVectorEnv) | After H3 (Rust VecEnv) |
+|---|---|---|
+| Per-step logic | Python validity checks, reward math, dict building | Rust, compiled, zero-overhead |
+| Tensor ↔ numpy | `.permute().to().numpy()` per step per env | Not needed — Rust writes directly to pre-allocated buffers |
+| Subprocess IPC | Serialize/deserialize obs+actions per step | None — single process |
+| GIL | Held during all Python env logic | Released via `py.allow_threads()` |
+| `simulate_throughput` FFI | One cross-boundary call per env per step | Internal Rust function call (inlined) |
+| Memory allocation | New numpy array per env per step | Pre-allocated, reused across steps |
+| Parallelism | OS-level subprocess scheduling | rayon thread pool, work-stealing, no IPC |
 
-- All Python per-step overhead
-- All tensor/numpy conversion overhead
-- GIL contention
-- IPC serialisation (no subprocess boundary needed, unlike H2)
+#### Feasibility (confirmed)
 
-This is the approach taken by EnvPool, Brax, and Isaac Gym. For a simple grid
-env like Factorion, this is very feasible in Rust. The `factorion_rs` crate
-already handles `simulate_throughput` — extending it to the full env logic is
-a natural next step.
+A proof-of-concept `VecEnvProof` was built and tested: a `#[pyclass]` Rust
+struct holding N flat arrays, with `reset()` and `step()` methods returning
+numpy arrays via PyO3. Confirmed working:
 
-**Rough scope:**
+- `#[pyclass]` struct holds mutable env state (`Vec<f32>`, `Vec<i32>`)
+- `reset()` → `(N, C, W, H)` numpy array via `PyArray1::from_vec().reshape()`
+- `step()` → `(obs, rewards, dones)` tuple of numpy arrays
+- Returned arrays are regular mutable numpy — `torch.as_tensor()` works
+- Pattern: ~80 lines of Rust for the full PyO3 plumbing
 
-- Port `FactorioEnv.__init__`, `reset`, `step` to Rust
-- Port `generate_lesson` (currently in `factorion.py` marimo notebook) to Rust
-- Expose a `VecEnv` struct that holds N env states and steps them all in one call
-- Return observations as numpy arrays via PyO3 (zero-copy with `numpy` feature)
+#### What already exists in `factorion_rs`
+
+The crate already has substantial infrastructure to build on:
+
+| Component | Status | Location |
+|---|---|---|
+| `World` struct (flat `Vec<i64>`, WHC layout) | Done | `world.rs` |
+| `World::from_numpy()` | Done | `world.rs` |
+| `Channel`, `Direction`, `EntityKind`, `Item`, `Misc` enums | Done | `types.rs` |
+| `Direction::delta()`, `Direction::opposite()` | Done | `types.rs` |
+| `EntityKind::flow_rate()`, `EntityKind::name()` | Done | `types.rs` |
+| `build_graph()` (world → factory graph) | Done | `graph.rs` |
+| `calc_throughput()` (graph → throughput) | Done | `throughput.rs` |
+| Entity connection logic (belt, inserter, underground) | Done | `entities.rs` |
+| Recipes (`get_recipe`) | Done | `types.rs` |
+| `simulate_throughput()` PyO3 binding | Done | `lib.rs` |
+
+#### What needs to be built
+
+##### Phase 1: `generate_lesson` (~250 lines of Python → Rust)
+
+Port `generate_lesson` and `find_belt_paths_with_source_sink_orient` from
+`factorion.py:1314-1569`. This is the hardest piece:
+
+1. **Random source/sink placement** — sample two distinct positions on the
+   grid, assign random directions. Uses `random.seed(seed)` for
+   determinism; Rust equivalent: seed a `rand::rngs::StdRng`.
+
+2. **BFS pathfinding** — `find_belt_paths_with_source_sink_orient` does a
+   multi-path BFS from source front to sink back, finding all shortest
+   belt paths. ~100 lines, straightforward BFS with parent tracking and
+   backtracking. Standard `VecDeque` in Rust.
+
+3. **Path selection + belt placement** — choose a random path, place
+   transport belts with correct directions along it.
+
+4. **Entity removal for curriculum** — randomly remove N belts from the
+   placed path to create the puzzle.
+
+**Determinism requirement:** Same seed must produce identical worlds from
+both Python and Rust. This enables parity tests: generate worlds from both
+implementations and assert equality.
+
+**Testing strategy:** For each seed in 0..100, generate a lesson from Python
+and from Rust, assert the world tensors are identical. This catches any
+divergence in RNG sequences, BFS ordering, or path selection.
+
+##### Phase 2: `step()` + `reset()` (~200 lines of Python → Rust)
+
+Port `FactorioEnv.step()` from `ppo.py:351-589`:
+
+1. **Action validation** — 8 checks (masked tile, source/sink, entity+direction
+   combos, bounds). All simple integer comparisons.
+
+2. **World mutation** — set 4 channels at `(x, y)`. One array write per channel.
+
+3. **Throughput computation** — call existing `build_graph()` +
+   `calc_throughput()` directly (no FFI boundary).
+
+4. **Reward computation** — `frac_reachable`, `material_cost`,
+   `final_dir_reward`, PBRS deltas (`_compute_solution_match`). All
+   arithmetic over the world array.
+
+5. **Termination logic** — `throughput >= 1.0` or `steps > max_steps`.
+
+Port `FactorioEnv.reset()` from `ppo.py:308-349`:
+
+1. Call `generate_lesson` twice (solved + incomplete).
+2. Initialize step counter, prev_match, cum_reward.
+
+##### Phase 3: `VecFactorioEnv` wrapper + rayon parallelism
+
+```rust
+// factorion_rs/src/vec_env.rs
+
+use rayon::prelude::*;
+
+#[pyclass]
+pub struct VecFactorioEnv {
+    num_envs: usize,
+    size: usize,
+    max_steps: usize,
+    channels: usize,
+
+    // Per-env state, contiguous in memory
+    worlds: Vec<i64>,            // (N * C * W * H) flat
+    solved_worlds: Vec<i64>,     // (N * C * W * H) flat
+    steps: Vec<usize>,           // (N,)
+    seeds: Vec<u64>,             // (N,)
+    max_missing: Vec<usize>,     // (N,)
+    prev_match: Vec<[f64; 3]>,   // (N,) for PBRS deltas
+    cum_rewards: Vec<f64>,       // (N,)
+
+    // Pre-allocated output buffers (reused across steps)
+    obs_buf: Vec<f32>,           // (N * C * W * H) flat
+    reward_buf: Vec<f32>,        // (N,)
+    done_buf: Vec<bool>,         // (N,)
+}
+
+#[pymethods]
+impl VecFactorioEnv {
+    #[new]
+    fn new(num_envs: usize, size: usize, max_steps: usize) -> Self { ... }
+
+    fn reset(&mut self, py: Python, seed: u64) -> PyArray4<f32> {
+        // For each env (parallelised with rayon):
+        //   1. generate_lesson(solved, seed+i)
+        //   2. generate_lesson(incomplete, seed+i)
+        //   3. init step counter, prev_match
+        // Copy world data into obs_buf, return as numpy
+    }
+
+    fn step(
+        &mut self,
+        py: Python,
+        actions: PyReadonlyArray2<i64>,  // (N, 6)
+    ) -> (PyArray4<f32>, PyArray1<f32>, PyArray1<bool>, ...) {
+        py.allow_threads(|| {
+            // Release the GIL for the entire batch computation
+            self.worlds
+                .par_chunks_mut(self.env_size())
+                .zip(self.reward_buf.par_iter_mut())
+                .zip(self.done_buf.par_iter_mut())
+                .enumerate()
+                .for_each(|(i, ((world, reward), done))| {
+                    // 1. Validate action
+                    // 2. Mutate world
+                    // 3. build_graph + calc_throughput (already Rust)
+                    // 4. Compute reward, PBRS deltas
+                    // 5. Check termination, auto-reset if done
+                });
+        });
+        // Return pre-allocated buffers as numpy views
+    }
+
+    fn set_max_missing(&mut self, value: usize) {
+        self.max_missing.fill(value);
+    }
+}
+```
+
+Key design decisions:
+
+- **Pre-allocated buffers**: `obs_buf`, `reward_buf`, `done_buf` are allocated
+  once in `new()` and reused every step. No allocation in the hot loop.
+- **`py.allow_threads()`**: Releases the GIL during the parallel computation.
+  Python can't call into the env while it's stepping, but that's fine — the
+  training loop is sequential (step → inference → step).
+- **rayon `par_chunks_mut`**: Each env's world slice is processed in parallel
+  with work-stealing. No manual thread management.
+- **Observation layout**: Store as `(N, C, W, H)` in the Rust buffer, matching
+  PyTorch's expected layout. No transpose needed.
+
+##### Phase 4: Integration with `ppo.py`
+
+Replace the gym/AsyncVectorEnv setup with the Rust env:
+
+```python
+# Before (current):
+envs = gym.vector.AsyncVectorEnv([make_env(...) for i in range(N)])
+obs, info = envs.reset(seed=seed, options={...})
+obs, reward, term, trunc, infos = envs.step(action_dict)
+
+# After:
+env = factorion_rs.VecFactorioEnv(num_envs=N, size=8, max_steps=16)
+obs = env.reset(seed=seed)
+obs, rewards, dones, infos = env.step(actions_array)
+```
+
+Changes to `ppo.py`:
+
+- Remove `FactorioEnv` class entirely (or keep for testing/rendering only)
+- Remove `make_env`, `_ensure_env_registered`, gym registration
+- Remove `gym.vector.AsyncVectorEnv` setup
+- Change action format from dict to flat `(N, 6)` int64 array
+- Episode statistics tracking moves to Rust (or a thin Python wrapper
+  that reads from the info arrays)
+- `AgentCNN.__init__` takes explicit `width`, `height`, `channels` args
+  instead of reading from `envs.single_observation_space`
+- Video rendering kept in Python (infrequent, uses a separate
+  `SyncVectorEnv` with the Python `FactorioEnv`)
+
+##### Phase 5: Info dict handling
+
+The current `step()` returns ~20 info keys per env. Options:
+
+**Option A (simple):** Return a flat numpy array of info values per env, with
+a fixed schema. Python unpacks by index:
+```python
+obs, rewards, dones, info_array = env.step(actions)
+# info_array shape: (N, 20) — throughput, frac_reachable, etc.
+throughputs = info_array[:, 0]
+```
+
+**Option B (structured):** Return a Python dict of numpy arrays:
+```python
+{"throughput": np.array([...]), "frac_reachable": np.array([...]), ...}
+```
+
+Option A is faster (no dict construction in the hot loop). Option B is more
+readable. Start with Option A, add convenience accessors if needed.
+
+#### Testing strategy
+
+1. **`generate_lesson` parity**: For seeds 0..100, generate worlds from both
+   Python and Rust, assert tensors are identical.
+
+2. **`step()` parity**: For seeds 0..20, reset both Python and Rust envs with
+   same seed, step with same random actions for 16 steps, assert observations,
+   rewards, and dones match at every step.
+
+3. **`VecFactorioEnv` consistency**: Reset with N=64, step 1000 times, verify
+   no panics, all rewards finite, all obs in valid range.
+
+4. **Determinism**: Same seed → same trajectory, verified across 10 runs.
+
+5. **Benchmark**: Compare SPS between AsyncVectorEnv (H2) and VecFactorioEnv
+   (H3) at N=16, 64, 256 envs.
+
+#### Dependencies
+
+- `rayon` — parallel iterators (add to `[dependencies]` in `Cargo.toml`)
+- `rand` — seeded RNG for `generate_lesson` (add to `[dependencies]`)
+- Existing: `pyo3`, `numpy`
+
+#### Implementation order
+
+1. Port `generate_lesson` + BFS pathfinder to Rust, with parity tests
+2. Port `step()` + `reset()` to a single-env `FactorioEnv` Rust struct, with
+   parity tests
+3. Wrap in `VecFactorioEnv` with rayon, expose via PyO3
+4. Update `ppo.py` to use the Rust env
+5. Benchmark and profile
 
 ### H4: Reduce `num_minibatches` / increase minibatch size
 

--- a/docs/PERFORMANCE_IMPROVEMENTS.md
+++ b/docs/PERFORMANCE_IMPROVEMENTS.md
@@ -1,0 +1,322 @@
+# Performance Improvements
+
+This document catalogues ideas for improving training wall-clock time. The core
+problem is **GPU starvation**: the model is tiny (~135K params) and GPU batch
+sizes are microscopic. With `num_envs=16`, every inference call during rollout
+processes a batch of 16 samples — an A100 can handle thousands. The GPU is idle
+95%+ of the time, waiting for the CPU to step 16 serial Python environments.
+
+The bottleneck is CPU-bound env stepping, not GPU compute.
+
+Ideas are ordered by estimated impact.
+
+---
+
+## Table of Contents
+
+- [High-impact ideas](#high-impact-ideas)
+  - [H1: Increase num_envs (64-256+)](#h1-increase-num_envs-64-256)
+  - [H2: AsyncVectorEnv](#h2-asyncvectorenv)
+  - [H3: Move the entire env to Rust (vectorized)](#h3-move-the-entire-env-to-rust-vectorized)
+  - [H4: Reduce num_minibatches / increase minibatch size](#h4-reduce-num_minibatches--increase-minibatch-size)
+  - [H5: Mixed precision (bf16 on A100)](#h5-mixed-precision-bf16-on-a100)
+- [Medium-impact ideas](#medium-impact-ideas)
+  - [M1: Action masking for invalid actions](#m1-action-masking-for-invalid-actions)
+  - [M2: Move video recording out of the training loop](#m2-move-video-recording-out-of-the-training-loop)
+  - [M3: Reduce update_epochs from 8 to 4](#m3-reduce-update_epochs-from-8-to-4)
+  - [M4: Pre-allocate numpy buffer for Rust calls](#m4-pre-allocate-numpy-buffer-for-rust-calls)
+- [Recommended implementation order](#recommended-implementation-order)
+
+---
+
+## High-impact ideas
+
+### H1: Increase `num_envs` (64-256+)
+
+**Estimated impact:** High | **Complexity:** Zero (CLI arg change)
+
+The single biggest lever. Current defaults: `num_envs=16`, `batch_size=4096`,
+`minibatch_size=128`.
+
+Benefits of more envs:
+
+- **Larger GPU batches during rollout**: inference batch goes from 16 to 256,
+  much better GPU utilisation.
+- **More episodes per iteration**: faster curriculum signal accumulation. The
+  `moving_average_length=500` throughput buffer fills faster, so the agent
+  levels up sooner.
+- **Larger batch_size**: `256 * 256 = 65K` batch gives smoother gradients.
+
+With the model this small (~135K params), GPU memory is not the constraint —
+even 512 envs would fit easily on an A100 80GB.
+
+The catch: with `SyncVectorEnv`, more envs means proportionally more serial CPU
+time per rollout step. This motivates H2.
+
+**How to test:**
+
+```bash
+python ppo.py --num-envs 128 --num-minibatches 8 --total-timesteps 500000
+```
+
+### H2: AsyncVectorEnv
+
+**Estimated impact:** High | **Complexity:** Easy (one-line change + reset fix)
+
+`SyncVectorEnv` (`ppo.py:940`) calls each env's `step()` serially, so all Rust
+`simulate_throughput` calls and Python reward computation happen sequentially.
+`AsyncVectorEnv` runs each env in its own subprocess, parallelising all per-env
+work across CPU cores.
+
+Combined with H1 (say 128 envs), you'd have 128 subprocesses stepping in
+parallel. On a machine with 32+ cores, this gives ~16-32x faster env stepping.
+
+```python
+# Current (ppo.py:940):
+envs = gym.vector.SyncVectorEnv([...])
+
+# Proposed:
+envs = gym.vector.AsyncVectorEnv([...])
+```
+
+**Implementation notes:**
+
+- Gymnasium's `AsyncVectorEnv` uses subprocesses by default. No Rust changes
+  needed — each subprocess loads its own copy of the extension.
+- The manual per-env reset loop at `ppo.py:1068-1072` needs reworking.
+  `AsyncVectorEnv` handles autoreset internally; you can't call
+  `envs.envs[idx].reset()` across a process boundary. Instead, pass
+  `num_missing_entities` via the env's `options` dict and let the autoreset
+  mechanism handle it.
+- IPC serialization overhead is the risk. At 8x8 grids each observation is
+  ~256 floats, so serialisation cost should be negligible. Worth a quick
+  benchmark to confirm.
+
+Also documented as P5 in `docs/EXPERIMENTS.md`.
+
+### H3: Move the entire env to Rust (vectorized)
+
+**Estimated impact:** Very high | **Complexity:** High
+
+The nuclear option with the highest performance ceiling. Currently each
+`step()` call involves:
+
+1. Python dict unpacking and 8+ validity checks in Python
+2. Torch tensor mutations (`_world_CWH[channel, x, y] = value`)
+3. `.permute(1, 2, 0).to(torch.int64).numpy()` conversion per step (`ppo.py:450`)
+4. Rust FFI call to `simulate_throughput`
+5. Python reward computation with multiple tensor operations
+6. Solution match computation (`_compute_solution_match`)
+
+If the full `step()` — action validation, world mutation, throughput simulation,
+reward computation — were moved into Rust and exposed as a **batched** interface,
+all of this overhead disappears:
+
+```python
+# Hypothetical API:
+obs, rewards, dones, infos = rust_env.step_batch(actions)  # actions: (N, 6)
+```
+
+This eliminates:
+
+- All Python per-step overhead
+- All tensor/numpy conversion overhead
+- GIL contention
+- IPC serialisation (no subprocess boundary needed, unlike H2)
+
+This is the approach taken by EnvPool, Brax, and Isaac Gym. For a simple grid
+env like Factorion, this is very feasible in Rust. The `factorion_rs` crate
+already handles `simulate_throughput` — extending it to the full env logic is
+a natural next step.
+
+**Rough scope:**
+
+- Port `FactorioEnv.__init__`, `reset`, `step` to Rust
+- Port `generate_lesson` (currently in `factorion.py` marimo notebook) to Rust
+- Expose a `VecEnv` struct that holds N env states and steps them all in one call
+- Return observations as numpy arrays via PyO3 (zero-copy with `numpy` feature)
+
+### H4: Reduce `num_minibatches` / increase minibatch size
+
+**Estimated impact:** High (with H1) | **Complexity:** Zero (CLI arg change)
+
+Current: `num_minibatches=32`, `batch_size=4096` → `minibatch_size=128`.
+
+A minibatch of 128 is tiny for GPU — kernel launch overhead dominates. Options:
+
+| `num_envs` | `batch_size` | `num_minibatches` | `minibatch_size` | Notes |
+|---|---|---|---|---|
+| 16 | 4,096 | 32 | 128 | Current (too small) |
+| 16 | 4,096 | 4 | 1,024 | Quick test, no env change |
+| 128 | 32,768 | 8 | 4,096 | With H1 (good GPU payload) |
+| 256 | 65,536 | 8 | 8,192 | With H1 (great GPU payload) |
+
+Even without changing `num_envs`, dropping `num_minibatches` from 32 to 4 gives
+8x larger minibatches and fewer kernel launches per epoch.
+
+### H5: Mixed precision (bf16 on A100)
+
+**Estimated impact:** Medium (after H1/H4) | **Complexity:** Easy
+
+A100s have massive bf16 throughput (312 TFLOPS bf16 vs 19.5 TFLOPS fp32). The
+model currently uses fp32 everywhere.
+
+```python
+scaler = torch.amp.GradScaler('cuda')
+
+# During rollout inference:
+with torch.amp.autocast('cuda', dtype=torch.bfloat16):
+    action_ED, logprobs_E, _entropy_E, value_E = agent.get_action_and_value(next_obs_ECWH)
+
+# During PPO update:
+with torch.amp.autocast('cuda', dtype=torch.bfloat16):
+    _action_BA, newlogprobs_B, entropy_B, newvalue_B = agent.get_action_and_value(
+        obs_B[idxs], actions_B.long()[idxs]
+    )
+    # ... loss computation ...
+
+scaler.scale(loss).backward()
+scaler.unscale_(optimizer)
+nn.utils.clip_grad_norm_(agent.parameters(), args.max_grad_norm)
+scaler.step(optimizer)
+scaler.update()
+```
+
+Won't help much at current batch sizes (GPU isn't the bottleneck), but becomes
+meaningful once `num_envs` and `minibatch_size` are increased via H1/H4.
+
+Note: bf16 doesn't need `GradScaler` on A100 (bf16 has the same exponent range
+as fp32). You can simplify to just `torch.amp.autocast` without the scaler.
+
+---
+
+## Medium-impact ideas
+
+### M1: Action masking for invalid actions
+
+**Estimated impact:** Medium-high (sample efficiency) | **Complexity:** Medium
+
+330 of 640 effective actions (51.6%) are invalid with the current
+`num_entities=2` action space. Invalid actions are silently rejected
+(`ppo.py:384-425`) — they don't modify the world, waste an entire step, and
+produce zero PBRS delta.
+
+With masking, every step modifies the world, so every step produces a non-zero
+PBRS delta signal. This roughly doubles the effective reward signal density.
+
+This is primarily a **sample efficiency** improvement (learning faster per
+timestep) rather than a wall-clock speed improvement, but the two compound:
+faster learning per step means fewer total steps needed.
+
+Set invalid action logits to `-inf` before the softmax:
+
+```python
+# In get_action_and_value, after computing tile_logits:
+tile_mask = get_tile_mask(x_BCWH)  # True for valid tiles
+tile_logits_BN[~tile_mask.reshape(B, -1)] = float('-inf')
+
+# After selecting a tile and computing entity logits:
+ent_mask = get_entity_mask(...)  # True for valid entities
+logits_e_BE[~ent_mask] = float('-inf')
+```
+
+Masks must be applied during both rollout and PPO update (otherwise the
+importance sampling ratio `pi_new / pi_old` is computed over different
+distributions).
+
+Also documented as P2 in `docs/EXPERIMENTS.md`.
+
+### M2: Move video recording out of the training loop
+
+**Estimated impact:** Medium | **Complexity:** Easy
+
+Lines `ppo.py:1262-1319`: every 50 iterations, training blocks while 5 new
+envs are created, stepped 10 times with rendering, saved as PNGs, and encoded
+to MP4 via ffmpeg. This is synchronous.
+
+Options (pick one):
+
+- **Background thread/process:** Spawn the recording in a separate process so
+  training continues immediately.
+- **Reduce frequency:** Record every 200 iterations instead of 50.
+- **Final-only:** Only record on the last iteration.
+- **Skip entirely during benchmarks:** Add a `--no-video` flag.
+
+### M3: Reduce `update_epochs` from 8 to 4
+
+**Estimated impact:** Medium | **Complexity:** Zero (CLI arg change)
+
+Each update epoch is a full forward+backward pass over the entire batch. 8
+epochs means the backward pass runs `8 * num_minibatches` times per iteration.
+
+With larger batches (H1/H4), each epoch already sees more data, so fewer epochs
+are needed for the same gradient quality. PPO typically uses 3-10 epochs; 4 is
+a common choice.
+
+This halves the time spent in the PPO update phase. Must validate empirically
+that throughput doesn't regress — fewer epochs means less policy refinement per
+batch of experience.
+
+```bash
+python ppo.py --update-epochs 4
+```
+
+### M4: Pre-allocate numpy buffer for Rust calls
+
+**Estimated impact:** Low-medium | **Complexity:** Easy
+
+Every `step()` converts the world tensor for Rust:
+
+```python
+self._world_CWH.permute(1, 2, 0).to(torch.int64).numpy()  # ppo.py:450
+```
+
+This runs 4,096 times per iteration (16 envs x 256 steps), allocating a new
+numpy array each time. Pre-allocate and do an incremental update:
+
+```python
+# In __init__:
+self._world_WHC_np = np.zeros((size, size, num_channels), dtype=np.int64)
+
+# In step(), after mutating _world_CWH at (x, y):
+self._world_WHC_np[x, y, :] = self._world_CWH[:, x, y].numpy()
+
+# In reset():
+self._world_WHC_np[:] = self._world_CWH.permute(1, 2, 0).to(torch.int64).numpy()
+
+# Then:
+throughput, num_unreachable = factorion_rs.simulate_throughput(self._world_WHC_np)
+```
+
+Risk: must keep `_world_WHC_np` perfectly in sync with `_world_CWH`. A missed
+update causes silent correctness bugs.
+
+Also documented as P3 in `docs/EXPERIMENTS.md`.
+
+---
+
+## Recommended implementation order
+
+The highest bang-for-buck sequence:
+
+1. **H1 + H4**: Increase `num_envs` to 64-128 and decrease `num_minibatches`
+   to 4-8. Zero code changes — just CLI args. Benchmark immediately.
+
+2. **H2**: Switch to `AsyncVectorEnv`. One-line change plus fixing the manual
+   reset loop. Combined with step 1, this parallelises env stepping across
+   cores.
+
+3. **M1**: Action masking. Moderate code change, big sample efficiency gain.
+   Every step now produces a useful learning signal.
+
+4. **Profile**: After steps 1-3, profile to see where time is actually spent
+   before investing in H3 (full Rust env). Use `py-spy` or PyTorch profiler.
+
+5. **H3**: If env stepping is still the bottleneck after H2, move the full env
+   to Rust with a batched interface. This is the highest-effort change but
+   removes all remaining Python overhead.
+
+6. **H5 + M3**: Mixed precision and fewer update epochs. These become
+   meaningful once GPU is actually doing work (after H1/H4).
+
+7. **M2 + M4**: Quality-of-life improvements. Small gains but easy to do.

--- a/ppo.py
+++ b/ppo.py
@@ -145,10 +145,16 @@ class Args:
     """the number of iterations (total_timesteps // batch_size)"""
 
 
-def make_env(env_id, idx, capture_video, size, run_name):
+def _ensure_env_registered():
+    """Register the FactorioEnv if not already registered (needed in subprocesses)."""
+    if "factorion/FactorioEnv-v0" not in gym.registry:
+        gym.register(id="factorion/FactorioEnv-v0", entry_point=FactorioEnv)
+
+def make_env(env_id, idx, capture_video, size, run_name, max_missing_entities=1):
     def thunk():
+        _ensure_env_registered()
         kwargs = {"render_mode": "rgb_array"} if capture_video else {}
-        kwargs.update({'size': size, 'max_steps': 2*size, 'idx': idx})
+        kwargs.update({'size': size, 'max_steps': 2*size, 'idx': idx, 'max_missing_entities': max_missing_entities})
         # kwargs.update({'size': size, 'max_steps': 6})
         env = gym.make(env_id, **kwargs)
         if capture_video:
@@ -218,6 +224,7 @@ class FactorioEnv(gym.Env):
         render_mode: Optional[str] = None,
         idx: Optional[int] = None,
         options: Optional[dict] = None,
+        max_missing_entities: int = 1,
     ):
         super().__init__()
         # Setup the renderer if requested
@@ -227,6 +234,7 @@ class FactorioEnv(gym.Env):
             self.render_modes = [render_mode]
 
         self.size = size
+        self.max_missing_entities = max_missing_entities
         if max_steps is None:
             max_steps = self.size * self.size
 
@@ -305,6 +313,10 @@ class FactorioEnv(gym.Env):
 
         return location_match, entity_match, direction_match
 
+    def set_max_missing(self, value: int):
+        """Update the curriculum level (called via envs.call from the training loop)."""
+        self.max_missing_entities = value
+
     def reset(self, seed: Optional[int] = None, options: Optional[dict] = None):
         if seed is None:
             seed = 0
@@ -324,7 +336,13 @@ class FactorioEnv(gym.Env):
         self._terminated = False
         self._truncated = False
         self.max_entities = 2
-        self._num_missing_entities = self._reset_options['num_missing_entities'] # TODO also change max_steps in tandem
+        # Use num_missing_entities from options if provided, otherwise sample
+        # from [0, max_missing_entities]. This lets AsyncVectorEnv autoreset
+        # work without needing per-env manual reset calls.
+        if 'num_missing_entities' in self._reset_options:
+            self._num_missing_entities = self._reset_options['num_missing_entities']
+        else:
+            self._num_missing_entities = int(torch.randint(0, self.max_missing_entities + 1, (1,)).item())
 
         self.actions = []
         # Generate the solved factory first (same seed → same layout),
@@ -738,15 +756,17 @@ class FactorioEnv(gym.Env):
 class AgentCNN(nn.Module):
     def __init__(self, envs, chan1=32, chan2=64, chan3=64, flat_dim=256, tile_head_std=0.01):
         super().__init__()
-        base_env = envs.envs[0].unwrapped
-        self.width = base_env.size
-        self.height = base_env.size
-        self.channels = len(base_env.Channel)
+        # Derive metadata from observation/action spaces (works with both
+        # SyncVectorEnv and AsyncVectorEnv).
+        obs_shape = envs.single_observation_space.shape  # (C, W, H)
+        self.channels = obs_shape[0]
+        self.width = obs_shape[1]
+        self.height = obs_shape[2]
         # minus two for the source and the sink
         self.num_entities = 2 # len(base_env.entities) - 2 TODO for now, only allow empty or transport_belt
-        self.num_directions = len(base_env.Direction)
-        self.num_items = len(base_env.items)
-        self.num_misc = len(base_env.Misc)
+        self.num_directions = envs.single_action_space["direction"].n
+        self.num_items = envs.single_action_space["item"].n
+        self.num_misc = envs.single_action_space["misc"].n
         self.chan3 = chan3
 
         self.encoder = nn.Sequential(
@@ -936,8 +956,9 @@ if __name__ == "__main__":
     print(f"running on {device}")
 
     print(f"Setting up envs with {args}")
-    # env setup
-    envs = gym.vector.SyncVectorEnv(
+    # env setup — AsyncVectorEnv runs each env in its own subprocess,
+    # parallelising Rust simulate_throughput calls across CPU cores.
+    envs = gym.vector.AsyncVectorEnv(
         [make_env(args.env_id, i, args.capture_video, args.size, run_name) for i in range(args.num_envs)],
     )
 
@@ -1063,13 +1084,9 @@ if __name__ == "__main__":
             next_done = np.logical_or(terminations, truncations)
             rewards_SE[step] = torch.as_tensor(np.array(reward), dtype=torch.float32, device=device)
 
-            # Reset only the done environments with updated num_missing_entities
-            done_indices = np.where(next_done)[0]
-            for idx in done_indices:
-                obs, _ = envs.envs[idx].reset(seed=args.seed + idx, options={
-                    'num_missing_entities': int(torch.randint(0, max_missing_entities+1, (1,))[0])
-                })
-                next_obs_ECWH[idx] = obs
+            # AsyncVectorEnv handles autoreset — done envs are automatically
+            # reset with the current max_missing_entities (set via envs.call).
+            # next_obs_ECWH already contains the post-reset observations.
 
             next_obs_ECWH = torch.as_tensor(np.array(next_obs_ECWH), dtype=torch.float32, device=device)
             next_done = torch.as_tensor(np.array(next_done), dtype=torch.float32, device=device)
@@ -1248,6 +1265,8 @@ if __name__ == "__main__":
                     for _ in range(moving_average_length):
                         end_of_episode_thputs.append(0)
                     max_missing_entities = min(max_missing_entities + 1, args.size*2)
+                    # Broadcast new curriculum level to all subprocess envs
+                    envs.call("set_max_missing", max_missing_entities)
                     print(f"\nNow working with {max_missing_entities=}")
             # Recompute after potential level-up so we use the reset buffer
             final_thputs_100ma = sum(end_of_episode_thputs) / len(end_of_episode_thputs)

--- a/ppo.py
+++ b/ppo.py
@@ -1137,6 +1137,7 @@ if __name__ == "__main__":
                     "curriculum/level": max_missing_entities,
                     "curriculum/score": (max_missing_entities - 1) + final_thputs_100ma,
                     "curriculum/throughput_avg": final_thputs_100ma,
+                    "perf/sps": int(global_step / (time.time() - start_time)),
                 }
                 eval_metrics.update(_flush_episode_means())
                 wandb.log(eval_metrics, step=global_step)

--- a/ppo.py
+++ b/ppo.py
@@ -336,13 +336,14 @@ class FactorioEnv(gym.Env):
         self._terminated = False
         self._truncated = False
         self.max_entities = 2
-        # Use num_missing_entities from options if provided, otherwise sample
-        # from [0, max_missing_entities]. This lets AsyncVectorEnv autoreset
-        # work without needing per-env manual reset calls.
-        if 'num_missing_entities' in self._reset_options:
-            self._num_missing_entities = self._reset_options['num_missing_entities']
+        # Use num_missing_entities from options if explicitly provided for
+        # this reset call, otherwise sample from [0, max_missing_entities].
+        # This lets AsyncVectorEnv autoreset (which passes options=None)
+        # work correctly with curriculum progression.
+        if options is not None and 'num_missing_entities' in options:
+            self._num_missing_entities = options['num_missing_entities']
         else:
-            self._num_missing_entities = int(torch.randint(0, self.max_missing_entities + 1, (1,)).item())
+            self._num_missing_entities = int(self.np_random.integers(0, self.max_missing_entities + 1))
 
         self.actions = []
         # Generate the solved factory first (same seed → same layout),
@@ -958,8 +959,12 @@ if __name__ == "__main__":
     print(f"Setting up envs with {args}")
     # env setup — AsyncVectorEnv runs each env in its own subprocess,
     # parallelising Rust simulate_throughput calls across CPU cores.
+    # autoreset_mode="same_step" resets done envs immediately (same step),
+    # matching the old SyncVectorEnv + manual reset semantics. The default
+    # "next_step" would waste one step per episode on a no-op autoreset.
     envs = gym.vector.AsyncVectorEnv(
         [make_env(args.env_id, i, args.capture_video, args.size, run_name) for i in range(args.num_envs)],
+        autoreset_mode="SameStep",
     )
 
     print(f"Creating agent with {args.chan1=}, {args.chan2=}, {args.chan3=}, {args.flat_dim=}, {args.tile_head_std=} ")

--- a/ppo.py
+++ b/ppo.py
@@ -1096,25 +1096,21 @@ if __name__ == "__main__":
             next_obs_ECWH = torch.as_tensor(np.array(next_obs_ECWH), dtype=torch.float32, device=device)
             next_done = torch.as_tensor(np.array(next_done), dtype=torch.float32, device=device)
 
-            if "episode" in infos:
-                # The "_episode" mask indicates which environments finished this step
-                # We can use any of the masks (_r, _l, _t) as they should be the same for a finished env
-                finished_envs_mask = infos["_episode"]
-
-                # Iterate through the boolean mask
+            # With SameStep autoreset, terminal episode info is in
+            # infos["final_info"] — a stacked dict where each value is
+            # an array indexed by env. "_final_info" is a boolean mask.
+            if "final_info" in infos:
+                fi = infos["final_info"]
                 for i in range(args.num_envs):
-                    if not finished_envs_mask[i]:
+                    if not infos["_final_info"][i]:
+                        continue
+                    if "episode" not in fi or not fi["_episode"][i]:
                         continue
                     # This environment finished, extract its stats
-                    episode_return = infos["episode"]["r"][i]
-                    episode_len = infos["episode"]["l"][i]
-                    end_of_episode_thput = infos["throughput"][i]
-                    final_frac_reachable = infos["frac_reachable"][i]
-                    # final_frac_hallucin = infos["frac_hallucin"][i]
-
-                    # episodic_returns.append(episode_return)
-                    # avg_return = sum(episodic_returns) / len(episodic_returns)
-                    # writer.add_scalar("old/charts/episodic_return_ma", avg_return, global_step)
+                    episode_return = fi["episode"]["r"][i]
+                    episode_len = fi["episode"]["l"][i]
+                    end_of_episode_thput = fi["throughput"][i]
+                    final_frac_reachable = fi["frac_reachable"][i]
 
                     end_of_episode_thputs.append(end_of_episode_thput)
 
@@ -1122,16 +1118,16 @@ if __name__ == "__main__":
                         "episode/throughput": float(end_of_episode_thput),
                         "episode/reward": float(episode_return),
                         "episode/length": float(episode_len),
-                        "episode/invalid_frac": float(infos['frac_invalid_actions'][i]),
-                        "episode/num_entities": float(infos['num_entities'][i]),
-                        "episode/entity_efficiency": float(infos['min_entities_required'][i]) / float(infos['num_entities'][i]),
+                        "episode/invalid_frac": float(fi['frac_invalid_actions'][i]),
+                        "episode/num_entities": float(fi['num_entities'][i]),
+                        "episode/entity_efficiency": float(fi['min_entities_required'][i]) / float(fi['num_entities'][i]),
                         "episode/frac_reachable": float(final_frac_reachable),
-                        "shaping/tile_location": float(infos['tile_match_location'][i]),
-                        "shaping/tile_entity": float(infos['tile_match_entity'][i]),
-                        "shaping/tile_direction": float(infos['tile_match_direction'][i]),
-                        "shaping/delta_location": float(infos['shaping_location_delta'][i]),
-                        "shaping/delta_entity": float(infos['shaping_entity_delta'][i]),
-                        "shaping/delta_direction": float(infos['shaping_direction_delta'][i]),
+                        "shaping/tile_location": float(fi['tile_match_location'][i]),
+                        "shaping/tile_entity": float(fi['tile_match_entity'][i]),
+                        "shaping/tile_direction": float(fi['tile_match_direction'][i]),
+                        "shaping/delta_location": float(fi['shaping_location_delta'][i]),
+                        "shaping/delta_entity": float(fi['shaping_entity_delta'][i]),
+                        "shaping/delta_direction": float(fi['shaping_direction_delta'][i]),
                     })
 
             # Log eval metrics every 256 global steps during rollout

--- a/scripts/ci/gpu_sweep.sh
+++ b/scripts/ci/gpu_sweep.sh
@@ -104,7 +104,8 @@ mkdir -p /workspace/agent_logs
 for i in $(seq 0 $((AGENTS_PER_POD - 1))); do
     LOG="/workspace/agent_logs/agent_${AGENT_ID}_${i}.log"
     echo ">>> Starting agent ${AGENT_ID}.${i} (log: ${LOG})"
-    if wandb agent --count "$SWEEP_COUNT" "$SWEEP_ID" > "$LOG" 2>&1; then
+    # Tee to both log file and stdout so SSH stays alive and we see progress
+    if wandb agent --count "$SWEEP_COUNT" "$SWEEP_ID" 2>&1 | tee "$LOG"; then
         echo ">>> Agent ${AGENT_ID}.${i} finished successfully"
     else
         EXIT_CODE=$?

--- a/scripts/ci/gpu_sweep.sh
+++ b/scripts/ci/gpu_sweep.sh
@@ -91,35 +91,24 @@ chmod +x run_sweep.sh
 export WANDB_API_KEY
 
 echo ""
-echo ">>> Launching ${AGENTS_PER_POD} parallel W&B sweep agents (${SWEEP_COUNT} iterations each)..."
+echo ">>> Launching ${AGENTS_PER_POD} sequential W&B sweep agents (${SWEEP_COUNT} iterations each)..."
 echo ">>> Sweep: ${SWEEP_ID}"
 echo ""
 
-# ── Launch sweep agents in parallel ──────────────────────────────
-# Each agent process independently pulls work from the W&B sweep controller.
-# CUDA time-slices between processes, keeping GPU utilisation high.
-PIDS=()
+# ── Launch sweep agents sequentially ──────────────────────────────
+# AsyncVectorEnv spawns subprocesses per env — running multiple agents
+# in parallel causes OOM on a single GPU. Run them one at a time.
+FAILED=0
 mkdir -p /workspace/agent_logs
 
 for i in $(seq 0 $((AGENTS_PER_POD - 1))); do
     LOG="/workspace/agent_logs/agent_${AGENT_ID}_${i}.log"
     echo ">>> Starting agent ${AGENT_ID}.${i} (log: ${LOG})"
-    wandb agent --count "$SWEEP_COUNT" "$SWEEP_ID" > "$LOG" 2>&1 &
-    PIDS+=($!)
-done
-
-echo ">>> All ${AGENTS_PER_POD} agents launched (PIDs: ${PIDS[*]})"
-echo ""
-
-# ── Wait for all agents and track failures ───────────────────────
-FAILED=0
-for i in "${!PIDS[@]}"; do
-    PID="${PIDS[$i]}"
-    if wait "$PID"; then
-        echo ">>> Agent ${AGENT_ID}.${i} (PID ${PID}) finished successfully"
+    if wandb agent --count "$SWEEP_COUNT" "$SWEEP_ID" > "$LOG" 2>&1; then
+        echo ">>> Agent ${AGENT_ID}.${i} finished successfully"
     else
         EXIT_CODE=$?
-        echo ">>> Agent ${AGENT_ID}.${i} (PID ${PID}) failed with exit code ${EXIT_CODE}"
+        echo ">>> Agent ${AGENT_ID}.${i} failed with exit code ${EXIT_CODE}"
         FAILED=$((FAILED + 1))
     fi
 done

--- a/scripts/ci/sweep_report.py
+++ b/scripts/ci/sweep_report.py
@@ -21,6 +21,27 @@ import sys
 import wandb
 
 
+def _get_summary_metric(summary, metric_name):
+    """Resolve a W&B metric name from a run summary.
+
+    Handles dot-notation like "perf/sps.last" where the summary stores
+    {"perf/sps": {"last": 359}}.  Falls back to a direct key lookup.
+    """
+    # Direct lookup first
+    val = summary.get(metric_name)
+    if val is not None and not isinstance(val, dict):
+        return val
+
+    # Try dot-notation: "perf/sps.last" -> summary["perf/sps"]["last"]
+    if "." in metric_name:
+        base, sub = metric_name.rsplit(".", 1)
+        val = summary.get(base)
+        if isinstance(val, dict):
+            return val.get(sub)
+
+    return None
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Generate markdown report from a W&B sweep"
@@ -58,12 +79,18 @@ def main():
     sweep_params = sweep.config.get("parameters", {})
     reverse = metric_goal == "maximize"
 
-    # Fetch runs that have the target metric (finished or crashed)
+    # Fetch runs that have the target metric (finished, crashed, or failed)
+    all_runs = list(sweep.runs)
+    print(f"Total runs in sweep: {len(all_runs)}")
+    for r in all_runs:
+        val = _get_summary_metric(r.summary, metric_name)
+        print(f"  {r.name}: state={r.state}, {metric_name}={val}")
     runs = [
-        r for r in sweep.runs
-        if r.state in ("finished", "crashed")
-        and r.summary.get(metric_name) is not None
+        r for r in all_runs
+        if r.state in ("finished", "crashed", "failed")
+        and _get_summary_metric(r.summary, metric_name) is not None
     ]
+    print(f"Runs with valid metric data: {len(runs)}")
 
     # sweep_path is entity/project/sweep_id — W&B URLs need /sweeps/ before the ID
     parts = args.sweep_path.split("/")
@@ -72,7 +99,8 @@ def main():
     if not runs:
         md = (
             "## W&B Hyperparameter Sweep Results\n\n"
-            "**No completed runs found in sweep.**\n\n"
+            f"**No runs with `{metric_name}` data found in sweep "
+            f"({len(all_runs)} total runs).**\n\n"
             f"[View sweep on W&B]({sweep_url})\n\n"
             f"<sub>Commit {args.commit_sha[:8]} "
             f"\u00b7 PR #{args.pr_number}</sub>\n"
@@ -84,7 +112,7 @@ def main():
 
     # Sort runs by the sweep metric
     def get_metric(run):
-        val = run.summary.get(metric_name)
+        val = _get_summary_metric(run.summary, metric_name)
         if val is None:
             return float("-inf") if reverse else float("inf")
         return val

--- a/scripts/ci/sweep_report.py
+++ b/scripts/ci/sweep_report.py
@@ -25,21 +25,25 @@ def _get_summary_metric(summary, metric_name):
     """Resolve a W&B metric name from a run summary.
 
     Handles dot-notation like "perf/sps.last" where the summary stores
-    {"perf/sps": {"last": 359}}.  Falls back to a direct key lookup.
+    {"perf/sps": SummarySubDict({"last": 359})}.
+    W&B's SummarySubDict supports .get() but isn't a dict subclass.
     """
-    # Direct lookup first
-    val = summary.get(metric_name)
-    if val is not None and not isinstance(val, dict):
-        return val
-
-    # Try dot-notation: "perf/sps.last" -> summary["perf/sps"]["last"]
+    # Try dot-notation first: "perf/sps.last" -> summary["perf/sps"]["last"]
     if "." in metric_name:
         base, sub = metric_name.rsplit(".", 1)
-        val = summary.get(base)
-        if isinstance(val, dict):
-            return val.get(sub)
+        container = summary.get(base)
+        if container is not None:
+            try:
+                return container.get(sub)
+            except AttributeError:
+                pass
 
-    return None
+    # Fall back to direct lookup (works for plain numeric summaries)
+    val = summary.get(metric_name)
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return None
 
 
 def main():

--- a/scripts/ci/sweep_report.py
+++ b/scripts/ci/sweep_report.py
@@ -58,8 +58,12 @@ def main():
     sweep_params = sweep.config.get("parameters", {})
     reverse = metric_goal == "maximize"
 
-    # Fetch all runs, keep only finished ones
-    runs = [r for r in sweep.runs if r.state == "finished"]
+    # Fetch runs that have the target metric (finished or crashed)
+    runs = [
+        r for r in sweep.runs
+        if r.state in ("finished", "crashed")
+        and r.summary.get(metric_name) is not None
+    ]
 
     # sweep_path is entity/project/sweep_id — W&B URLs need /sweeps/ before the ID
     parts = args.sweep_path.split("/")
@@ -100,7 +104,7 @@ def main():
     md_lines.append(
         f"| **Sweep** | [{args.sweep_path}]({sweep_url}) |"
     )
-    md_lines.append(f"| **Completed runs** | {len(runs)} |")
+    md_lines.append(f"| **Runs with data** | {len(runs)} |")
     md_lines.append(
         f"| **Metric** | `{metric_name}` ({metric_goal}) |"
     )

--- a/sweep.yaml
+++ b/sweep.yaml
@@ -1,4 +1,9 @@
 # sweep.yaml — Performance sweep (maximise training speed)
+#
+# Sweeps over parallelism and batching parameters to find the fastest
+# configuration. The metric to maximise is perf/sps (steps per second).
+# total-timesteps is set high enough that even the largest batch configs
+# (256 envs * 512 steps = 131072 batch) get multiple training iterations.
 
 method: bayes
 run_cap: 30
@@ -25,6 +30,6 @@ command:
   - bash
   - run_sweep.sh
   - --total-timesteps
-  - "100000"
+  - "500000"
   - --track
   - ${args}

--- a/sweep.yaml
+++ b/sweep.yaml
@@ -1,90 +1,23 @@
-# sweep.yaml — Delta-based reward shaping sweep
+# sweep.yaml — Performance sweep (maximise training speed)
 
 method: bayes
-run_cap: 20
+run_cap: 30
 metric:
-  name: "curriculum/score"
+  name: "perf/sps"
   goal: maximize
 
 parameters:
-  coeff_shaping_location:
-    distribution: log_uniform_values
-    min: 0.1
-    max: 5.0
+  num_envs:
+    values: [16, 32, 64, 128, 256]
 
-  coeff_shaping_entity:
-    distribution: log_uniform_values
-    min: 0.1
-    max: 5.0
+  num_steps:
+    values: [64, 128, 256, 512]
 
-  coeff_shaping_direction:
-    distribution: log_uniform_values
-    min: 0.1
-    max: 5.0
+  num_minibatches:
+    values: [2, 4, 8, 16, 32]
 
-  coeff_throughput:
-    distribution: uniform
-    min: 0.5
-    max: 0.99
-
-  ent_coef_start:
-    distribution: log_uniform_values
-    min: 0.005
-    max: 0.2
-
-  ent_coef_end:
-    distribution: log_uniform_values
-    min: 1e-4
-    max: 0.01
-
-  learning_rate:
-    distribution: log_uniform_values
-    min: 5e-5
-    max: 1e-3
-
-  chan1:
-    values: [32, 48, 64]
-
-  chan2:
-    values: [48, 64]
-
-  chan3:
-    values: [48, 64]
-
-  clip_coef:
-    distribution: uniform
-    min: 0.18
-    max: 0.32
-
-  gamma:
-    distribution: uniform
-    min: 0.95
-    max: 0.999
-
-  gae_lambda:
-    distribution: uniform
-    min: 0.8
-    max: 0.975
-
-  tile_head_std:
-    distribution: log_uniform_values
-    min: 0.001
-    max: 0.1
-
-  vf_coef:
-    distribution: uniform
-    min: 0.5
-    max: 0.9
-
-  max_grad_norm:
-    distribution: uniform
-    min: 0.75
-    max: 2.5
-
-  adam_epsilon:
-    distribution: log_uniform_values
-    min: 1e-6
-    max: 2e-4
+  update_epochs:
+    values: [2, 4, 6, 8]
 
 program: ppo.py
 
@@ -92,6 +25,6 @@ command:
   - bash
   - run_sweep.sh
   - --total-timesteps
-  - 250_000
+  - "100000"
   - --track
   - ${args}

--- a/sweep.yaml
+++ b/sweep.yaml
@@ -8,7 +8,7 @@
 method: bayes
 run_cap: 30
 metric:
-  name: "perf/sps"
+  name: "perf/sps.last"
   goal: maximize
 
 parameters:
@@ -30,6 +30,6 @@ command:
   - bash
   - run_sweep.sh
   - --total-timesteps
-  - "500000"
+  - "100000"
   - --track
   - ${args}

--- a/tests/test_async_env.py
+++ b/tests/test_async_env.py
@@ -1,0 +1,201 @@
+"""Tests for AsyncVectorEnv migration: curriculum sampling, set_max_missing,
+env registration in subprocesses, and autoreset behavior."""
+
+import os
+import sys
+
+import gymnasium as gym
+import numpy as np
+
+# Disable wandb before importing ppo
+os.environ["WANDB_MODE"] = "disabled"
+os.environ["WANDB_DISABLED"] = "true"
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from ppo import FactorioEnv, _ensure_env_registered, make_env  # noqa: E402
+
+
+def _make_env(size=5, max_steps=10, max_missing_entities=1):
+    """Create a FactorioEnv for testing."""
+    return FactorioEnv(
+        size=size, max_steps=max_steps, idx=0,
+        max_missing_entities=max_missing_entities,
+    )
+
+
+def _noop_action():
+    """Return a no-op action (place empty entity at 0,0)."""
+    return {
+        "xy": np.array([0, 0]),
+        "entity": 0,
+        "direction": 0,
+        "item": 0,
+        "misc": 0,
+    }
+
+
+class TestSetMaxMissing:
+    """Test the set_max_missing() method used by envs.call()."""
+
+    def test_updates_max_missing_entities(self):
+        env = _make_env(max_missing_entities=1)
+        assert env.max_missing_entities == 1
+        env.set_max_missing(5)
+        assert env.max_missing_entities == 5
+
+    def test_autoreset_uses_updated_max(self):
+        """After set_max_missing(3), autoreset should sample from [0, 3]."""
+        env = _make_env(size=5, max_steps=10, max_missing_entities=1)
+        env.reset(seed=42, options={"num_missing_entities": 0})
+
+        env.set_max_missing(3)
+
+        # Reset without options (simulating autoreset)
+        env.reset(seed=99)
+        assert 0 <= env._num_missing_entities <= 3
+
+    def test_autoreset_samples_vary(self):
+        """Autoreset with max_missing_entities=3 should produce varied values
+        across many resets (not always the same)."""
+        env = _make_env(size=5, max_steps=10, max_missing_entities=3)
+        env.reset(seed=0, options={"num_missing_entities": 0})
+
+        values = set()
+        for seed in range(50):
+            env.reset(seed=seed)
+            values.add(env._num_missing_entities)
+
+        assert len(values) > 1, (
+            f"Expected varied num_missing_entities across resets, got only {values}"
+        )
+
+
+class TestAutoresetCurriculumSampling:
+    """Test that autoreset (options=None) samples num_missing_entities
+    instead of reusing the stale initial value."""
+
+    def test_autoreset_does_not_reuse_initial_options(self):
+        """If the first reset passes num_missing_entities=0, subsequent
+        autosets (options=None) should NOT always use 0."""
+        env = _make_env(size=5, max_steps=10, max_missing_entities=3)
+
+        # First explicit reset with num_missing_entities=0
+        env.reset(seed=42, options={"num_missing_entities": 0})
+        assert env._num_missing_entities == 0
+
+        # Simulate multiple autoreset calls (no options)
+        values = set()
+        for seed in range(50):
+            env.reset(seed=seed)
+            values.add(env._num_missing_entities)
+
+        # Should not always be 0 — the random sampling path should trigger
+        assert values != {0}, (
+            f"Autoreset always produced 0, suggesting _reset_options stickiness bug"
+        )
+
+    def test_explicit_options_still_honored(self):
+        """Passing options with num_missing_entities should override sampling."""
+        env = _make_env(size=5, max_steps=10, max_missing_entities=5)
+        env.reset(seed=42, options={"num_missing_entities": 2})
+        assert env._num_missing_entities == 2
+
+    def test_autoreset_respects_max_bound(self):
+        """Autoreset should never exceed max_missing_entities."""
+        env = _make_env(size=5, max_steps=10, max_missing_entities=2)
+        for seed in range(50):
+            env.reset(seed=seed)
+            assert 0 <= env._num_missing_entities <= 2
+
+
+class TestEnsureEnvRegistered:
+    """Test the _ensure_env_registered helper for subprocess compatibility."""
+
+    def test_registers_when_missing(self):
+        # Temporarily remove the registration if present
+        was_registered = "factorion/FactorioEnv-v0" in gym.registry
+        if was_registered:
+            del gym.registry["factorion/FactorioEnv-v0"]
+
+        try:
+            assert "factorion/FactorioEnv-v0" not in gym.registry
+            _ensure_env_registered()
+            assert "factorion/FactorioEnv-v0" in gym.registry
+        finally:
+            # Clean up: re-register if it was there before
+            if was_registered and "factorion/FactorioEnv-v0" not in gym.registry:
+                gym.register(id="factorion/FactorioEnv-v0", entry_point=FactorioEnv)
+
+    def test_idempotent(self):
+        """Calling _ensure_env_registered twice should not raise."""
+        _ensure_env_registered()
+        _ensure_env_registered()
+        assert "factorion/FactorioEnv-v0" in gym.registry
+
+
+class TestMaxMissingEntitiesConstructor:
+    """Test that max_missing_entities is properly passed through make_env."""
+
+    def test_default_max_missing_entities(self):
+        env = _make_env()
+        assert env.max_missing_entities == 1
+
+    def test_custom_max_missing_entities(self):
+        env = _make_env(max_missing_entities=4)
+        assert env.max_missing_entities == 4
+
+
+class TestAsyncVectorEnvIntegration:
+    """Integration tests with actual AsyncVectorEnv."""
+
+    def test_async_env_creates_and_steps(self):
+        """AsyncVectorEnv should create envs, reset, and step without error."""
+        _ensure_env_registered()
+        num_envs = 4
+        envs = gym.vector.AsyncVectorEnv(
+            [make_env("factorion/FactorioEnv-v0", i, False, 5, "test")
+             for i in range(num_envs)],
+            autoreset_mode="SameStep",
+        )
+        try:
+            obs, info = envs.reset(
+                seed=42, options={"num_missing_entities": 1}
+            )
+            assert obs.shape[0] == num_envs
+
+            actions = {
+                "xy": np.zeros((num_envs, 2), dtype=int),
+                "entity": np.zeros(num_envs, dtype=int),
+                "direction": np.zeros(num_envs, dtype=int),
+                "item": np.zeros(num_envs, dtype=int),
+                "misc": np.zeros(num_envs, dtype=int),
+            }
+            obs, rewards, terminated, truncated, infos = envs.step(actions)
+            assert obs.shape[0] == num_envs
+            assert rewards.shape == (num_envs,)
+        finally:
+            envs.close()
+
+    def test_async_env_call_set_max_missing(self):
+        """envs.call('set_max_missing', ...) should update all subprocess envs."""
+        _ensure_env_registered()
+        num_envs = 4
+        envs = gym.vector.AsyncVectorEnv(
+            [make_env("factorion/FactorioEnv-v0", i, False, 5, "test")
+             for i in range(num_envs)],
+            autoreset_mode="SameStep",
+        )
+        try:
+            envs.reset(seed=42, options={"num_missing_entities": 0})
+
+            # Update curriculum level
+            envs.call("set_max_missing", 3)
+
+            # Verify all envs received the update
+            results = envs.get_attr("max_missing_entities")
+            assert all(v == 3 for v in results), (
+                f"Expected all envs to have max_missing_entities=3, got {results}"
+            )
+        finally:
+            envs.close()


### PR DESCRIPTION
## Summary

- **AsyncVectorEnv**: Replace `SyncVectorEnv` with `AsyncVectorEnv` so env stepping runs in parallel across CPU cores. Each env runs in its own subprocess, parallelising Rust `simulate_throughput` calls. Uses `autoreset_mode="SameStep"` to match old manual-reset semantics.
- **Self-resetting curriculum**: Envs now sample `num_missing_entities` on autoreset via `self.np_random.integers()`, with curriculum level broadcast via `envs.call("set_max_missing", ...)`. No more manual per-env reset loop (which doesn't work across process boundaries).
- **Performance sweep**: Rewrote `sweep.yaml` to maximise `perf/sps` by sweeping `num_envs` (16–256), `num_steps` (64–512), `num_minibatches` (2–32), and `update_epochs` (2–8).
- **Performance doc**: Added `docs/PERFORMANCE_IMPROVEMENTS.md` cataloguing 9 ideas for improving training wall-clock time, ordered by estimated impact.

## Test plan

- [x] `cargo fmt` + `cargo test --no-default-features` pass
- [x] `python -m pytest tests/ -v` — 284 passed, 38 skipped
- [x] `ruff check .` — all checks passed
- [x] PPO smoke test (`--total-timesteps 5000`) completes successfully with AsyncVectorEnv

🤖 Generated with [Claude Code](https://claude.com/claude-code)