### PR TITLE
Add splitter entity + 3 new lesson types (INSERTER_TRANSFER, SPLITTER_SPLIT, SPLITTER_MERGE)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__/
 .venv/
 plan.md
 summary.json
+.env

--- a/factorion.py
+++ b/factorion.py
@@ -1792,17 +1792,40 @@ def functions(
                     continue  # connection cells overlap entity positions
 
                 # Path 1: source output → one of the splitter input cells
-                # Block entity positions, but NOT the start/end cells of each path
+                # Block entity positions, but NOT the start/end cells of each path.
+                # Also block the unused input cell AND the cell behind it to
+                # prevent sideloading into the splitter's unused input.
                 blocked_base = all_fixed
-                blocked1 = blocked_base | set(output_cells) | {sink1_input, sink2_input, input_cells[1]}
+                dd = d_delta
+                unused_input_buffer_0 = (input_cells[0][0] - dd[0], input_cells[0][1] - dd[1])
+                unused_input_buffer_1 = (input_cells[1][0] - dd[0], input_cells[1][1] - dd[1])
+
+                blocked1 = blocked_base | set(output_cells) | {sink1_input, sink2_input, input_cells[1], unused_input_buffer_1}
                 path1 = find_belt_path(W, H, source_output, input_cells[0], splitter_dir, blocked1)
                 if path1 is None:
-                    blocked1 = blocked_base | set(output_cells) | {sink1_input, sink2_input, input_cells[0]}
+                    blocked1 = blocked_base | set(output_cells) | {sink1_input, sink2_input, input_cells[0], unused_input_buffer_0}
                     path1 = find_belt_path(W, H, source_output, input_cells[1], splitter_dir, blocked1)
                     if path1 is None:
                         continue
 
+                # Determine which input was used vs unused
+                path1_end = path1[-1][:2]
+                if path1_end == input_cells[0]:
+                    unused_input = input_cells[1]
+                    unused_buffer = unused_input_buffer_1
+                else:
+                    unused_input = input_cells[0]
+                    unused_buffer = unused_input_buffer_0
+
                 path1_cells = {(x, y) for x, y, _ in path1}
+
+                # Block unused input + buffer, plus the cells ahead of each sink
+                # (where the sink would output to) to prevent pass-through
+                # double-counting where one output path routes through a sink.
+                unused_block = {unused_input, unused_buffer}
+                sink1_output = (sink1_pos[0] + dk1[0], sink1_pos[1] + dk1[1])
+                sink2_output = (sink2_pos[0] + dk2[0], sink2_pos[1] + dk2[1])
+                sink_buffers = {sink1_output, sink2_output}
 
                 # Path 2+3: splitter outputs → sink inputs
                 # Try both assignments: (out0→sink1, out1→sink2) and (out0→sink2, out1→sink1)
@@ -1812,12 +1835,12 @@ def functions(
                     (output_cells[0], output_cells[1], sink1_input, sink1_dir, sink2_input, sink2_dir),
                     (output_cells[0], output_cells[1], sink2_input, sink2_dir, sink1_input, sink1_dir),
                 ]:
-                    blocked2 = blocked_base | path1_cells | {sk_b, out_b} | set(input_cells)
+                    blocked2 = blocked_base | path1_cells | {sk_b, out_b} | set(input_cells) | unused_block | sink_buffers
                     p2 = find_belt_path(W, H, out_a, sk_a, sk_a_dir, blocked2)
                     if p2 is None:
                         continue
                     p2_cells = {(x, y) for x, y, _ in p2}
-                    blocked3 = blocked_base | path1_cells | p2_cells | {out_a} | set(input_cells)
+                    blocked3 = blocked_base | path1_cells | p2_cells | {out_a} | set(input_cells) | unused_block | sink_buffers
                     p3 = find_belt_path(W, H, out_b, sk_b, sk_b_dir, blocked3)
                     if p3 is not None:
                         path2, path3 = p2, p3
@@ -1967,11 +1990,17 @@ def functions(
 
                 path2_cells = {(x, y) for x, y, _ in path2}
 
-                # Path 3: splitter output → sink input (try both output cells)
-                blocked3 = blocked_base | path1_cells | path2_cells | set(input_cells) | {output_cells[1]}
+                # Path 3: splitter output → sink input (try both output cells).
+                # Block the unused output cell AND the cell ahead of it to
+                # prevent sideloading from the output path into the unused output.
+                dd = d_delta
+                unused_output_buffer_0 = (output_cells[0][0] + dd[0], output_cells[0][1] + dd[1])
+                unused_output_buffer_1 = (output_cells[1][0] + dd[0], output_cells[1][1] + dd[1])
+
+                blocked3 = blocked_base | path1_cells | path2_cells | set(input_cells) | {output_cells[1], unused_output_buffer_1}
                 path3 = find_belt_path(W, H, output_cells[0], sink_input, sink_dir, blocked3)
                 if path3 is None:
-                    blocked3 = blocked_base | path1_cells | path2_cells | set(input_cells) | {output_cells[0]}
+                    blocked3 = blocked_base | path1_cells | path2_cells | set(input_cells) | {output_cells[0], unused_output_buffer_0}
                     path3 = find_belt_path(W, H, output_cells[1], sink_input, sink_dir, blocked3)
                     if path3 is None:
                         continue

--- a/factorion.py
+++ b/factorion.py
@@ -154,7 +154,7 @@ def datatypes(Enum, dataclass, mo):
             name="stack_inserter", value=6, width=1, height=1, flow=float("inf")
         ),
         # splitter: 2 tiles wide perpendicular to flow, 1 tile deep
-        # flow = 2 lanes × 15 i/s per lane = 30 i/s total
+        # 2 input belts × 2 lanes × 7.5 i/s per lane = 30 i/s total
         7: Entity(name="splitter", value=7, width=2, height=1, flow=30.0),
         #     4:  Entity(name='copper_cable',          value=4,  width=1, height=1, flow=0.0),
         #     6:  Entity(name='copper_plate',          value=6,  width=1, height=1, flow=0.0),
@@ -190,13 +190,9 @@ def datatypes(Enum, dataclass, mo):
     class LessonKind(Enum):
         MOVE_ONE_ITEM = 0
         ALL_BELTS_ALREADY_IN_PLACE = 1
-        MOVE_TWO_ITEMS_NO_UNDERGROUND = 2
-        MOVE_TWO_ITEMS_WITH_UNDERGROUND = 2
-        CREATE_COPPER_WIRE = 3
-        CREATE_ELECTRONIC_CIRCUIT = 4
-        INSERTER_TRANSFER = 5
-        SPLITTER_SPLIT = 6
-        SPLITTER_MERGE = 7
+        INSERTER_TRANSFER = 2
+        SPLITTER_SPLIT = 3
+        SPLITTER_MERGE = 4
 
 
     # Map Enum <--> grid deltas
@@ -380,34 +376,38 @@ def functions(
         }
         html = ["<table style='border-collapse: collapse;'>"]
         W, H, C = world_WHC.shape
-        display_asm_ghost = 0
-        ghosts = []
+        # Pre-compute which cells are secondary tiles of multi-tile entities,
+        # mapping (x, y) → anchor entity name for ghost rendering
+        ghost_at = {}
+        visited_tiles = set()
+        for y in range(H):
+            for x in range(W):
+                if (x, y) in visited_tiles:
+                    continue
+                proto = entities[world_WHC[x, y, Channel.ENTITIES.value]]
+                if proto.width == 1 and proto.height == 1:
+                    continue
+                d_val = world_WHC[x, y, Channel.DIRECTION.value]
+                tile_list = factorion_rs.py_entity_tiles(x, y, int(d_val), proto.width, proto.height)
+                if tile_list is None:
+                    continue
+                anchor = tuple(tile_list[0])
+                for tx, ty in tile_list:
+                    visited_tiles.add((tx, ty))
+                    if (tx, ty) != anchor:
+                        ghost_at[(tx, ty)] = proto.name
+
         for y in range(H):
             html.append("<tr>")
             for x in range(W):
                 proto = entities[world_WHC[x, y, Channel.ENTITIES.value]]
-                if proto.width != 1 or proto.height != 1:
-                    ghosts.append(
-                        {
-                            "x_lo": x,
-                            "y_lo": y,
-                            "x_hi": x + proto.width,
-                            "y_hi": y + proto.height,
-                            "name": proto.name,
-                        }
-                    )
                 item = items[world_WHC[x, y, Channel.ITEMS.value]]
                 direction = world_WHC[x, y, Channel.DIRECTION.value]
-                #             entity, direction, recipe = get_entity_info(world_WHC, x, y)
                 entity_icon = ent_str2b64img(proto.name)
 
                 ghost_icons = []
-                for ghost in ghosts:
-                    if (
-                        ghost["x_lo"] <= x < ghost["x_hi"]
-                        and ghost["y_lo"] <= y < ghost["y_hi"]
-                    ):
-                        ghost_icons.append(ent_str2b64img(ghost["name"]))
+                if (x, y) in ghost_at:
+                    ghost_icons.append(ent_str2b64img(ghost_at[(x, y)]))
 
                 item_icon = item_str2b64img(item.name)
                 direction_arrow = DIRECTION_ARROWS.get(direction, "")
@@ -1357,19 +1357,17 @@ def functions(
                     if tiles is None:
                         continue
 
+                    dx, dy = DIR_TO_DELTA.get(d, (0, 0))
+                    opposite_dir = {
+                        Direction.NORTH: Direction.SOUTH,
+                        Direction.SOUTH: Direction.NORTH,
+                        Direction.EAST: Direction.WEST,
+                        Direction.WEST: Direction.EAST,
+                    }.get(d, Direction.NONE)
+
                     for tx, ty in tiles:
                         # Input: cell behind this tile
-                        if d == Direction.EAST:
-                            in_cell = (tx - 1, ty)
-                        elif d == Direction.WEST:
-                            in_cell = (tx + 1, ty)
-                        elif d == Direction.NORTH:
-                            in_cell = (tx, ty + 1)
-                        elif d == Direction.SOUTH:
-                            in_cell = (tx, ty - 1)
-                        else:
-                            continue
-
+                        in_cell = (tx - dx, ty - dy)
                         if (
                             0 <= in_cell[0] < W
                             and 0 <= in_cell[1] < H
@@ -1394,17 +1392,7 @@ def functions(
                                 ))
 
                         # Output: cell ahead of this tile
-                        if d == Direction.EAST:
-                            out_cell = (tx + 1, ty)
-                        elif d == Direction.WEST:
-                            out_cell = (tx - 1, ty)
-                        elif d == Direction.NORTH:
-                            out_cell = (tx, ty - 1)
-                        elif d == Direction.SOUTH:
-                            out_cell = (tx, ty + 1)
-                        else:
-                            continue
-
+                        out_cell = (tx + dx, ty + dy)
                         if (
                             0 <= out_cell[0] < W
                             and 0 <= out_cell[1] < H
@@ -1426,13 +1414,7 @@ def functions(
                             out_is_sink = out_ent.name in (
                                 "stack_inserter", "bulk_inserter"
                             )
-                            out_not_opposing = out_dir != {
-                                Direction.NORTH: Direction.SOUTH,
-                                Direction.SOUTH: Direction.NORTH,
-                                Direction.EAST: Direction.WEST,
-                                Direction.WEST: Direction.EAST,
-                            }.get(d, Direction.NONE)
-                            if (out_is_belt or out_is_sink) and out_not_opposing:
+                            if (out_is_belt or out_is_sink) and out_dir != opposite_dir:
                                 pending_edges.append((
                                     self_name,
                                     f"{out_ent.name}\n@{out_cell[0]},{out_cell[1]}",
@@ -1446,6 +1428,74 @@ def functions(
             G.add_edge(remap_node_name(src), remap_node_name(dst))
 
         return G
+
+
+    def _remove_entities(world_CWH, num_missing_entities, total_entities):
+        """Remove entities from a completed lesson, respecting multi-tile units.
+
+        Returns min_entities_required (number of entity units removed).
+        For multi-tile entities (e.g. splitters), all tiles are removed together
+        as a single unit.
+        """
+        if num_missing_entities == float("inf"):
+            return total_entities
+
+        C, W, H = world_CWH.shape
+        skip = {str2ent("source").value, str2ent("sink").value, str2ent("empty").value}
+
+        # Pass 1: identify which cells are secondary tiles of multi-tile entities.
+        # Map secondary → anchor so we skip them in pass 2.
+        secondary_tiles = set()
+        for x in range(W):
+            for y in range(H):
+                if (x, y) in secondary_tiles:
+                    continue
+                ent_val = world_CWH[Channel.ENTITIES.value, x, y].item()
+                if ent_val in skip:
+                    continue
+                ent = entities[ent_val]
+                if ent.width == 1 and ent.height == 1:
+                    continue
+                d_val = world_CWH[Channel.DIRECTION.value, x, y].item()
+                tiles_list = factorion_rs.py_entity_tiles(x, y, d_val, ent.width, ent.height)
+                if tiles_list is not None:
+                    for tx, ty in tiles_list:
+                        if (tx, ty) != (x, y):
+                            secondary_tiles.add((tx, ty))
+
+        # Pass 2: build entity groups from anchors only
+        entity_groups = []
+        for x in range(W):
+            for y in range(H):
+                if (x, y) in secondary_tiles:
+                    continue
+                ent_val = world_CWH[Channel.ENTITIES.value, x, y].item()
+                if ent_val in skip:
+                    continue
+                ent = entities[ent_val]
+                if ent.width == 1 and ent.height == 1:
+                    entity_groups.append({(x, y)})
+                else:
+                    d_val = world_CWH[Channel.DIRECTION.value, x, y].item()
+                    tiles_list = factorion_rs.py_entity_tiles(x, y, d_val, ent.width, ent.height)
+                    if tiles_list is None:
+                        entity_groups.append({(x, y)})
+                    else:
+                        entity_groups.append(set(map(tuple, tiles_list)))
+
+        num_samples = min(num_missing_entities, len(entity_groups))
+        if num_samples == 0:
+            return 0
+
+        sampled_groups = random.sample(entity_groups, num_samples)
+        for group in sampled_groups:
+            for x, y in group:
+                world_CWH[Channel.ENTITIES.value, x, y] = str2ent("empty").value
+                world_CWH[Channel.DIRECTION.value, x, y] = Direction.NONE.value
+                world_CWH[Channel.ITEMS.value, x, y] = str2item("empty").value
+                world_CWH[Channel.MISC.value, x, y] = Misc.NONE.value
+
+        return num_samples
 
 
     def generate_lesson(
@@ -1547,49 +1597,422 @@ def functions(
                     else:
                         min_entities_required = min([len(p) for p in paths])
 
-                # Randomly remove some number of transport belts from the map
-
-                if num_missing_entities != float("inf"):
-                    entity_locs = (
-                        (
-                            world_CWH[Channel.ENTITIES.value]
-                            != str2ent("source").value
-                        )
-                        & (
-                            world_CWH[Channel.ENTITIES.value]
-                            != str2ent("sink").value
-                        )
-                        & (
-                            world_CWH[Channel.ENTITIES.value]
-                            != str2ent("empty").value
-                        )
-                    ).nonzero(as_tuple=False)
-                    num_samples = min(num_missing_entities, len(entity_locs))
-                    samples = (
-                        []
-                        if num_samples == 0
-                        else random.sample(list(entity_locs), num_samples)
-                    )
-                    min_entities_required = num_samples
-                    # print(f"Removing {num_samples} entities")
-                    # if num_samples != 0:
-                    #     breakpoint()
-                    for x, y in samples:
-                        # print(f"  Removing entity from {x},{y}, num_samples: {num_samples}")
-                        world_CWH[Channel.ENTITIES.value, x, y] = str2ent(
-                            "empty"
-                        ).value
-                        world_CWH[Channel.DIRECTION.value, x, y] = (
-                            Direction.NONE.value
-                        )
-                        world_CWH[Channel.ITEMS.value, x, y] = str2item(
-                            "empty"
-                        ).value
-                        world_CWH[Channel.MISC.value, x, y] = Misc.NONE.value
+                min_entities_required = _remove_entities(
+                    world_CWH, num_missing_entities, min_entities_required
+                )
                 break
             if count == 0:
                 raise Exception(
                     f"Failed to find valid lesson after {original_count} attempts"
+                )
+        elif kind.value == LessonKind.INSERTER_TRANSFER.value:
+            # Source → belts → inserter → belts → sink
+            original_count = max(500, size * size * 8)
+            count = original_count
+
+            if random_item:
+                item_value = random.choice([v.value for k, v in items.items()])
+            else:
+                item_value = str2item("electronic_circuit").value
+
+            while count > 0:
+                count -= 1
+                world_CWH = torch.tensor(new_world(width=size, height=size)).permute(2, 0, 1)
+                C, W, H = world_CWH.shape
+
+                # Pick 3 distinct random positions
+                positions = random.sample(range(W * H), 3)
+                source_pos = divmod(positions[0], W)
+                sink_pos = divmod(positions[1], W)
+                inserter_pos = divmod(positions[2], W)
+
+                dirs = [d for d in Direction if d != Direction.NONE]
+                source_dir = random.choice(dirs)
+                sink_dir = random.choice(dirs)
+                inserter_dir = random.choice(dirs)
+
+                # Compute connection cells
+                ds = DIR_TO_DELTA[source_dir]
+                dk = DIR_TO_DELTA[sink_dir]
+                di = DIR_TO_DELTA[inserter_dir]
+
+                source_output = (source_pos[0] + ds[0], source_pos[1] + ds[1])
+                sink_input = (sink_pos[0] - dk[0], sink_pos[1] - dk[1])
+                inserter_pickup = (inserter_pos[0] - di[0], inserter_pos[1] - di[1])
+                inserter_drop = (inserter_pos[0] + di[0], inserter_pos[1] + di[1])
+
+                # All key cells must be in bounds and distinct
+                key_cells = [source_pos, sink_pos, inserter_pos,
+                             source_output, sink_input, inserter_pickup, inserter_drop]
+                if any(not (0 <= r < W and 0 <= c < H) for r, c in key_cells):
+                    continue
+                if len(set(key_cells)) != len(key_cells):
+                    continue
+
+                # Fixed cells that belts cannot occupy
+                fixed = {source_pos, sink_pos, inserter_pos}
+
+                # Path 1: source output → inserter pickup cell
+                blocked1 = fixed | {inserter_drop, sink_input}
+                path1 = find_belt_path(W, H, source_output, inserter_pickup, inserter_dir, blocked1)
+                if path1 is None:
+                    continue
+
+                # Path 2: inserter drop → sink input cell
+                path1_cells = {(x, y) for x, y, _ in path1}
+                blocked2 = fixed | {inserter_pickup} | path1_cells
+                path2 = find_belt_path(W, H, inserter_drop, sink_input, sink_dir, blocked2)
+                if path2 is None:
+                    continue
+
+                # Enforce max_entities constraint
+                total_entities = len(path1) + len(path2) + 1  # +1 for the inserter
+                if total_entities > max_entities:
+                    continue
+
+                # Place source and sink
+                world_CWH[Channel.ENTITIES.value, source_pos[0], source_pos[1]] = str2ent("source").value
+                world_CWH[Channel.DIRECTION.value, source_pos[0], source_pos[1]] = source_dir.value
+                world_CWH[Channel.ITEMS.value, source_pos[0], source_pos[1]] = item_value
+
+                world_CWH[Channel.ENTITIES.value, sink_pos[0], sink_pos[1]] = str2ent("sink").value
+                world_CWH[Channel.DIRECTION.value, sink_pos[0], sink_pos[1]] = sink_dir.value
+                world_CWH[Channel.ITEMS.value, sink_pos[0], sink_pos[1]] = item_value
+
+                # Place inserter
+                world_CWH[Channel.ENTITIES.value, inserter_pos[0], inserter_pos[1]] = str2ent("inserter").value
+                world_CWH[Channel.DIRECTION.value, inserter_pos[0], inserter_pos[1]] = inserter_dir.value
+
+                # Place belt paths
+                for x, y, d in path1 + path2:
+                    world_CWH[Channel.ENTITIES.value, x, y] = str2ent("transport_belt").value
+                    world_CWH[Channel.DIRECTION.value, x, y] = d.value
+
+                # Verify throughput > 0
+                tp, _ = funge_throughput(world_CWH.permute(1, 2, 0))
+                if tp <= 0:
+                    continue
+
+                min_entities_required = _remove_entities(
+                    world_CWH, num_missing_entities, total_entities
+                )
+
+                break
+            if count == 0:
+                raise Exception(
+                    f"Failed to find valid INSERTER_TRANSFER lesson after {original_count} attempts"
+                )
+
+        elif kind.value == LessonKind.SPLITTER_SPLIT.value:
+            # 1 source → belts → splitter → 2x(belts → sink)
+            original_count = max(500, size * size * 10)
+            count = original_count
+
+            if random_item:
+                item_value = random.choice([v.value for k, v in items.items()])
+            else:
+                item_value = str2item("electronic_circuit").value
+
+            splitter_ent = str2ent("splitter")
+
+            while count > 0:
+                count -= 1
+                world_CWH = torch.tensor(new_world(width=size, height=size)).permute(2, 0, 1)
+                C, W, H = world_CWH.shape
+
+                dirs = [d for d in Direction if d != Direction.NONE]
+                splitter_dir = random.choice(dirs)
+
+                # Pick splitter anchor position; both tiles must fit
+                tiles = None
+                for _ in range(20):
+                    sx = random.randint(0, W - 1)
+                    sy = random.randint(0, H - 1)
+                    tiles = factorion_rs.py_entity_tiles(sx, sy, splitter_dir.value, splitter_ent.width, splitter_ent.height)
+                    if tiles is not None and all(0 <= tx < W and 0 <= ty < H for tx, ty in tiles):
+                        break
+                    tiles = None
+                if tiles is None:
+                    continue
+
+                tile_set = set(map(tuple, tiles))
+                d_delta = DIR_TO_DELTA[splitter_dir]
+
+                # Compute input/output cells for each splitter tile
+                input_cells = []
+                output_cells = []
+                for tx, ty in tiles:
+                    inp = (tx - d_delta[0], ty - d_delta[1])
+                    out = (tx + d_delta[0], ty + d_delta[1])
+                    input_cells.append(inp)
+                    output_cells.append(out)
+
+                # All input/output cells must be in bounds and not overlap splitter tiles
+                all_io = input_cells + output_cells
+                if any(not (0 <= r < W and 0 <= c < H) for r, c in all_io):
+                    continue
+                if any(c in tile_set for c in all_io):
+                    continue
+
+                # Pick 1 source and 2 sinks at random positions (avoiding splitter tiles and I/O cells)
+                reserved = tile_set | set(all_io)
+                available = [(x, y) for x in range(W) for y in range(H) if (x, y) not in reserved]
+                if len(available) < 3:
+                    continue
+
+                chosen = random.sample(available, 3)
+                source_pos = chosen[0]
+                sink1_pos = chosen[1]
+                sink2_pos = chosen[2]
+
+                source_dir = random.choice(dirs)
+                sink1_dir = random.choice(dirs)
+                sink2_dir = random.choice(dirs)
+
+                # Compute connection cells for source and sinks
+                ds = DIR_TO_DELTA[source_dir]
+                dk1 = DIR_TO_DELTA[sink1_dir]
+                dk2 = DIR_TO_DELTA[sink2_dir]
+
+                source_output = (source_pos[0] + ds[0], source_pos[1] + ds[1])
+                sink1_input = (sink1_pos[0] - dk1[0], sink1_pos[1] - dk1[1])
+                sink2_input = (sink2_pos[0] - dk2[0], sink2_pos[1] - dk2[1])
+
+                # All connection cells must be in bounds
+                conn_cells = [source_output, sink1_input, sink2_input]
+                if any(not (0 <= r < W and 0 <= c < H) for r, c in conn_cells):
+                    continue
+
+                # Connection cells must not overlap entity positions or each other
+                all_fixed = tile_set | {source_pos, sink1_pos, sink2_pos}
+                conn_set = set(conn_cells)
+                if len(conn_set) != len(conn_cells):
+                    continue  # connection cells overlap each other
+                if conn_set & all_fixed:
+                    continue  # connection cells overlap entity positions
+
+                # Path 1: source output → one of the splitter input cells
+                # Block entity positions, but NOT the start/end cells of each path
+                blocked_base = all_fixed
+                blocked1 = blocked_base | set(output_cells) | {sink1_input, sink2_input, input_cells[1]}
+                path1 = find_belt_path(W, H, source_output, input_cells[0], splitter_dir, blocked1)
+                if path1 is None:
+                    blocked1 = blocked_base | set(output_cells) | {sink1_input, sink2_input, input_cells[0]}
+                    path1 = find_belt_path(W, H, source_output, input_cells[1], splitter_dir, blocked1)
+                    if path1 is None:
+                        continue
+
+                path1_cells = {(x, y) for x, y, _ in path1}
+
+                # Path 2+3: splitter outputs → sink inputs
+                # Try both assignments: (out0→sink1, out1→sink2) and (out0→sink2, out1→sink1)
+                path2 = None
+                path3 = None
+                for out_a, out_b, sk_a, sk_a_dir, sk_b, sk_b_dir in [
+                    (output_cells[0], output_cells[1], sink1_input, sink1_dir, sink2_input, sink2_dir),
+                    (output_cells[0], output_cells[1], sink2_input, sink2_dir, sink1_input, sink1_dir),
+                ]:
+                    blocked2 = blocked_base | path1_cells | {sk_b, out_b} | set(input_cells)
+                    p2 = find_belt_path(W, H, out_a, sk_a, sk_a_dir, blocked2)
+                    if p2 is None:
+                        continue
+                    p2_cells = {(x, y) for x, y, _ in p2}
+                    blocked3 = blocked_base | path1_cells | p2_cells | {out_a} | set(input_cells)
+                    p3 = find_belt_path(W, H, out_b, sk_b, sk_b_dir, blocked3)
+                    if p3 is not None:
+                        path2, path3 = p2, p3
+                        break
+                if path2 is None or path3 is None:
+                    continue
+
+                path2_cells = {(x, y) for x, y, _ in path2}
+
+                # Enforce max_entities
+                total_entities = len(path1) + len(path2) + len(path3) + 1  # +1 for splitter (2 tiles but 1 entity)
+                if total_entities > max_entities:
+                    continue
+
+                # Place source and sinks
+                world_CWH[Channel.ENTITIES.value, source_pos[0], source_pos[1]] = str2ent("source").value
+                world_CWH[Channel.DIRECTION.value, source_pos[0], source_pos[1]] = source_dir.value
+                world_CWH[Channel.ITEMS.value, source_pos[0], source_pos[1]] = item_value
+
+                for sink_pos, sink_dir in [(sink1_pos, sink1_dir), (sink2_pos, sink2_dir)]:
+                    world_CWH[Channel.ENTITIES.value, sink_pos[0], sink_pos[1]] = str2ent("sink").value
+                    world_CWH[Channel.DIRECTION.value, sink_pos[0], sink_pos[1]] = sink_dir.value
+                    world_CWH[Channel.ITEMS.value, sink_pos[0], sink_pos[1]] = item_value
+
+                # Place splitter (all tiles)
+                for tx, ty in tiles:
+                    world_CWH[Channel.ENTITIES.value, tx, ty] = splitter_ent.value
+                    world_CWH[Channel.DIRECTION.value, tx, ty] = splitter_dir.value
+
+                # Place belt paths
+                for x, y, d in path1 + path2 + path3:
+                    world_CWH[Channel.ENTITIES.value, x, y] = str2ent("transport_belt").value
+                    world_CWH[Channel.DIRECTION.value, x, y] = d.value
+
+                # Verify throughput > 0
+                tp, _ = funge_throughput(world_CWH.permute(1, 2, 0))
+                if tp <= 0:
+                    continue
+
+                min_entities_required = _remove_entities(
+                    world_CWH, num_missing_entities, total_entities
+                )
+
+                break
+            if count == 0:
+                raise Exception(
+                    f"Failed to find valid SPLITTER_SPLIT lesson after {original_count} attempts"
+                )
+
+        elif kind.value == LessonKind.SPLITTER_MERGE.value:
+            # 2x(source → belts) → splitter → belts → 1 sink
+            original_count = max(500, size * size * 10)
+            count = original_count
+
+            if random_item:
+                item_value = random.choice([v.value for k, v in items.items()])
+            else:
+                item_value = str2item("electronic_circuit").value
+
+            splitter_ent = str2ent("splitter")
+
+            while count > 0:
+                count -= 1
+                world_CWH = torch.tensor(new_world(width=size, height=size)).permute(2, 0, 1)
+                C, W, H = world_CWH.shape
+
+                dirs = [d for d in Direction if d != Direction.NONE]
+                splitter_dir = random.choice(dirs)
+
+                # Pick splitter anchor; both tiles must fit
+                tiles = None
+                for _ in range(20):
+                    sx = random.randint(0, W - 1)
+                    sy = random.randint(0, H - 1)
+                    tiles = factorion_rs.py_entity_tiles(sx, sy, splitter_dir.value, splitter_ent.width, splitter_ent.height)
+                    if tiles is not None and all(0 <= tx < W and 0 <= ty < H for tx, ty in tiles):
+                        break
+                    tiles = None
+                if tiles is None:
+                    continue
+
+                tile_set = set(map(tuple, tiles))
+                d_delta = DIR_TO_DELTA[splitter_dir]
+
+                input_cells = [(tx - d_delta[0], ty - d_delta[1]) for tx, ty in tiles]
+                output_cells = [(tx + d_delta[0], ty + d_delta[1]) for tx, ty in tiles]
+
+                all_io = input_cells + output_cells
+                if any(not (0 <= r < W and 0 <= c < H) for r, c in all_io):
+                    continue
+                if any(c in tile_set for c in all_io):
+                    continue
+
+                # Pick 2 sources and 1 sink
+                reserved = tile_set | set(all_io)
+                available = [(x, y) for x in range(W) for y in range(H) if (x, y) not in reserved]
+                if len(available) < 3:
+                    continue
+
+                chosen = random.sample(available, 3)
+                source1_pos = chosen[0]
+                source2_pos = chosen[1]
+                sink_pos = chosen[2]
+
+                source1_dir = random.choice(dirs)
+                source2_dir = random.choice(dirs)
+                sink_dir = random.choice(dirs)
+
+                ds1 = DIR_TO_DELTA[source1_dir]
+                ds2 = DIR_TO_DELTA[source2_dir]
+                dk = DIR_TO_DELTA[sink_dir]
+
+                source1_output = (source1_pos[0] + ds1[0], source1_pos[1] + ds1[1])
+                source2_output = (source2_pos[0] + ds2[0], source2_pos[1] + ds2[1])
+                sink_input = (sink_pos[0] - dk[0], sink_pos[1] - dk[1])
+
+                conn_cells = [source1_output, source2_output, sink_input]
+                if any(not (0 <= r < W and 0 <= c < H) for r, c in conn_cells):
+                    continue
+
+                all_fixed = tile_set | {source1_pos, source2_pos, sink_pos}
+                conn_set = set(conn_cells)
+                if len(conn_set) != len(conn_cells):
+                    continue
+                if conn_set & all_fixed:
+                    continue
+
+                # Path 1: source1 output → splitter input 0
+                blocked_base = all_fixed
+                blocked1 = blocked_base | set(output_cells) | {source2_output, sink_input, input_cells[1]}
+                path1 = find_belt_path(W, H, source1_output, input_cells[0], splitter_dir, blocked1)
+                if path1 is None:
+                    blocked1 = blocked_base | set(output_cells) | {source2_output, sink_input, input_cells[0]}
+                    path1 = find_belt_path(W, H, source1_output, input_cells[1], splitter_dir, blocked1)
+                    if path1 is None:
+                        continue
+
+                path1_cells = {(x, y) for x, y, _ in path1}
+                path1_end = path1[-1][:2]
+                remaining_input = input_cells[1] if path1_end == input_cells[0] else input_cells[0]
+
+                # Path 2: source2 output → remaining splitter input
+                blocked2 = blocked_base | set(output_cells) | path1_cells | {sink_input}
+                path2 = find_belt_path(W, H, source2_output, remaining_input, splitter_dir, blocked2)
+                if path2 is None:
+                    continue
+
+                path2_cells = {(x, y) for x, y, _ in path2}
+
+                # Path 3: splitter output → sink input (try both output cells)
+                blocked3 = blocked_base | path1_cells | path2_cells | set(input_cells) | {output_cells[1]}
+                path3 = find_belt_path(W, H, output_cells[0], sink_input, sink_dir, blocked3)
+                if path3 is None:
+                    blocked3 = blocked_base | path1_cells | path2_cells | set(input_cells) | {output_cells[0]}
+                    path3 = find_belt_path(W, H, output_cells[1], sink_input, sink_dir, blocked3)
+                    if path3 is None:
+                        continue
+
+                total_entities = len(path1) + len(path2) + len(path3) + 1
+                if total_entities > max_entities:
+                    continue
+
+                # Place sources and sink
+                for src_pos, src_dir in [(source1_pos, source1_dir), (source2_pos, source2_dir)]:
+                    world_CWH[Channel.ENTITIES.value, src_pos[0], src_pos[1]] = str2ent("source").value
+                    world_CWH[Channel.DIRECTION.value, src_pos[0], src_pos[1]] = src_dir.value
+                    world_CWH[Channel.ITEMS.value, src_pos[0], src_pos[1]] = item_value
+
+                world_CWH[Channel.ENTITIES.value, sink_pos[0], sink_pos[1]] = str2ent("sink").value
+                world_CWH[Channel.DIRECTION.value, sink_pos[0], sink_pos[1]] = sink_dir.value
+                world_CWH[Channel.ITEMS.value, sink_pos[0], sink_pos[1]] = item_value
+
+                # Place splitter
+                for tx, ty in tiles:
+                    world_CWH[Channel.ENTITIES.value, tx, ty] = splitter_ent.value
+                    world_CWH[Channel.DIRECTION.value, tx, ty] = splitter_dir.value
+
+                # Place belt paths
+                for x, y, d in path1 + path2 + path3:
+                    world_CWH[Channel.ENTITIES.value, x, y] = str2ent("transport_belt").value
+                    world_CWH[Channel.DIRECTION.value, x, y] = d.value
+
+                # Verify throughput > 0
+                tp, _ = funge_throughput(world_CWH.permute(1, 2, 0))
+                if tp <= 0:
+                    continue
+
+                min_entities_required = _remove_entities(
+                    world_CWH, num_missing_entities, total_entities
+                )
+
+                break
+            if count == 0:
+                raise Exception(
+                    f"Failed to find valid SPLITTER_MERGE lesson after {original_count} attempts"
                 )
         else:
             raise Exception(f"Can't handle {kind}")

--- a/factorion.py
+++ b/factorion.py
@@ -1796,9 +1796,8 @@ def functions(
                 # Also block the unused input cell AND the cell behind it to
                 # prevent sideloading into the splitter's unused input.
                 blocked_base = all_fixed
-                dd = d_delta
-                unused_input_buffer_0 = (input_cells[0][0] - dd[0], input_cells[0][1] - dd[1])
-                unused_input_buffer_1 = (input_cells[1][0] - dd[0], input_cells[1][1] - dd[1])
+                unused_input_buffer_0 = (input_cells[0][0] - d_delta[0], input_cells[0][1] - d_delta[1])
+                unused_input_buffer_1 = (input_cells[1][0] - d_delta[0], input_cells[1][1] - d_delta[1])
 
                 blocked1 = blocked_base | set(output_cells) | {sink1_input, sink2_input, input_cells[1], unused_input_buffer_1}
                 path1 = find_belt_path(W, H, source_output, input_cells[0], splitter_dir, blocked1)
@@ -1993,9 +1992,8 @@ def functions(
                 # Path 3: splitter output → sink input (try both output cells).
                 # Block the unused output cell AND the cell ahead of it to
                 # prevent sideloading from the output path into the unused output.
-                dd = d_delta
-                unused_output_buffer_0 = (output_cells[0][0] + dd[0], output_cells[0][1] + dd[1])
-                unused_output_buffer_1 = (output_cells[1][0] + dd[0], output_cells[1][1] + dd[1])
+                unused_output_buffer_0 = (output_cells[0][0] + d_delta[0], output_cells[0][1] + d_delta[1])
+                unused_output_buffer_1 = (output_cells[1][0] + d_delta[0], output_cells[1][1] + d_delta[1])
 
                 blocked3 = blocked_base | path1_cells | path2_cells | set(input_cells) | {output_cells[1], unused_output_buffer_1}
                 path3 = find_belt_path(W, H, output_cells[0], sink_input, sink_dir, blocked3)

--- a/ppo.py
+++ b/ppo.py
@@ -267,6 +267,9 @@ class FactorioEnv(gym.Env):
             "item": gym.spaces.Discrete(len(self.items)),
             "misc": gym.spaces.Discrete(len(self.Misc))
         })
+        # Cache source/sink IDs (non-placeable prototypes)
+        self._source_id = self.str2ent('stack_inserter').value
+        self._sink_id = self.str2ent('bulk_inserter').value
         self._reset_options = options if options is not None else {}
 
         self.steps = 0
@@ -360,9 +363,8 @@ class FactorioEnv(gym.Env):
         # (x, y), entity_id, direc = action
         assert 0 <= x < self._world_CWH.shape[1], f"x={x} out of bounds [0, {self._world_CWH.shape[1]})"
         assert 0 <= y < self._world_CWH.shape[2], f"y={y} out of bounds [0, {self._world_CWH.shape[2]})"
-        # non-placeable prototypes: source and sink
-        source_id = self.str2ent('stack_inserter').value
-        sink_id = self.str2ent('bulk_inserter').value
+        source_id = self._source_id
+        sink_id = self._sink_id
 
         # Mutate the world with the agent's actions
         entity_to_be_replaced = self._world_CWH[self.Channel.ENTITIES.value, x, y]
@@ -471,8 +473,7 @@ class FactorioEnv(gym.Env):
         frac_hallucin = 0
 
         # Give some small reward for having the belt be the right direction
-        sink_id = self.str2ent('bulk_inserter').value
-        sink_locs = torch.where(self._world_CWH[self.Channel.ENTITIES.value] == sink_id)
+        sink_locs = torch.where(self._world_CWH[self.Channel.ENTITIES.value] == self._sink_id)
         assert len(sink_locs[0]) == len(sink_locs[1]) == 1, f"Expected 1 bulk inserter, found {sink_locs} in world {self._world_CWH}"
         C, W, H = self._world_CWH.shape
         w_sink, h_sink = sink_locs[0][0], sink_locs[1][0]

--- a/scripts/spot_check.py
+++ b/scripts/spot_check.py
@@ -1,0 +1,207 @@
+"""Spot-check script for verifying lesson generation.
+
+Generates complete factories for each scenario type, verifies throughput,
+renders to HTML, and prints summary statistics.
+
+Usage:
+    uv run python scripts/spot_check.py --scenario all --count 10 --size 8
+    uv run python scripts/spot_check.py --scenario splitter_split --count 5 --size 12 --output-dir /tmp/factories
+"""
+
+import os
+import sys
+import dataclasses
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import tyro
+
+# Ensure factorion is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+os.environ["WANDB_MODE"] = "disabled"
+os.environ["WANDB_DISABLED"] = "true"
+
+import factorion  # noqa: E402
+import factorion_rs  # noqa: E402
+
+_, _objs = factorion.datatypes.run()
+_, _fns = factorion.functions.run()
+
+LessonKind = _objs["LessonKind"]
+generate_lesson = _fns["generate_lesson"]
+world2html = _fns["world2html"]
+str2ent = _fns["str2ent"]
+
+
+class Scenario(Enum):
+    belt = "belt"
+    inserter = "inserter"
+    splitter_split = "splitter_split"
+    splitter_merge = "splitter_merge"
+    all = "all"
+
+
+SCENARIO_TO_KIND = {
+    Scenario.belt: LessonKind.MOVE_ONE_ITEM,
+    Scenario.inserter: LessonKind.INSERTER_TRANSFER,
+    Scenario.splitter_split: LessonKind.SPLITTER_SPLIT,
+    Scenario.splitter_merge: LessonKind.SPLITTER_MERGE,
+}
+
+
+@dataclasses.dataclass
+class Args:
+    scenario: Scenario = Scenario.all
+    """Which scenario to generate."""
+    count: int = 10
+    """Number of factories to generate per scenario."""
+    size: int = 8
+    """Grid size (NxN)."""
+    output_dir: str = "spot_check_output"
+    """Directory to write HTML files."""
+    seed_start: int = 0
+    """Starting seed."""
+
+
+def run_scenario(kind: LessonKind, name: str, args: Args) -> dict:
+    """Generate factories for a scenario, verify, and render to a single HTML page."""
+    output_path = Path(args.output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    generated = 0
+    passed = 0
+    failed = 0
+    throughputs = []
+    html_fragments = []
+
+    for i in range(args.count):
+        seed = args.seed_start + i
+        try:
+            world_cwh, min_ent = generate_lesson(
+                size=args.size,
+                kind=kind,
+                num_missing_entities=0,
+                seed=seed,
+            )
+            world_whc = world_cwh.permute(1, 2, 0)
+            tp, unreachable = factorion_rs.simulate_throughput(
+                world_whc.numpy().astype(np.int64)
+            )
+            generated += 1
+
+            status = "PASS" if tp > 0 else "FAIL"
+            if tp > 0:
+                passed += 1
+                throughputs.append(tp)
+            else:
+                failed += 1
+                print(f"  [{name}] seed={seed}: throughput=0 (FAIL)")
+
+            html_obj = world2html(world_WHC=world_whc)
+            color = "#d4edda" if tp > 0 else "#f8d7da"
+            html_fragments.append(
+                f'<div style="border:1px solid #ccc; padding:10px; margin:10px 0; '
+                f'background:{color}; border-radius:6px;">'
+                f'<h3 style="margin:0 0 6px 0;">[{status}] seed={seed} | '
+                f'size={args.size} | kind={name} | '
+                f'tp={tp:.4f} | unreachable={unreachable} | min_ent={min_ent}</h3>'
+                f'<code style="font-size:12px; color:#555;">generate_lesson('
+                f'size={args.size}, kind=LessonKind.{kind.name}, '
+                f'num_missing_entities=0, seed={seed})</code>'
+                f'<div style="margin-top:8px;">{html_obj.text}</div>'
+                f'</div>'
+            )
+
+        except Exception as e:
+            failed += 1
+            print(f"  [{name}] seed={seed}: EXCEPTION: {e}")
+            html_fragments.append(
+                f'<div style="border:1px solid #ccc; padding:10px; margin:10px 0; '
+                f'background:#f8d7da; border-radius:6px;">'
+                f'<h3 style="margin:0;">[ERROR] seed={seed} | size={args.size} | kind={name}</h3>'
+                f'<code style="font-size:12px; color:#555;">generate_lesson('
+                f'size={args.size}, kind=LessonKind.{kind.name}, '
+                f'num_missing_entities=0, seed={seed})</code>'
+                f'<pre style="color:red; margin-top:8px;">{e}</pre>'
+                f'</div>'
+            )
+
+    # Write single HTML page per scenario
+    tps = throughputs
+    summary = (
+        f"{passed}/{generated} passed"
+        + (f", tp range [{min(tps):.2f}, {max(tps):.2f}], avg {sum(tps)/len(tps):.2f}" if tps else "")
+    )
+    html_page = f"""<!DOCTYPE html>
+<html><head>
+<meta charset="utf-8">
+<title>{name} — spot check</title>
+<style>body {{ font-family: system-ui, sans-serif; max-width: 1200px; margin: 0 auto; padding: 20px; }}</style>
+</head><body>
+<h1>{name}</h1>
+<p><strong>{summary}</strong> | size={args.size} | seeds {args.seed_start}..{args.seed_start + args.count - 1}</p>
+<hr>
+{''.join(html_fragments)}
+</body></html>"""
+    html_path = output_path / f"{name}.html"
+    html_path.write_text(html_page)
+    print(f"  Wrote {html_path}")
+
+    return {
+        "name": name,
+        "generated": generated,
+        "passed": passed,
+        "failed": failed,
+        "throughputs": throughputs,
+    }
+
+
+def main():
+    args = tyro.cli(Args)
+
+    if args.scenario == Scenario.all:
+        scenarios = [
+            (Scenario.belt, "belt"),
+            (Scenario.inserter, "inserter"),
+            (Scenario.splitter_split, "splitter_split"),
+            (Scenario.splitter_merge, "splitter_merge"),
+        ]
+    else:
+        scenarios = [(args.scenario, args.scenario.value)]
+
+    print(f"Spot-check: {len(scenarios)} scenario(s), {args.count} each, size={args.size}")
+    print(f"Output: {args.output_dir}/")
+    print()
+
+    results = []
+    for scenario, name in scenarios:
+        kind = SCENARIO_TO_KIND[scenario]
+        print(f"--- {name} ---")
+        result = run_scenario(kind, name, args)
+        results.append(result)
+
+    # Print summary
+    print()
+    print("=" * 60)
+    print(f"{'Scenario':<20} {'Gen':>5} {'Pass':>5} {'Fail':>5} {'Min TP':>8} {'Max TP':>8} {'Avg TP':>8}")
+    print("-" * 60)
+    for r in results:
+        tps = r["throughputs"]
+        min_tp = f"{min(tps):.2f}" if tps else "N/A"
+        max_tp = f"{max(tps):.2f}" if tps else "N/A"
+        avg_tp = f"{sum(tps)/len(tps):.2f}" if tps else "N/A"
+        print(f"{r['name']:<20} {r['generated']:>5} {r['passed']:>5} {r['failed']:>5} {min_tp:>8} {max_tp:>8} {avg_tp:>8}")
+    print("=" * 60)
+
+    total_failed = sum(r["failed"] for r in results)
+    if total_failed > 0:
+        print(f"\nWARNING: {total_failed} total failures!")
+        sys.exit(1)
+    else:
+        print(f"\nAll factories passed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_lesson_generation.py
+++ b/tests/test_lesson_generation.py
@@ -1,0 +1,923 @@
+"""Tests for lesson generation: INSERTER_TRANSFER, SPLITTER_SPLIT, SPLITTER_MERGE."""
+
+import pytest
+import random
+import torch
+
+from helpers import (
+    Channel,
+    Direction,
+    LessonKind,
+    Misc,
+    compare_throughput,
+    entities,
+    generate_lesson,
+    py_throughput_safe,
+    rs_throughput,
+    str2ent,
+    str2item,
+)
+
+
+DIRS = [Direction.NORTH, Direction.EAST, Direction.SOUTH, Direction.WEST]
+
+
+class TestInserterTransferBasic:
+    """Basic sanity checks for INSERTER_TRANSFER lesson generation."""
+
+    def test_generates_without_error(self):
+        """Can generate at least one lesson without raising."""
+        world, min_ent = generate_lesson(
+            size=8, kind=LessonKind.INSERTER_TRANSFER, num_missing_entities=0, seed=42
+        )
+        assert world is not None
+        assert min_ent is not None
+
+    def test_returns_cwh_tensor(self):
+        """Output tensor is CWH format with correct shape."""
+        size = 8
+        world, _ = generate_lesson(
+            size=size, kind=LessonKind.INSERTER_TRANSFER, num_missing_entities=0, seed=42
+        )
+        assert world.shape[0] == len(Channel)
+        assert world.shape[1] == size
+        assert world.shape[2] == size
+
+    def test_has_source_and_sink(self):
+        """Generated world contains exactly one source and one sink."""
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.INSERTER_TRANSFER, num_missing_entities=0, seed=42
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        source_count = (ent_layer == str2ent("source").value).sum().item()
+        sink_count = (ent_layer == str2ent("sink").value).sum().item()
+        assert source_count == 1, f"Expected 1 source, got {source_count}"
+        assert sink_count == 1, f"Expected 1 sink, got {sink_count}"
+
+    def test_has_inserter(self):
+        """Generated world contains exactly one inserter."""
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.INSERTER_TRANSFER, num_missing_entities=0, seed=42
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        inserter_count = (ent_layer == str2ent("inserter").value).sum().item()
+        assert inserter_count == 1, f"Expected 1 inserter, got {inserter_count}"
+
+    def test_has_belts(self):
+        """Generated world contains at least one transport belt."""
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.INSERTER_TRANSFER, num_missing_entities=0, seed=42
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        belt_count = (ent_layer == str2ent("transport_belt").value).sum().item()
+        assert belt_count >= 2, f"Expected at least 2 belts, got {belt_count}"
+
+    def test_nonzero_throughput(self):
+        """Complete factory has throughput > 0."""
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.INSERTER_TRANSFER, num_missing_entities=0, seed=42
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0, f"Expected positive throughput, got {tp}"
+
+    def test_throughput_bottlenecked_by_inserter(self):
+        """Throughput should be <= inserter flow rate (0.86)."""
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.INSERTER_TRANSFER, num_missing_entities=0, seed=42
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        inserter_flow = str2ent("inserter").flow
+        assert tp <= inserter_flow + 1e-6, (
+            f"Throughput {tp} exceeds inserter flow rate {inserter_flow}"
+        )
+
+
+class TestInserterTransferManySeeds:
+    """Generate many lessons with different seeds and verify all are valid."""
+
+    @pytest.mark.parametrize("seed", range(50))
+    def test_size_8_seed(self, seed):
+        """Size 8 grid, many seeds — all must produce valid factories."""
+        world, min_ent = generate_lesson(
+            size=8, kind=LessonKind.INSERTER_TRANSFER, num_missing_entities=0, seed=seed
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0, f"seed={seed}: throughput is {tp}"
+        assert tp <= str2ent("inserter").flow + 1e-6
+
+    @pytest.mark.parametrize("seed", range(30))
+    def test_size_6_seed(self, seed):
+        """Size 6 grid — smaller grid, still must work."""
+        world, min_ent = generate_lesson(
+            size=6, kind=LessonKind.INSERTER_TRANSFER, num_missing_entities=0, seed=seed
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0, f"seed={seed}: throughput is {tp}"
+
+    @pytest.mark.parametrize("seed", range(30))
+    def test_size_10_seed(self, seed):
+        """Size 10 grid — larger grid."""
+        world, min_ent = generate_lesson(
+            size=10, kind=LessonKind.INSERTER_TRANSFER, num_missing_entities=0, seed=seed
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0, f"seed={seed}: throughput is {tp}"
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_size_15_seed(self, seed):
+        """Size 15 grid — large grid."""
+        world, min_ent = generate_lesson(
+            size=15, kind=LessonKind.INSERTER_TRANSFER, num_missing_entities=0, seed=seed
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0, f"seed={seed}: throughput is {tp}"
+
+
+class TestInserterTransferParity:
+    """Python and Rust throughput must agree on generated inserter factories."""
+
+    @pytest.mark.parametrize("seed", range(30))
+    def test_parity_size_8(self, seed):
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.INSERTER_TRANSFER, num_missing_entities=0, seed=seed
+        )
+        world_whc = world.permute(1, 2, 0)
+        py_tp, py_ur = py_throughput_safe(world_whc)
+        rs_tp, rs_ur = rs_throughput(world_whc)
+        assert abs(py_tp - rs_tp) < 1e-6, (
+            f"seed={seed}: Python={py_tp}, Rust={rs_tp}"
+        )
+        assert py_ur == rs_ur, (
+            f"seed={seed}: unreachable Python={py_ur}, Rust={rs_ur}"
+        )
+
+
+class TestInserterTransferGridSizes:
+    """Test across a range of grid sizes with a fixed seed."""
+
+    @pytest.mark.parametrize("size", [5, 6, 7, 8, 9, 10, 12, 15])
+    def test_valid_factory_per_size(self, size):
+        world, min_ent = generate_lesson(
+            size=size, kind=LessonKind.INSERTER_TRANSFER, num_missing_entities=0, seed=7
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        assert (ent_layer == str2ent("source").value).sum().item() == 1
+        assert (ent_layer == str2ent("sink").value).sum().item() == 1
+        assert (ent_layer == str2ent("inserter").value).sum().item() == 1
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0
+
+
+class TestInserterTransferMissingEntities:
+    """Test that entity removal works correctly."""
+
+    @pytest.mark.parametrize("num_missing", [1, 2, 3])
+    def test_removes_correct_count(self, num_missing):
+        """Removing N entities should leave the right number missing."""
+        world_full, _ = generate_lesson(
+            size=8, kind=LessonKind.INSERTER_TRANSFER, num_missing_entities=0, seed=42
+        )
+        world_partial, min_ent = generate_lesson(
+            size=8, kind=LessonKind.INSERTER_TRANSFER, num_missing_entities=num_missing, seed=42
+        )
+        assert min_ent == num_missing
+
+        # Source and sink should still be present
+        ent_layer = world_partial[Channel.ENTITIES.value]
+        assert (ent_layer == str2ent("source").value).sum().item() == 1
+        assert (ent_layer == str2ent("sink").value).sum().item() == 1
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_missing_1_preserves_source_sink(self, seed):
+        """With 1 missing entity, source and sink remain."""
+        world, min_ent = generate_lesson(
+            size=8, kind=LessonKind.INSERTER_TRANSFER, num_missing_entities=1, seed=seed
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        assert (ent_layer == str2ent("source").value).sum().item() == 1
+        assert (ent_layer == str2ent("sink").value).sum().item() == 1
+        assert min_ent == 1
+
+    def test_missing_inf_returns_min_entities(self):
+        """With inf missing, min_entities_required equals total placeable count."""
+        world, min_ent = generate_lesson(
+            size=8, kind=LessonKind.INSERTER_TRANSFER, num_missing_entities=float("inf"), seed=42
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        assert (ent_layer == str2ent("source").value).sum().item() == 1
+        assert (ent_layer == str2ent("sink").value).sum().item() == 1
+        # min_ent should be the total number of inserter + belt entities
+        assert min_ent >= 3  # at least 1 inserter + 2 belts
+
+
+class TestInserterTransferEntityDirections:
+    """Verify that all placed entities have valid, non-NONE directions."""
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_all_entities_have_directions(self, seed):
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.INSERTER_TRANSFER, num_missing_entities=0, seed=seed
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        dir_layer = world[Channel.DIRECTION.value]
+
+        for x in range(world.shape[1]):
+            for y in range(world.shape[2]):
+                ent_val = ent_layer[x, y].item()
+                if ent_val != str2ent("empty").value:
+                    dir_val = dir_layer[x, y].item()
+                    assert dir_val != Direction.NONE.value, (
+                        f"seed={seed}: entity {entities[ent_val].name} at ({x},{y}) "
+                        f"has NONE direction"
+                    )
+
+
+class TestInserterTransferNoOverlaps:
+    """Verify no entity overlaps in generated factories."""
+
+    @pytest.mark.parametrize("seed", range(30))
+    def test_unique_positions(self, seed):
+        """Source, sink, inserter, and belts should all occupy unique cells."""
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.INSERTER_TRANSFER, num_missing_entities=0, seed=seed
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+
+        occupied = []
+        for x in range(world.shape[1]):
+            for y in range(world.shape[2]):
+                if ent_layer[x, y].item() != str2ent("empty").value:
+                    occupied.append((x, y))
+
+        # No duplicate positions
+        assert len(occupied) == len(set(occupied)), (
+            f"seed={seed}: duplicate positions found"
+        )
+
+
+class TestInserterTransferItems:
+    """Verify item channels are set correctly."""
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_source_sink_have_matching_items(self, seed):
+        """Source and sink should carry the same item."""
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.INSERTER_TRANSFER, num_missing_entities=0, seed=seed
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        item_layer = world[Channel.ITEMS.value]
+
+        source_pos = (ent_layer == str2ent("source").value).nonzero(as_tuple=False)[0]
+        sink_pos = (ent_layer == str2ent("sink").value).nonzero(as_tuple=False)[0]
+
+        source_item = item_layer[source_pos[0], source_pos[1]].item()
+        sink_item = item_layer[sink_pos[0], sink_pos[1]].item()
+
+        assert source_item == sink_item, (
+            f"seed={seed}: source item={source_item}, sink item={sink_item}"
+        )
+        assert source_item != str2item("empty").value, (
+            f"seed={seed}: source has empty item"
+        )
+
+
+class TestInserterTransferDeterminism:
+    """Same seed should produce identical results."""
+
+    @pytest.mark.parametrize("seed", [0, 1, 42, 99])
+    def test_deterministic(self, seed):
+        world1, min1 = generate_lesson(
+            size=8, kind=LessonKind.INSERTER_TRANSFER, num_missing_entities=0, seed=seed
+        )
+        world2, min2 = generate_lesson(
+            size=8, kind=LessonKind.INSERTER_TRANSFER, num_missing_entities=0, seed=seed
+        )
+        assert torch.equal(world1, world2), f"seed={seed}: not deterministic"
+        assert min1 == min2
+
+
+class TestInserterTransferMaxEntities:
+    """Test max_entities constraint limits factory complexity."""
+
+    @pytest.mark.parametrize("seed", range(10))
+    def test_respects_max_entities(self, seed):
+        """With a reasonable max_entities, total placeable entities should be bounded."""
+        max_ent = 15
+        world, _ = generate_lesson(
+            size=10,
+            kind=LessonKind.INSERTER_TRANSFER,
+            num_missing_entities=0,
+            seed=seed,
+            max_entities=max_ent,
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        # Count non-source, non-sink, non-empty entities
+        placeable = (
+            (ent_layer != str2ent("source").value)
+            & (ent_layer != str2ent("sink").value)
+            & (ent_layer != str2ent("empty").value)
+        ).sum().item()
+        assert placeable <= max_ent, (
+            f"seed={seed}: {placeable} placeable entities exceeds max {max_ent}"
+        )
+
+
+class TestInserterTransferThroughputRange:
+    """Verify throughput falls in expected range across many configurations."""
+
+    @pytest.mark.parametrize("size", [6, 8, 10])
+    @pytest.mark.parametrize("seed", range(15))
+    def test_throughput_in_range(self, size, seed):
+        """Throughput should be > 0 and <= inserter rate (0.86)."""
+        world, _ = generate_lesson(
+            size=size, kind=LessonKind.INSERTER_TRANSFER, num_missing_entities=0, seed=seed
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        inserter_flow = str2ent("inserter").flow
+        assert 0 < tp <= inserter_flow + 1e-6, (
+            f"size={size}, seed={seed}: throughput {tp} not in (0, {inserter_flow}]"
+        )
+
+
+# ── SPLITTER_SPLIT tests ─────────────────────────────────────────────────────
+
+
+class TestSplitterSplitBasic:
+    """Basic sanity checks for SPLITTER_SPLIT lesson generation."""
+
+    def test_generates_without_error(self):
+        world, min_ent = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=0, seed=42
+        )
+        assert world is not None
+        assert min_ent is not None
+
+    def test_returns_cwh_tensor(self):
+        size = 10
+        world, _ = generate_lesson(
+            size=size, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=0, seed=42
+        )
+        assert world.shape[0] == len(Channel)
+        assert world.shape[1] == size
+        assert world.shape[2] == size
+
+    def test_has_one_source_two_sinks(self):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=0, seed=42
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        assert (ent_layer == str2ent("source").value).sum().item() == 1
+        assert (ent_layer == str2ent("sink").value).sum().item() == 2
+
+    def test_has_splitter(self):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=0, seed=42
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        splitter_count = (ent_layer == str2ent("splitter").value).sum().item()
+        # Splitter occupies 2 tiles
+        assert splitter_count == 2, f"Expected 2 splitter tiles, got {splitter_count}"
+
+    def test_has_belts(self):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=0, seed=42
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        belt_count = (ent_layer == str2ent("transport_belt").value).sum().item()
+        assert belt_count >= 3, f"Expected at least 3 belts, got {belt_count}"
+
+    def test_nonzero_throughput(self):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=0, seed=42
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0, f"Expected positive throughput, got {tp}"
+
+    def test_throughput_bounded_by_splitter(self):
+        """Total throughput should be <= 30.0 (splitter max flow)."""
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=0, seed=42
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp <= 30.0 + 1e-6, f"Throughput {tp} exceeds splitter max flow"
+
+
+class TestSplitterSplitManySeeds:
+    """Generate many lessons with different seeds and verify all are valid."""
+
+    @pytest.mark.parametrize("seed", range(50))
+    def test_size_10_seed(self, seed):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=0, seed=seed
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0, f"seed={seed}: throughput is {tp}"
+
+    @pytest.mark.parametrize("seed", range(30))
+    def test_size_8_seed(self, seed):
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=0, seed=seed
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0, f"seed={seed}: throughput is {tp}"
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_size_12_seed(self, seed):
+        world, _ = generate_lesson(
+            size=12, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=0, seed=seed
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0, f"seed={seed}: throughput is {tp}"
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_size_15_seed(self, seed):
+        world, _ = generate_lesson(
+            size=15, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=0, seed=seed
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0, f"seed={seed}: throughput is {tp}"
+
+
+class TestSplitterSplitParity:
+    """Python and Rust throughput must agree on generated splitter-split factories."""
+
+    @pytest.mark.parametrize("seed", range(30))
+    def test_parity_size_10(self, seed):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=0, seed=seed
+        )
+        world_whc = world.permute(1, 2, 0)
+        py_tp, py_ur = py_throughput_safe(world_whc)
+        rs_tp, rs_ur = rs_throughput(world_whc)
+        assert abs(py_tp - rs_tp) < 1e-6, (
+            f"seed={seed}: Python={py_tp}, Rust={rs_tp}"
+        )
+        assert py_ur == rs_ur, (
+            f"seed={seed}: unreachable Python={py_ur}, Rust={rs_ur}"
+        )
+
+
+class TestSplitterSplitGridSizes:
+    """Test across a range of grid sizes."""
+
+    @pytest.mark.parametrize("size", [8, 9, 10, 12, 15])
+    def test_valid_factory_per_size(self, size):
+        world, _ = generate_lesson(
+            size=size, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=0, seed=7
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        assert (ent_layer == str2ent("source").value).sum().item() == 1
+        assert (ent_layer == str2ent("sink").value).sum().item() == 2
+        assert (ent_layer == str2ent("splitter").value).sum().item() == 2
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0
+
+
+class TestSplitterSplitEntityDirections:
+    """Verify all placed entities have valid directions."""
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_all_entities_have_directions(self, seed):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=0, seed=seed
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        dir_layer = world[Channel.DIRECTION.value]
+
+        for x in range(world.shape[1]):
+            for y in range(world.shape[2]):
+                ent_val = ent_layer[x, y].item()
+                if ent_val != str2ent("empty").value:
+                    dir_val = dir_layer[x, y].item()
+                    assert dir_val != Direction.NONE.value, (
+                        f"seed={seed}: entity {entities[ent_val].name} at ({x},{y}) "
+                        f"has NONE direction"
+                    )
+
+
+class TestSplitterSplitNoOverlaps:
+    """Verify no entity overlaps in generated factories."""
+
+    @pytest.mark.parametrize("seed", range(30))
+    def test_no_double_placement(self, seed):
+        """Each cell should have at most one entity."""
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=0, seed=seed
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        occupied = []
+        for x in range(world.shape[1]):
+            for y in range(world.shape[2]):
+                if ent_layer[x, y].item() != str2ent("empty").value:
+                    occupied.append((x, y))
+        assert len(occupied) == len(set(occupied)), (
+            f"seed={seed}: duplicate positions"
+        )
+
+
+class TestSplitterSplitItems:
+    """Verify item channels are set correctly."""
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_source_sinks_have_matching_items(self, seed):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=0, seed=seed
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        item_layer = world[Channel.ITEMS.value]
+
+        source_pos = (ent_layer == str2ent("source").value).nonzero(as_tuple=False)[0]
+        sink_positions = (ent_layer == str2ent("sink").value).nonzero(as_tuple=False)
+
+        source_item = item_layer[source_pos[0], source_pos[1]].item()
+        assert source_item != str2item("empty").value
+
+        for i in range(len(sink_positions)):
+            sink_item = item_layer[sink_positions[i][0], sink_positions[i][1]].item()
+            assert sink_item == source_item, (
+                f"seed={seed}: sink {i} item={sink_item} != source item={source_item}"
+            )
+
+
+class TestSplitterSplitMissingEntities:
+    """Test entity removal for splitter-split lessons."""
+
+    @pytest.mark.parametrize("num_missing", [1, 2, 3])
+    def test_removes_correct_count(self, num_missing):
+        world, min_ent = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=num_missing, seed=42
+        )
+        assert min_ent == num_missing
+        ent_layer = world[Channel.ENTITIES.value]
+        assert (ent_layer == str2ent("source").value).sum().item() == 1
+        assert (ent_layer == str2ent("sink").value).sum().item() == 2
+
+    @pytest.mark.parametrize("seed", range(10))
+    def test_missing_inf_returns_positive_count(self, seed):
+        world, min_ent = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=float("inf"), seed=seed
+        )
+        assert min_ent >= 4  # at least 1 splitter + 3 belts
+
+
+class TestSplitterSplitDeterminism:
+    """Same seed produces identical results."""
+
+    @pytest.mark.parametrize("seed", [0, 1, 42, 99])
+    def test_deterministic(self, seed):
+        world1, min1 = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=0, seed=seed
+        )
+        world2, min2 = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=0, seed=seed
+        )
+        assert torch.equal(world1, world2), f"seed={seed}: not deterministic"
+        assert min1 == min2
+
+
+class TestSplitterSplitThroughputRange:
+    """Throughput should be in the expected range for splitting."""
+
+    @pytest.mark.parametrize("size", [8, 10, 12])
+    @pytest.mark.parametrize("seed", range(15))
+    def test_throughput_in_range(self, size, seed):
+        """Throughput should be > 0 and <= 15.0 (single belt input)."""
+        world, _ = generate_lesson(
+            size=size, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=0, seed=seed
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        # Splitter max flow is 30.0 (can sideload both inputs)
+        assert 0 < tp <= 30.0 + 1e-6, (
+            f"size={size}, seed={seed}: throughput {tp} not in (0, 30.0]"
+        )
+
+
+# ── SPLITTER_MERGE tests ─────────────────────────────────────────────────────
+
+
+class TestSplitterMergeBasic:
+    """Basic sanity checks for SPLITTER_MERGE lesson generation."""
+
+    def test_generates_without_error(self):
+        world, min_ent = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_MERGE, num_missing_entities=0, seed=42
+        )
+        assert world is not None
+        assert min_ent is not None
+
+    def test_returns_cwh_tensor(self):
+        size = 10
+        world, _ = generate_lesson(
+            size=size, kind=LessonKind.SPLITTER_MERGE, num_missing_entities=0, seed=42
+        )
+        assert world.shape[0] == len(Channel)
+        assert world.shape[1] == size
+        assert world.shape[2] == size
+
+    def test_has_two_sources_one_sink(self):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_MERGE, num_missing_entities=0, seed=42
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        assert (ent_layer == str2ent("source").value).sum().item() == 2
+        assert (ent_layer == str2ent("sink").value).sum().item() == 1
+
+    def test_has_splitter(self):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_MERGE, num_missing_entities=0, seed=42
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        splitter_count = (ent_layer == str2ent("splitter").value).sum().item()
+        assert splitter_count == 2, f"Expected 2 splitter tiles, got {splitter_count}"
+
+    def test_has_belts(self):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_MERGE, num_missing_entities=0, seed=42
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        belt_count = (ent_layer == str2ent("transport_belt").value).sum().item()
+        assert belt_count >= 3, f"Expected at least 3 belts, got {belt_count}"
+
+    def test_nonzero_throughput(self):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_MERGE, num_missing_entities=0, seed=42
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0, f"Expected positive throughput, got {tp}"
+
+    def test_throughput_bounded_by_splitter(self):
+        """Total throughput should be <= 30.0 (splitter max flow)."""
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_MERGE, num_missing_entities=0, seed=42
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp <= 30.0 + 1e-6, f"Throughput {tp} exceeds splitter max flow"
+
+
+class TestSplitterMergeManySeeds:
+    """Generate many lessons with different seeds and verify all are valid."""
+
+    @pytest.mark.parametrize("seed", range(50))
+    def test_size_10_seed(self, seed):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_MERGE, num_missing_entities=0, seed=seed
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0, f"seed={seed}: throughput is {tp}"
+
+    @pytest.mark.parametrize("seed", range(30))
+    def test_size_8_seed(self, seed):
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.SPLITTER_MERGE, num_missing_entities=0, seed=seed
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0, f"seed={seed}: throughput is {tp}"
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_size_12_seed(self, seed):
+        world, _ = generate_lesson(
+            size=12, kind=LessonKind.SPLITTER_MERGE, num_missing_entities=0, seed=seed
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0, f"seed={seed}: throughput is {tp}"
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_size_15_seed(self, seed):
+        world, _ = generate_lesson(
+            size=15, kind=LessonKind.SPLITTER_MERGE, num_missing_entities=0, seed=seed
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0, f"seed={seed}: throughput is {tp}"
+
+
+class TestSplitterMergeParity:
+    """Python and Rust throughput must agree on generated splitter-merge factories."""
+
+    @pytest.mark.parametrize("seed", range(30))
+    def test_parity_size_10(self, seed):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_MERGE, num_missing_entities=0, seed=seed
+        )
+        world_whc = world.permute(1, 2, 0)
+        py_tp, py_ur = py_throughput_safe(world_whc)
+        rs_tp, rs_ur = rs_throughput(world_whc)
+        assert abs(py_tp - rs_tp) < 1e-6, (
+            f"seed={seed}: Python={py_tp}, Rust={rs_tp}"
+        )
+        assert py_ur == rs_ur, (
+            f"seed={seed}: unreachable Python={py_ur}, Rust={rs_ur}"
+        )
+
+
+class TestSplitterMergeGridSizes:
+    """Test across a range of grid sizes."""
+
+    @pytest.mark.parametrize("size", [8, 9, 10, 12, 15])
+    def test_valid_factory_per_size(self, size):
+        world, _ = generate_lesson(
+            size=size, kind=LessonKind.SPLITTER_MERGE, num_missing_entities=0, seed=7
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        assert (ent_layer == str2ent("source").value).sum().item() == 2
+        assert (ent_layer == str2ent("sink").value).sum().item() == 1
+        assert (ent_layer == str2ent("splitter").value).sum().item() == 2
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0
+
+
+class TestSplitterMergeEntityDirections:
+    """Verify all placed entities have valid directions."""
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_all_entities_have_directions(self, seed):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_MERGE, num_missing_entities=0, seed=seed
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        dir_layer = world[Channel.DIRECTION.value]
+
+        for x in range(world.shape[1]):
+            for y in range(world.shape[2]):
+                ent_val = ent_layer[x, y].item()
+                if ent_val != str2ent("empty").value:
+                    dir_val = dir_layer[x, y].item()
+                    assert dir_val != Direction.NONE.value, (
+                        f"seed={seed}: entity {entities[ent_val].name} at ({x},{y}) "
+                        f"has NONE direction"
+                    )
+
+
+class TestSplitterMergeNoOverlaps:
+    """Verify no entity overlaps in generated factories."""
+
+    @pytest.mark.parametrize("seed", range(30))
+    def test_no_double_placement(self, seed):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_MERGE, num_missing_entities=0, seed=seed
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        occupied = []
+        for x in range(world.shape[1]):
+            for y in range(world.shape[2]):
+                if ent_layer[x, y].item() != str2ent("empty").value:
+                    occupied.append((x, y))
+        assert len(occupied) == len(set(occupied)), (
+            f"seed={seed}: duplicate positions"
+        )
+
+
+class TestSplitterMergeItems:
+    """Verify item channels are set correctly."""
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_sources_sink_have_matching_items(self, seed):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_MERGE, num_missing_entities=0, seed=seed
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        item_layer = world[Channel.ITEMS.value]
+
+        source_positions = (ent_layer == str2ent("source").value).nonzero(as_tuple=False)
+        sink_pos = (ent_layer == str2ent("sink").value).nonzero(as_tuple=False)[0]
+
+        sink_item = item_layer[sink_pos[0], sink_pos[1]].item()
+        assert sink_item != str2item("empty").value
+
+        for i in range(len(source_positions)):
+            src_item = item_layer[source_positions[i][0], source_positions[i][1]].item()
+            assert src_item == sink_item, (
+                f"seed={seed}: source {i} item={src_item} != sink item={sink_item}"
+            )
+
+
+class TestSplitterMergeMissingEntities:
+    """Test entity removal for splitter-merge lessons."""
+
+    @pytest.mark.parametrize("num_missing", [1, 2, 3])
+    def test_removes_correct_count(self, num_missing):
+        world, min_ent = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_MERGE, num_missing_entities=num_missing, seed=42
+        )
+        assert min_ent == num_missing
+        ent_layer = world[Channel.ENTITIES.value]
+        assert (ent_layer == str2ent("source").value).sum().item() == 2
+        assert (ent_layer == str2ent("sink").value).sum().item() == 1
+
+    @pytest.mark.parametrize("seed", range(10))
+    def test_missing_inf_returns_positive_count(self, seed):
+        world, min_ent = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_MERGE, num_missing_entities=float("inf"), seed=seed
+        )
+        assert min_ent >= 4  # at least 1 splitter + 3 belts
+
+
+class TestSplitterMergeDeterminism:
+    """Same seed produces identical results."""
+
+    @pytest.mark.parametrize("seed", [0, 1, 42, 99])
+    def test_deterministic(self, seed):
+        world1, min1 = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_MERGE, num_missing_entities=0, seed=seed
+        )
+        world2, min2 = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_MERGE, num_missing_entities=0, seed=seed
+        )
+        assert torch.equal(world1, world2), f"seed={seed}: not deterministic"
+        assert min1 == min2
+
+
+class TestSplitterMergeThroughputRange:
+    """Throughput should be in the expected range for merging."""
+
+    @pytest.mark.parametrize("size", [8, 10, 12])
+    @pytest.mark.parametrize("seed", range(15))
+    def test_throughput_in_range(self, size, seed):
+        """Throughput should be > 0 and <= 30.0 (splitter max)."""
+        world, _ = generate_lesson(
+            size=size, kind=LessonKind.SPLITTER_MERGE, num_missing_entities=0, seed=seed
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert 0 < tp <= 30.0 + 1e-6, (
+            f"size={size}, seed={seed}: throughput {tp} not in (0, 30.0]"
+        )
+
+
+# ── Multi-tile entity removal tests ──────────────────────────────────────────
+
+
+class TestRemoveEntitiesSplitterIntegrity:
+    """When a splitter is removed, both tiles must be cleared together."""
+
+    @pytest.mark.parametrize("seed", range(50))
+    def test_splitter_removal_clears_both_tiles(self, seed):
+        """Generate a splitter lesson, remove 1 entity. If the splitter was
+        removed, BOTH tiles must be empty — no orphaned single tile."""
+        world, min_ent = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=1, seed=seed
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        splitter_val = str2ent("splitter").value
+        splitter_tiles = (ent_layer == splitter_val).sum().item()
+        # Splitter is 2 tiles. After removal it should be 0 or 2, never 1.
+        assert splitter_tiles in (0, 2), (
+            f"seed={seed}: found {splitter_tiles} splitter tiles — "
+            f"expected 0 (removed) or 2 (kept), not 1 (orphaned)"
+        )
+
+    @pytest.mark.parametrize("seed", range(50))
+    def test_splitter_merge_removal_clears_both_tiles(self, seed):
+        """Same test for SPLITTER_MERGE lessons."""
+        world, min_ent = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_MERGE, num_missing_entities=1, seed=seed
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        splitter_val = str2ent("splitter").value
+        splitter_tiles = (ent_layer == splitter_val).sum().item()
+        assert splitter_tiles in (0, 2), (
+            f"seed={seed}: found {splitter_tiles} splitter tiles — "
+            f"expected 0 (removed) or 2 (kept), not 1 (orphaned)"
+        )
+
+    @pytest.mark.parametrize("seed", range(30))
+    @pytest.mark.parametrize("num_missing", [1, 2, 3, 4])
+    def test_no_orphaned_splitter_tiles_any_removal_count(self, seed, num_missing):
+        """With various removal counts, splitter tiles are always 0 or 2."""
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=num_missing, seed=seed
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        splitter_val = str2ent("splitter").value
+        splitter_tiles = (ent_layer == splitter_val).sum().item()
+        assert splitter_tiles in (0, 2), (
+            f"seed={seed}, missing={num_missing}: {splitter_tiles} splitter tiles (orphaned!)"
+        )
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_removed_entity_count_matches_min_entities(self, seed):
+        """The number of entity *units* removed should equal min_entities_required."""
+        # Generate a full factory first to count total entity units
+        world_full, _ = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=0, seed=seed
+        )
+        ent_full = world_full[Channel.ENTITIES.value]
+
+        # Count entity units (splitter = 1 unit despite 2 tiles)
+        full_belts = (ent_full == str2ent("transport_belt").value).sum().item()
+        full_splitter_tiles = (ent_full == str2ent("splitter").value).sum().item()
+        full_units = full_belts + (full_splitter_tiles // 2)
+
+        # Remove 2 entities
+        world_partial, min_ent = generate_lesson(
+            size=10, kind=LessonKind.SPLITTER_SPLIT, num_missing_entities=2, seed=seed
+        )
+        assert min_ent == 2
+
+        ent_partial = world_partial[Channel.ENTITIES.value]
+        partial_belts = (ent_partial == str2ent("transport_belt").value).sum().item()
+        partial_splitter_tiles = (ent_partial == str2ent("splitter").value).sum().item()
+        partial_units = partial_belts + (partial_splitter_tiles // 2)
+
+        units_removed = full_units - partial_units
+        assert units_removed == 2, (
+            f"seed={seed}: removed {units_removed} entity units, expected 2"
+        )

--- a/wiki/splitter.md
+++ b/wiki/splitter.md
@@ -68,23 +68,46 @@ blocked side clears, it sends the owed items to balance out.
 
 ## Factorion Implementation
 
-### Current Status: Not Yet Implemented
+### Current Status: Implemented
 
-The splitter is listed as a planned entity in the README ("Factorio environment
-rewrite/overhaul" section). It does not currently exist in the `EntityKind`
-enum or in `entities.rs`.
+- **Entity enum:** `EntityKind::Splitter = 7` (Rust), entity value 7 (Python)
+- **Size:** 2 tiles wide (perpendicular to flow), 1 tile deep
+- **Flow rate:** 30.0 items/sec (2 input belts × 15 items/sec each)
+- **Footprint:** Computed via `entity_tiles(x, y, dir, 2, 1)`. Anchor is the
+  "left" tile when looking in the flow direction. Tile layout depends on
+  direction:
+  - **East/West:** anchor (x, y), second tile (x, y+1)
+  - **North/South:** anchor (x, y), second tile (x+1, y)
 
-### Implementation Notes
+### Connection Logic
 
-When added, the splitter will need:
+For each of the splitter's 2 tiles:
 
-- A new `EntityKind` variant (value TBD)
-- 1x2 footprint handling (like [[assembling-machine]]'s 3x3, but 1x2)
-- Connection logic: accept input from the two tiles behind, output to the two
-  tiles ahead
-- `transform_flow`: split input evenly across outputs (or just pass-through
-  at 15 items/sec per side if modeled as a simple flow entity)
-- No need for priority or filter mechanics per current project scope
+- **Input (behind tile):** Accepts transport belts or underground belts pointing
+  in the **same direction** as the splitter. Also accepts sources/sinks with
+  matching direction.
+- **Output (ahead of tile):** Connects to transport belts, underground belts,
+  or sinks that are **not facing the opposite direction** (sideloading allowed).
+
+### Flow Splitting
+
+`transform_flow()` caps input at the splitter's flow rate (30.0). The
+throughput calculation then divides output evenly by the number of successors
+in the flow graph. With 2 outputs, each gets half the input.
+
+### Lesson Types
+
+Three lesson generators use splitters:
+
+- `SPLITTER_SPLIT`: 1 source → belts → splitter → 2×(belts → sink)
+- `SPLITTER_MERGE`: 2×(source → belts) → splitter → belts → 1 sink
+- Both are tested across many seeds, grid sizes, and with Rust/Python parity
+
+### Not Implemented
+
+- Priority settings (input/output priority)
+- Filtering (item-type routing)
+- Memory (rebalancing after blockage clears)
 
 ## Interactions
 


### PR DESCRIPTION
## Summary

- Adds **splitter** entity to the Python side (Rust added in #55): 2×1 multi-tile entity, 30 i/s flow, connection logic in `world2graph`, flow-splitting in `calc_throughput`.
- Adds **3 new curriculum lessons**: \`INSERTER_TRANSFER\`, \`SPLITTER_SPLIT\`, \`SPLITTER_MERGE\` (closes #40 partially, closes #41).
- Fixes **#60** (multi-tile entity removal) via new \`_remove_entities\` helper that treats each multi-tile entity as a single unit.
- Fixes source/sink protection that was silently broken by adding splitter as entity 7 (was using \`len(entities)-1/-2\` positional arithmetic).
- Fixes pass-through double-counting in splitter lessons where belt paths could route through sinks or the splitter's unused I/O cells, inflating throughput (e.g. 22.5 i/s when a 1-belt input should cap at 15).
- Cleans up \`world2graph\` splitter branch using \`DIR_TO_DELTA\` and precomputed opposite-direction map.
- Fixes \`world2html\` ghost rendering for rotated multi-tile entities (used naive bbox instead of \`entity_tiles\`).
- Caches source/sink IDs in \`FactorioEnv.__init__\` to remove per-step string lookups from the PPO hot path.
- Adds \`scripts/spot_check.py\` visualization helper and updates \`wiki/splitter.md\` to reflect the implementation.
- Adds 66 new lesson-generation tests (1553 total passing).

## Verification

At size=10, 1000 seeds per lesson, \`num_missing_entities=0\`, throughput must not exceed 15 i/s (1-belt bottleneck):
- \`SPLITTER_SPLIT\`: 0/1000 exceeded
- \`SPLITTER_MERGE\`: 0/1000 exceeded

## Test plan

- [x] \`cargo fmt --manifest-path factorion_rs/Cargo.toml --check\`
- [x] \`cargo test --manifest-path factorion_rs/Cargo.toml --no-default-features\` (46 passed)
- [x] \`maturin develop --release --manifest-path factorion_rs/Cargo.toml\`
- [x] \`pytest tests/ -v\` (1553 passed, 64 skipped)
- [x] \`ruff check .\`
- [x] PPO smoke test \`--total-timesteps 5000\`

## Notes

- \`LessonKind\` enum values were renumbered (removed unused \`MOVE_TWO_ITEMS_*\`, \`CREATE_COPPER_WIRE\`, \`CREATE_ELECTRONIC_CIRCUIT\` variants). All code references enum names, not raw values — no runtime breakage, but any W&B configs or saved artifacts referencing raw ints should be audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)