### PR TITLE
Bump sweep agents per pod from 5 to 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ on:
       sweep_agents_per_pod:
         description: "Parallel wandb agents per pod (GPU time-slicing)"
         required: false
-        default: "5"
+        default: "20"
         type: string
 
 permissions:
@@ -580,7 +580,7 @@ jobs:
           SWEEP_URL="${{ steps.create.outputs.sweep_url }}"
           SWEEP_COUNT="${{ inputs.sweep_count || '20' }}"
           SWEEP_PODS="${{ inputs.sweep_agents || '1' }}"
-          AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '5' }}"
+          AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '20' }}"
           TOTAL_AGENTS=$(( SWEEP_PODS * AGENTS_PER_POD ))
           gh pr comment "${{ github.event.pull_request.number }}" --body "$(cat <<EOF
           **W&B Sweep started** — ${SWEEP_COUNT} iterations across ${SWEEP_PODS} pod(s) x ${AGENTS_PER_POD} agents/pod (${TOTAL_AGENTS} total agents)
@@ -593,7 +593,7 @@ jobs:
         id: matrix
         run: |
           NUM_PODS="${{ inputs.sweep_agents || '1' }}"
-          AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '5' }}"
+          AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '20' }}"
           TOTAL_COUNT="${{ inputs.sweep_count || '20' }}"
           TOTAL_AGENTS=$(( NUM_PODS * AGENTS_PER_POD ))
           COUNT_PER=$(( TOTAL_COUNT / TOTAL_AGENTS ))


### PR DESCRIPTION
## Summary
- Increase default parallel sweep agents from 5 to 20 per GPU pod
- Based on W&B system metrics: GPU power usage was ~41% with 10 parallel seeds, memory ~6.5% (~3.2 GB total on 48 GB A6000)
- 20 agents should bring power to ~90% utilization, finishing sweeps ~4x faster

## Test plan
- [ ] Next sweep run will validate — monitor GPU power % in W&B system metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)