### PR TITLE
Gate ffmpeg video rendering behind --capture-video flag

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -1270,7 +1270,7 @@ if __name__ == "__main__":
         if args.track:
             wandb.log(iter_metrics, step=global_step)
 
-        if (iteration-1) % 50 == 0 or iteration + 1 == args.num_iterations:
+        if args.capture_video and ((iteration-1) % 50 == 0 or iteration + 1 == args.num_iterations):
             print(f"Recording agent progress at {iteration}")
             num_render_envs = 5
             render_envs = gym.vector.SyncVectorEnv([make_env(args.env_id, i, False, args.size, run_name) for i in range(num_render_envs)])


### PR DESCRIPTION
## Summary
- The every-50-iterations ffmpeg subprocess in `ppo.py`'s training loop ran unconditionally, breaking runs on machines without ffmpeg installed.
- Gate it on the existing `capture_video` flag (default `False`) so it only runs when explicitly opted in.

## Test plan
- [x] `cargo fmt --check` / `cargo clippy -- -D warnings`
- [x] `cargo test --no-default-features` (46 passed)
- [x] `maturin develop --release`
- [x] `ruff check .`
- [x] `pytest tests/ -v` (1714 passed, 100 skipped)
- [x] PPO smoke test (`--total-timesteps 5000`) completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)