### PR TITLE
Add highlights= kwarg to world2html (fixes visualise_sft_data.py)

### DIFF
--- a/factorion.py
+++ b/factorion.py
@@ -355,7 +355,13 @@ def functions(
         # world[x, y, Channel.MISC.value] = misc.value
 
 
-    def world2html(world_WHC):
+    def world2html(world_WHC, highlights=None):
+        """Render a world tensor as an HTML table.
+
+        highlights: optional {(x, y): css_color_str} to colour specific cells
+        (overrides the default unavailable-footprint shading). Useful for
+        visualising diffs, model predictions, etc.
+        """
         assert len(world_WHC.shape) == 3, (
             f"Expected 3 dimensions got {world_WHC.shape}"
         )
@@ -428,9 +434,12 @@ def functions(
                     world_WHC[x, y, Channel.FOOTPRINT.value]
                     == Footprint.AVAILABLE.value
                 )
-                bg_style = (
-                    "background: rgba(255, 0, 0, 0.3);" if not available else ""
-                )
+                if highlights and (x, y) in highlights:
+                    bg_style = f"background: {highlights[(x, y)]};"
+                else:
+                    bg_style = (
+                        "background: rgba(255, 0, 0, 0.3);" if not available else ""
+                    )
                 #             tint_style = "filter: brightness(1.5) sepia(1) hue-rotate(30deg);" if available else ""
 
                 ghost_imgs = "\n".join(


### PR DESCRIPTION
## Summary
- `scripts/visualise_sft_data.py` (merged in #70) calls `world2html(..., highlights={(x,y): TARGET_COLOR})`, but `world2html` on `main` doesn't accept that kwarg — script is broken on main as-is.
- Cherry-picks `fa4d740` from `sft-pretraining` which adds the optional `highlights={(x,y): css_color}` kwarg. Default behaviour unchanged.

## Test plan
- [x] Pre-push hook (cargo fmt/clippy/test, maturin develop, ruff, pytest) passed locally
- [ ] `python scripts/visualise_sft_data.py` no longer raises TypeError on the highlights kwarg

🤖 Generated with [Claude Code](https://claude.com/claude-code)