### PR TITLE
Fix wandb artifact name containing spaces

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -1335,7 +1335,7 @@ if __name__ == "__main__":
     if runtime > 60 * 5: # 5 minutes
         # avg_throughput = 0 if len(final_throughputs) == 0 else float(sum(final_throughputs) / len(final_throughputs))
         # Save the model to a file
-        run_name_dir_safe = run_name.replace('/', '-').replace(':', '-')
+        run_name_dir_safe = run_name.replace('/', '-').replace(':', '-').replace(' ', '_')
         agent_name = f"agent-{run_name_dir_safe}"
         print(f"Saving model to artifacts/{agent_name}.pt")
         os.makedirs("artifacts", exist_ok=True)


### PR DESCRIPTION
## Summary
- Artifact name crashes when run_name has a space (e.g. `"2026-03-30T16-16-51 seed3"`)
- Adds `.replace(' ', '_')` to sanitize it
- This has been breaking all CI benchmark baselines since March

## Test plan
- [x] One-line fix, verified the pattern in CI logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)