### PR TITLE
Fix env step() to fill multi-tile entity footprints

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -395,16 +395,6 @@ class FactorioEnv(gym.Env):
             # agent tried to place a source or sink
             invalid_reason['placed_source_or_sink'] = True
             action_is_invalid = True
-        elif self._world_CWH[self.Channel.FOOTPRINT.value, x, y] == self.Footprint.UNAVAILABLE.value:
-            # disallow placement on masked-out tiles
-            invalid_reason['placed_on_masked_tile'] = True
-            action_is_invalid = True
-            pass
-        elif entity_to_be_replaced in (source_id, sink_id):
-            # disallow the replacement of the source+sink
-            invalid_reason['replaced_source_or_sink'] = True
-            action_is_invalid = True
-            pass
         elif entity_id == self.str2ent('assembling_machine_1').value and item_id == self.str2item('empty'):
             # Model is trying to place an assembling machine without a recipe
             invalid_reason['place_asm_mach_wo_recipe'] = True
@@ -431,31 +421,59 @@ class FactorioEnv(gym.Env):
             invalid_reason['placement_with_unneeded_misc'] = True
             action_is_invalid = True
             pass
-        elif x + self.entities[entity_id].width > self.size:
-            # The thing is too wide to be placed here
-            invalid_reason['too_wide'] = True
-            action_is_invalid = True
-            pass
-        elif y + self.entities[entity_id].height > self.size:
-            # The thing is too tall to be placed here
-            invalid_reason['too_tall'] = True
-            action_is_invalid = True
-            pass
         else:
-            action_is_invalid = False
-            # If all the above guards didn't catch anything, allow the
-            # placement of the entity
-            self._world_CWH[self.Channel.ENTITIES.value, x, y] = entity_id
-            self._world_CWH[self.Channel.DIRECTION.value, x, y] = direc
-            self._world_CWH[self.Channel.ITEMS.value, x, y] = item_id
-            self._world_CWH[self.Channel.MISC.value, x, y] = misc
-            self.actions[-1] = {
-                'entity': self.entities[entity_id].name,
-                'xy': (x, y),
-                'direction': self.Direction(direc),
-                'item': self.items[item_id].name,
-                'misc': self.Misc(misc),
-            }
+            # Compute the entity's full footprint (anchor for 1x1, all
+            # occupied tiles for multi-tile). py_entity_tiles handles
+            # rotation correctly; the previous x+width/y+height bounds
+            # checks were direction-agnostic and wrong for rotated splitters.
+            proto = self.entities[entity_id]
+            tiles_list = factorion_rs.py_entity_tiles(x, y, direc, proto.width, proto.height)
+            if tiles_list is None:
+                tiles_list = [(x, y)]
+            tiles_list = [tuple(t) for t in tiles_list]
+
+            # Validate every tile of the footprint. Multi-tile placements
+            # were previously only validated at the anchor, so a splitter
+            # could overlap an existing belt at its secondary tile or
+            # extend off-grid undetected.
+            out_of_bounds = any(
+                not (0 <= tx < self.size and 0 <= ty < self.size)
+                for tx, ty in tiles_list
+            )
+            if out_of_bounds:
+                invalid_reason['too_wide'] = True
+                action_is_invalid = True
+            elif any(
+                self._world_CWH[self.Channel.FOOTPRINT.value, tx, ty]
+                    == self.Footprint.UNAVAILABLE.value
+                for tx, ty in tiles_list
+            ):
+                invalid_reason['placed_on_masked_tile'] = True
+                action_is_invalid = True
+            elif any(
+                int(self._world_CWH[self.Channel.ENTITIES.value, tx, ty]) in (source_id, sink_id)
+                for tx, ty in tiles_list
+            ):
+                invalid_reason['replaced_source_or_sink'] = True
+                action_is_invalid = True
+            else:
+                action_is_invalid = False
+                # Write entity_id and direction at every tile of the
+                # footprint, matching how lessons and place_multi_tile
+                # represent multi-tile entities. Items + misc go on the
+                # anchor only (those channels are anchor-scoped).
+                for tx, ty in tiles_list:
+                    self._world_CWH[self.Channel.ENTITIES.value, tx, ty] = entity_id
+                    self._world_CWH[self.Channel.DIRECTION.value, tx, ty] = direc
+                self._world_CWH[self.Channel.ITEMS.value, x, y] = item_id
+                self._world_CWH[self.Channel.MISC.value, x, y] = misc
+                self.actions[-1] = {
+                    'entity': self.entities[entity_id].name,
+                    'xy': (x, y),
+                    'direction': self.Direction(direc),
+                    'item': self.items[item_id].name,
+                    'misc': self.Misc(misc),
+                }
 
         self.invalid_actions += 1 if action_is_invalid else 0
 

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -253,3 +253,152 @@ class TestThroughputWithMask:
 
         assert t1 == t2
         assert u1 == u2
+
+
+class TestMultiTilePlacement:
+    """One agent action placing a multi-tile entity must fill the entity's
+    full footprint (anchor + secondaries), matching how the lesson
+    generators and place_multi_tile represent multi-tile entities."""
+
+    DIRS = [Direction.NORTH, Direction.EAST, Direction.SOUTH, Direction.WEST]
+
+    @pytest.fixture()
+    def big_env(self, registered_env):
+        envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, 8, "test")])
+        env = envs.envs[0].unwrapped
+        env.reset(options={"num_missing_entities": 0})
+        # Manually configure the world: keep just one source and one sink
+        # (the env's reward calc asserts on that), clear everything else,
+        # and reset the FOOTPRINT mask. This gives us a clean canvas for
+        # the multi-tile placement assertions.
+        size = env.size
+        env._world_CWH[Channel.ENTITIES.value, :, :] = str2ent("empty").value
+        env._world_CWH[Channel.DIRECTION.value, :, :] = Direction.NONE.value
+        env._world_CWH[Channel.FOOTPRINT.value, :, :] = 1
+        env._world_CWH[Channel.ENTITIES.value, 0, 0] = str2ent("source").value
+        env._world_CWH[Channel.DIRECTION.value, 0, 0] = Direction.EAST.value
+        env._world_CWH[Channel.ENTITIES.value, size - 1, size - 1] = str2ent("sink").value
+        env._world_CWH[Channel.DIRECTION.value, size - 1, size - 1] = Direction.EAST.value
+        return env
+
+    @pytest.mark.parametrize("direction", DIRS, ids=lambda d: d.name)
+    def test_splitter_fills_both_tiles(self, big_env, direction):
+        """Placing a splitter at an anchor must mark BOTH occupied cells."""
+        import factorion_rs
+
+        env = big_env
+        ax, ay = 3, 3
+
+        env.step({
+            "xy": np.array([ax, ay]),
+            "entity": str2ent("splitter").value,
+            "direction": direction.value,
+            "item": 0,
+            "misc": Misc.NONE.value,
+        })
+
+        expected_tiles = factorion_rs.py_entity_tiles(
+            ax, ay, direction.value, 2, 1
+        )
+        assert expected_tiles is not None, "splitter footprint computable"
+        for tx, ty in expected_tiles:
+            assert env._world_CWH[Channel.ENTITIES.value, tx, ty] == str2ent("splitter").value, (
+                f"direction={direction.name}: tile ({tx},{ty}) should hold splitter"
+            )
+            assert env._world_CWH[Channel.DIRECTION.value, tx, ty] == direction.value, (
+                f"direction={direction.name}: tile ({tx},{ty}) should carry direction"
+            )
+
+    @pytest.mark.parametrize("direction", DIRS, ids=lambda d: d.name)
+    def test_splitter_secondary_out_of_bounds_rejected(self, big_env, direction):
+        """A splitter placed so its secondary tile lands off-grid must be
+        rejected (previously: anchor-only bounds check let this pass)."""
+        import factorion_rs
+
+        env = big_env
+
+        # Pick an anchor that's in bounds but whose secondary lands off-grid
+        # for the chosen direction. py_entity_tiles tells us the footprint.
+        size = env.size
+        candidates = [(0, 0), (0, size - 1), (size - 1, 0), (size - 1, size - 1)]
+        anchor = None
+        for ax, ay in candidates:
+            tiles = factorion_rs.py_entity_tiles(ax, ay, direction.value, 2, 1)
+            if tiles is None:
+                continue
+            if any(not (0 <= tx < size and 0 <= ty < size) for tx, ty in tiles):
+                anchor = (ax, ay)
+                break
+        if anchor is None:
+            pytest.skip(f"no off-grid splitter footprint at corners for {direction.name}")
+        ax, ay = anchor
+
+        invalid_before = env.invalid_actions
+        env.step({
+            "xy": np.array([ax, ay]),
+            "entity": str2ent("splitter").value,
+            "direction": direction.value,
+            "item": 0,
+            "misc": Misc.NONE.value,
+        })
+        assert env.invalid_actions == invalid_before + 1, (
+            f"direction={direction.name}: secondary off-grid not rejected"
+        )
+        # World must be unchanged at the anchor.
+        assert env._world_CWH[Channel.ENTITIES.value, ax, ay] == str2ent("empty").value
+
+    @pytest.mark.parametrize("direction", DIRS, ids=lambda d: d.name)
+    def test_splitter_secondary_overlaps_source_rejected(self, big_env, direction):
+        """If a splitter's secondary tile would overlap an existing source
+        or sink, the placement must be rejected."""
+        import factorion_rs
+
+        env = big_env
+        ax, ay = 3, 3
+        tiles = factorion_rs.py_entity_tiles(ax, ay, direction.value, 2, 1)
+        secondary = next((t for t in tiles if t != (ax, ay)), None)
+        assert secondary is not None
+        sx, sy = secondary
+        env._world_CWH[Channel.ENTITIES.value, sx, sy] = str2ent("source").value
+
+        invalid_before = env.invalid_actions
+        env.step({
+            "xy": np.array([ax, ay]),
+            "entity": str2ent("splitter").value,
+            "direction": direction.value,
+            "item": 0,
+            "misc": Misc.NONE.value,
+        })
+        assert env.invalid_actions == invalid_before + 1, (
+            f"direction={direction.name}: splitter overlapping source not rejected"
+        )
+        # Source survives.
+        assert env._world_CWH[Channel.ENTITIES.value, sx, sy] == str2ent("source").value
+        # Anchor stays empty.
+        assert env._world_CWH[Channel.ENTITIES.value, ax, ay] == str2ent("empty").value
+
+    @pytest.mark.parametrize("direction", DIRS, ids=lambda d: d.name)
+    def test_splitter_secondary_masked_rejected(self, big_env, direction):
+        """If a splitter's secondary tile is FOOTPRINT=UNAVAILABLE, the
+        whole placement must be rejected (anchor-only mask check used to
+        let this through)."""
+        import factorion_rs
+
+        env = big_env
+        ax, ay = 3, 3
+        tiles = factorion_rs.py_entity_tiles(ax, ay, direction.value, 2, 1)
+        secondary = next(t for t in tiles if t != (ax, ay))
+        env._world_CWH[Channel.FOOTPRINT.value, secondary[0], secondary[1]] = 0
+
+        invalid_before = env.invalid_actions
+        env.step({
+            "xy": np.array([ax, ay]),
+            "entity": str2ent("splitter").value,
+            "direction": direction.value,
+            "item": 0,
+            "misc": Misc.NONE.value,
+        })
+        assert env.invalid_actions == invalid_before + 1, (
+            f"direction={direction.name}: splitter on masked secondary not rejected"
+        )
+        assert env._world_CWH[Channel.ENTITIES.value, ax, ay] == str2ent("empty").value


### PR DESCRIPTION
## Summary

When the agent placed a 2-tile splitter (or any future multi-tile entity) at its anchor, `FactorioEnv.step()` wrote `entity_id` only to the anchor cell, leaving the secondary tile empty. This conflicts with the world-tensor convention used everywhere else (lessons, `place_multi_tile`, throughput graph) and let three bugs slip past validation:

1. **Convention mismatch.** Lessons write entity_id to every cell of a multi-tile entity's footprint so "is this tile occupied?" is a single channel lookup. The agent could not reproduce a lesson's world by replaying its actions — the SFT target world had splitter at (anchor) AND (secondary), but a trained policy's rollout only filled the anchor.
2. **Direction-blind bounds.** `x + width > size` / `y + height > size` ignored direction. A splitter facing NORTH could extend past the right edge undetected; a splitter facing EAST could extend past the bottom.
3. **Anchor-only collision/mask checks.** The FOOTPRINT and source/sink-replacement checks only inspected the anchor, so a splitter could silently overlap an UNAVAILABLE tile or a source/sink at the secondary cell.

## Fix

`step()` now computes the actual footprint via `factorion_rs.py_entity_tiles` (which handles direction correctly) and validates *every* tile for in-bounds, `FOOTPRINT == AVAILABLE`, and not source/sink. On placement, `entity_id` and `direction` are written to every cell of the footprint; `items` and `misc` remain anchor-scoped to match how lessons represent multi-tile entities.

## Tests

`TestMultiTilePlacement` (16 new tests, parametrised over all 4 rotations):
- splitter placement fills both tiles
- secondary off-grid → invalid
- secondary overlaps source → invalid
- secondary masked UNAVAILABLE → invalid

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo test --no-default-features` — 0 tests in this PR's diff, no regressions
- [x] `ruff check .`
- [x] `pytest tests/` — **1730 passed**, 100 skipped (was 1714 before adding the 16 new tests)
- [x] PPO smoke at 5k steps — completes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)