### PR TITLE
Document Factorio two-lane belt mechanics in wiki

### DIFF
--- a/wiki/README.md
+++ b/wiki/README.md
@@ -18,12 +18,14 @@ implementation simplifies or diverges from the real game.
 | Inserter | Yes | [[inserter]] |
 | Assembling Machine 1 | Yes | [[assembling-machine]] |
 | Underground Belt | Yes | [[underground-belt]] |
-| Splitter | Planned | [[splitter]] |
+| Splitter | Yes | [[splitter]] |
 | Source / Sink | Yes (custom) | See [[inserter]] — they use inserter connection logic |
 
 ## Other docs
 
 - [[items-and-recipes]] — items, crafting recipes, and how Factorion models them
+- [[two-lane-system]] — the left/right lane mechanic that spans belts,
+  inserters, splitters, and sideloading (**not yet modelled in Factorion**)
 - [[glossary]] — definitions of Factorio terms used in these docs
 
 ## What's deliberately excluded

--- a/wiki/glossary.md
+++ b/wiki/glossary.md
@@ -9,21 +9,31 @@ how Factorion simplifies or omits them.
 ### Lane
 
 Every [[transport-belt]] (and [[underground-belt]], [[splitter]]) has two
-independent lanes — a **left lane** and a **right lane**. Each lane carries
-items independently at half the belt's total throughput. Items stay on their
-lane unless moved by a [[splitter]] or by sideloading.
+independent lanes — a **left lane** and a **right lane** (relative to the
+belt's facing direction). Each lane carries items at **7.5 items/sec**
+independently of the other; density and speed per lane are constant. Items
+stay on their lane unless moved by a [[splitter]], by [[glossary#sideloading|
+sideloading]], or by inserter placement/extraction.
 
 > **Not yet in Factorion.** Belts are modeled as single-lane pipes.
 
 ### Sideloading
 
 Feeding a belt **perpendicularly** into the side of another belt. Items merge
-onto only one lane of the receiving belt (the lane on the side the feeder belt
-connects to). This is the primary technique for controlling which lane carries
-which item type.
+onto only **one lane** of the receiving belt — the lane on the side the feeder
+belt connects from. This is the primary technique for controlling which lane
+carries which item type.
 
-Example: A belt pointing East meets the side of a belt pointing North. Items
-from the eastbound belt go onto the **right lane** of the northbound belt.
+Example: a belt pointing East into the **west** side of a belt pointing North
+lands its items on the **left lane** of the northbound belt. Reversed (West
+belt into the **east** side of a North belt) lands on the right lane.
+
+Common uses:
+- **Lane isolation:** put copper on the left lane, iron on the right lane, of
+  a single belt feeding a smelter row.
+- **Lane compression:** sideloading onto a partly-full belt can fully
+  saturate it beyond what forward-loading alone achieves.
+- **Lane swapping:** chain two sideloads to swap items from left to right.
 
 > **Not yet in Factorion.** Requires the lane system.
 

--- a/wiki/inserter.md
+++ b/wiki/inserter.md
@@ -38,10 +38,21 @@ Factorion implementation uses 0.86 items/sec.
 
 ### Lane Interaction
 
-In real Factorio, inserters interact with [[glossary#lane|belt lanes]]:
+In real Factorio, inserters interact with [[glossary#lane|belt lanes]]
+asymmetrically:
 
-- **Placing onto a belt:** Items go on the **near lane** (closest to inserter)
-- **Picking from a belt:** Grabs from the **near lane** first
+- **Placing onto a belt:** Items go on the **far lane** (the lane on the far
+  side of the belt from the inserter). When belt and inserter face the same
+  direction, this is the **right lane from the belt's perspective**.
+- **Picking from a belt:** Inserters **prefer the nearest lane** and only
+  reach to the far lane if the near one is empty. For belts parallel to the
+  inserter, "nearest" resolves to the **left lane from the belt's
+  perspective**.
+
+This asymmetry (drop far, pick near) is deliberate: it means an inserter
+inserting into a belt and a second inserter extracting from the same belt
+downstream will not short-circuit — the extracting inserter sees the item on
+the lane it doesn't read first.
 
 > **Not yet in Factorion.** No lane distinction — inserters interact with the
 > belt as a single flow.
@@ -102,7 +113,7 @@ Python legacy names) but behave as infinite-capacity item endpoints.
 
 | Mechanic | Real Factorio | Factorion |
 |---|---|---|
-| Lane awareness | Near lane pickup/drop | No lanes |
+| Lane awareness | Drop on far lane, pick from near lane preferentially | No lanes |
 | Stack size | 1 per swing (basic) | Not modeled — flow rate only |
 | Power | Requires electricity | No power simulation |
 | Variants | 5+ types | Basic only (+ Source/Sink) |

--- a/wiki/splitter.md
+++ b/wiki/splitter.md
@@ -32,11 +32,30 @@ can handle two full belts simultaneously (30 items/sec total).
 
 ### Lane Behavior
 
-Each [[glossary#lane]] is split independently — left lane items on the input
-are distributed to left lanes on the outputs, and same for right lanes. The
-splitting decision is independent of item type.
+Splitters **preserve lanes**. As of Factorio 0.16.16:
 
-> **Not relevant to Factorion yet.** Lanes aren't modeled.
+> "The left and right lane splitting is now completely independent. The
+> decision whether item goes to left or right output is now independent of
+> the item type." — [Splitter](https://wiki.factorio.com/Splitter)
+
+The phrase "left and right lane splitting is independent" refers to the
+**routing decisions**, not to items physically moving between lanes:
+
+- An item entering on the left lane of an input belt exits on the left lane
+  of whichever output belt it's routed to.
+- An item entering on the right lane exits on the right lane of whichever
+  output.
+- The splitter decides per-lane which of the two output belts an item goes
+  to, and these two per-lane decisions are independent of each other (and
+  independent of item type).
+
+**Lanes are preserved by every belt-like entity in the game** — straight
+belts, curves, undergrounds, splitters, and sideloads (each sideload
+deposits onto a specific lane). Swapping lanes is only possible via a
+**pair of sideloads**.
+
+> **Not relevant to Factorion yet.** Lanes aren't modeled — splitters simply
+> divide total flow equally across outputs.
 
 ### Priority Settings
 

--- a/wiki/transport-belt.md
+++ b/wiki/transport-belt.md
@@ -21,15 +21,29 @@ entity and the backbone of every factory.
 
 ### Two-Lane System
 
-Every belt has a **left lane** and a **right lane**, each carrying items
-independently. This is fundamental to belt mechanics:
+Every belt has a **left lane** and a **right lane** (relative to the belt's
+facing direction), and the two are **completely independent**:
 
-- Each lane carries half the total throughput (7.5 items/sec per lane)
-- Items stay on their lane unless forced off by a [[splitter]] or via
-  [[glossary#sideloading]]
-- An [[inserter]] placing onto a belt drops items on the **near lane** (the
-  lane closest to the inserter)
-- An [[inserter]] picking up from a belt grabs from the **near lane** first
+> "Belts have two parallel lanes, and the density and speed of each lane is
+> constant and independent of the other one." — [Transport belts/Physics](https://wiki.factorio.com/Transport_belts/Physics)
+
+- Each lane carries half the total throughput: **7.5 items/sec per lane**,
+  15 items/sec combined
+- Each lane holds **4 items per tile** (8 total per tile)
+- Items stay on their lane unless moved by a [[splitter]] or by
+  [[glossary#sideloading|sideloading]]
+- Internally each tile has **256 positions per lane**; saturated items sit
+  64 positions apart
+
+**Inserter lane targeting** ([Inserter](https://wiki.factorio.com/Inserter)):
+
+- **Placing onto a belt:** the inserter drops onto the **far lane** (the lane
+  on the far side of the belt from the inserter). When the belt and inserter
+  face the same direction, this is the **right lane from the belt's
+  perspective**.
+- **Picking from a belt:** the inserter **prefers the nearest lane** and only
+  reaches to the far lane if the near one is empty. For belts parallel to the
+  inserter, "nearest" resolves to the left lane from the belt's perspective.
 
 > **Not yet in Factorion:** The two-lane system is not modeled. Belts are
 > treated as single-lane pipes. If lanes are added later, sideloading and
@@ -39,23 +53,32 @@ independently. This is fundamental to belt mechanics:
 
 - Belts auto-connect when placed adjacent in compatible directions
 - A belt curves when placed at a 90-degree angle to an adjacent belt
-- Curved belts **compress** the inner lane and **spread** the outer lane — this
-  affects throughput on curves
+- **Curve geometry:** the outer lane of a turn is **1.15234375× longer**
+  (295/256) than a straight belt. Items on the outer lane travel a longer
+  path at the same speed, so they exit the curve later than items on the
+  inner lane — this staggers item arrivals but doesn't reduce per-lane
+  throughput.
 - Items do not fall off the end of a belt; they stop and wait
 
-> **Not yet in Factorion:** Belt curving and curve throughput penalties are not
-> modeled.
+> **Not yet in Factorion:** Belt curving and curve geometry are not modeled.
 
 ### Sideloading
 
 When a belt feeds into the **side** of another belt (perpendicular), items
-merge onto only **one lane** of the receiving belt. This is called
-[[glossary#sideloading]] and is a key technique for lane control:
+merge onto only **one lane** of the receiving belt — the lane on the side the
+feeder belt connects from. This is called [[glossary#sideloading|sideloading]]
+and is the primary technique for **lane control**:
 
-- Belt pointing East into the side of a belt pointing North → items go onto
-  the right lane of the northbound belt
-- Used to load a single lane or merge two item types onto separate lanes of
-  one belt
+- Belt pointing East into the west side of a belt pointing North → items go
+  onto the **left lane** of the northbound belt
+- Belt pointing West into the east side of a belt pointing North → items go
+  onto the **right lane** of the northbound belt
+- Used to: isolate a single item type onto one lane, merge two item types onto
+  separate lanes of one belt, or reach "lane compression" past a long chain
+
+Sideloading also has travel-distance mechanics (late sideloads travel 68
+internal positions, early sideloads travel 188) that affect how a sideloading
+junction behaves under load.
 
 > **Not yet in Factorion:** Sideloading is not modeled (requires lanes).
 

--- a/wiki/two-lane-system.md
+++ b/wiki/two-lane-system.md
@@ -1,0 +1,165 @@
+# Two-Lane System
+
+Every belt in Factorio is actually **two parallel lanes** that carry items
+independently. This is one of the most important cross-cutting mechanics in
+the game — it touches belts, inserters, splitters, sideloading, and factory
+design patterns like "main bus".
+
+**Not in Factorion.** Factorion models belts as single-lane pipes. This page
+documents what Factorio actually does so we can reason about what changes if
+we decide to add lanes.
+
+## Canonical specs
+
+From [Transport belts/Physics](https://wiki.factorio.com/Transport_belts/Physics):
+
+> "Belts have two parallel lanes, and the density and speed of each lane is
+> constant and independent of the other one."
+
+| Property | Per lane | Both lanes |
+|---|---|---|
+| Throughput | 7.5 items/sec | 15 items/sec |
+| Density | 4 items/tile | 8 items/tile |
+| Speed | 1.875 tiles/sec | 1.875 tiles/sec |
+| Internal positions | 256/tile | 512/tile |
+
+Lanes are labelled **left** and **right** relative to the belt's facing
+direction.
+
+## Rules for which lane an item ends up on
+
+### Forward belt-to-belt flow
+
+Items travelling straight along connected belts **stay on their lane**. Left
+stays left, right stays right. This is the simple case.
+
+### Curves
+
+Curved belts preserve lane assignments, but the outer lane is
+**1.15234375× longer** (295/256) than the inner lane. Items exit the curve
+at different times but per-lane throughput is unchanged.
+
+### Sideloading (perpendicular feed)
+
+When a belt feeds into the **side** of another belt, its items are merged
+onto **only one lane** of the receiving belt — the lane on the side the
+feeder belt connects from.
+
+- East belt → west side of North belt → items land on the **left lane** of
+  the northbound belt.
+- West belt → east side of North belt → items land on the **right lane**.
+
+This is the primary mechanism for **lane control** (isolating an item type
+to one lane, swapping lanes, or compressing a partially-full belt).
+
+### Inserters
+
+See [[inserter]].
+
+- **Drop:** always on the **far lane** (the lane on the opposite side of the
+  belt from the inserter). When belt and inserter face the same direction,
+  that's the right lane from the belt's perspective.
+- **Pickup:** **prefers the near lane**; falls back to far lane if near is
+  empty.
+
+The drop/pickup asymmetry means a belt loaded by an inserter upstream and
+drained by an inserter downstream won't double-count — the drainer looks at
+a different lane than the loader targeted.
+
+### Splitters
+
+See [[splitter]]. Splitters **preserve lanes**:
+
+> "The left and right lane splitting is now completely independent."
+> — [Splitter](https://wiki.factorio.com/Splitter)
+
+This means the routing decision (which output belt) is made independently
+per lane, **not** that items move between lanes. An item on the left lane
+of an input exits on the left lane of whichever output it's routed to.
+
+**No passive entity in Factorio moves items between lanes.** Lane swapping
+requires a **pair of sideloads**.
+
+## Design patterns that depend on lanes
+
+Several standard Factorio factory patterns exist *only because* belts have
+two lanes:
+
+- **Main bus:** a row of belts with distinct item types on each lane of each
+  belt. Sideloading is used to pull a partial bandwidth off onto branch
+  belts.
+- **Lane balancer:** a pattern of splitters + sideloads that evens out
+  uneven lane loads (common when a smelter array dumps onto a belt
+  asymmetrically).
+- **Lane compressor:** sideloading a partly-full belt onto itself via a
+  loop to fully saturate both lanes.
+
+None of these patterns are meaningful in Factorion's single-lane model.
+
+## What lanes would cost Factorion to add
+
+Rough blast radius if we wanted to add two-lane support:
+
+### Data model
+
+- Every tile channel carrying item flow would need to become two channels
+  (per-lane). Alternatively, keep one channel but double the node count in
+  the flow graph (one node per (tile, lane) pair).
+- Throughput calculation becomes a graph with ~2× nodes and asymmetric
+  edges (sideload = perpendicular cross-lane edge).
+
+### Connection logic (in `entities.rs`)
+
+- Belt→belt forward connection: one edge per lane (2 edges instead of 1).
+- Sideload: one edge from feeder belt (both lanes combined) → specific lane
+  of receiver (1 edge, but to a per-lane node).
+- Inserter drop: edge to `(receiver_belt, far_lane)`.
+- Inserter pickup: two edges with priority (near > far).
+- Splitter: lane-preserving, so edges only connect left→left and
+  right→right, but each lane distributes independently across both outputs
+  (4 edges per input belt: left_in→left_out0, left_in→left_out1,
+  right_in→right_out0, right_in→right_out1). Roughly doubles splitter
+  edge count.
+- Underground belt: lanes persist through the underground segment (2
+  edges).
+
+### Lesson generators
+
+Every lesson that places a belt, inserter, or splitter would need to reason
+about lane assignments. Existing `SPLITTER_SPLIT` / `SPLITTER_MERGE` tests
+that assert throughput caps would need updating (per-lane caps differ from
+combined caps).
+
+### Throughput caps
+
+Current cap "15 i/s per belt" remains, but many scenarios become more
+restrictive: e.g. a single inserter feeding a belt can saturate at most
+7.5 i/s (one lane) rather than 15 i/s.
+
+### Tests
+
+All parity tests (`tests/test_parity.py`) would need to assert per-lane
+throughput against Rust, not just combined throughput.
+
+## When to add lanes
+
+Adding lanes is only worth it if:
+
+1. We want the agent to learn **lane control** as a skill (sideloading,
+   lane compression). This is a meaningful factory-design primitive.
+2. We care about **throughput accuracy** for scenarios where single-lane
+   modelling overstates capacity (e.g. an inserter feeding a belt capped at
+   7.5 i/s, not 15).
+3. We're targeting layouts that rely on main-bus-style designs where each
+   lane carries a distinct item type.
+
+If the current curriculum target (single-item factories up to green
+circuits) can be expressed without lane reasoning, we can defer lanes
+indefinitely.
+
+## Sources
+
+- [Transport belt](https://wiki.factorio.com/Transport_belt)
+- [Transport belts/Physics](https://wiki.factorio.com/Transport_belts/Physics)
+- [Inserter](https://wiki.factorio.com/Inserter)
+- [Splitter](https://wiki.factorio.com/Splitter)


### PR DESCRIPTION
## Summary

- Adds `wiki/two-lane-system.md` as a dedicated reference for Factorio's two independent belt lanes
- Corrects lane-targeting facts across `transport-belt.md`, `inserter.md`, `splitter.md`, `glossary.md`, and `README.md` against the canonical Factorio wiki
- Notable corrections: inserters drop on the **far** lane (not "near"); curve outer lane is 1.15234375× longer (295/256); per-lane spec is 7.5 items/sec, 4 items/tile, 256 internal positions/tile

Two-lane behaviour is **not** modeled in Factorion today — this is groundwork for that decision (tracked in a follow-up issue).

## Test plan
- [x] Pre-push hook (rust fmt/clippy/test, maturin build, ruff, pytest) ran clean
- [ ] Docs-only — no runtime behaviour changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)