### PR TITLE
Dial sweep agents per pod back from 20 to 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ on:
       sweep_agents_per_pod:
         description: "Parallel wandb agents per pod (GPU time-slicing)"
         required: false
-        default: "20"
+        default: "10"
         type: string
 
 permissions:
@@ -580,7 +580,7 @@ jobs:
           SWEEP_URL="${{ steps.create.outputs.sweep_url }}"
           SWEEP_COUNT="${{ inputs.sweep_count || '20' }}"
           SWEEP_PODS="${{ inputs.sweep_agents || '1' }}"
-          AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '20' }}"
+          AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '10' }}"
           TOTAL_AGENTS=$(( SWEEP_PODS * AGENTS_PER_POD ))
           gh pr comment "${{ github.event.pull_request.number }}" --body "$(cat <<EOF
           **W&B Sweep started** — ${SWEEP_COUNT} iterations across ${SWEEP_PODS} pod(s) x ${AGENTS_PER_POD} agents/pod (${TOTAL_AGENTS} total agents)
@@ -593,7 +593,7 @@ jobs:
         id: matrix
         run: |
           NUM_PODS="${{ inputs.sweep_agents || '1' }}"
-          AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '20' }}"
+          AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '10' }}"
           TOTAL_COUNT="${{ inputs.sweep_count || '20' }}"
           TOTAL_AGENTS=$(( NUM_PODS * AGENTS_PER_POD ))
           COUNT_PER=$(( TOTAL_COUNT / TOTAL_AGENTS ))


### PR DESCRIPTION
## Summary
- 20 parallel agents OOMed on system RAM (fork failed with ENOMEM)
- Each ppo.py process uses ~2-3 GB CPU RAM; 20 × 3 GB > pod's ~40 GB
- 10 agents worked reliably in benchmarks

## Test plan
- [x] 10 agents confirmed working in prior benchmark runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)