### PR TITLE
Belt corner connection fix + --kind/--final-only viz flags

### DIFF
--- a/factorion.py
+++ b/factorion.py
@@ -420,6 +420,18 @@ def functions(
             Direction.SOUTH.value: (0, 1),
             Direction.WEST.value: (-1, 0),
         }
+        DIR_OPPOSITE = {
+            Direction.NORTH.value: Direction.SOUTH.value,
+            Direction.SOUTH.value: Direction.NORTH.value,
+            Direction.EAST.value: Direction.WEST.value,
+            Direction.WEST.value: Direction.EAST.value,
+        }
+        BORDER_SIDES = [
+            ("n", Direction.NORTH.value, (0, -1)),
+            ("e", Direction.EAST.value, (1, 0)),
+            ("s", Direction.SOUTH.value, (0, 1)),
+            ("w", Direction.WEST.value, (-1, 0)),
+        ]
 
         for y in range(H):
             html.append("<tr>")
@@ -483,31 +495,20 @@ def functions(
                     ]
                 )
 
-                hide_n = hide_e = hide_s = hide_w = False
-                if proto.name in BELT_NAMES and direction in DIR_INT_TO_DELTA:
-                    dx, dy = DIR_INT_TO_DELTA[direction]
-                    side_lead = {(1, 0): "e", (-1, 0): "w", (0, 1): "s", (0, -1): "n"}[(dx, dy)]
-                    side_trail = {"e": "w", "w": "e", "s": "n", "n": "s"}[side_lead]
-                    fb, _ = _belt_at(x + dx, y + dy)
-                    if fb:
-                        if side_lead == "e":
-                            hide_e = True
-                        elif side_lead == "w":
-                            hide_w = True
-                        elif side_lead == "s":
-                            hide_s = True
-                        elif side_lead == "n":
-                            hide_n = True
-                    bb, bd = _belt_at(x - dx, y - dy)
-                    if bb and bd == direction:
-                        if side_trail == "e":
-                            hide_e = True
-                        elif side_trail == "w":
-                            hide_w = True
-                        elif side_trail == "s":
-                            hide_s = True
-                        elif side_trail == "n":
-                            hide_n = True
+                hide_map = {"n": False, "e": False, "s": False, "w": False}
+                if proto.name in BELT_NAMES:
+                    for side_lbl, side_dir, (sx, sy) in BORDER_SIDES:
+                        nb_is_belt, nb_dir = _belt_at(x + sx, y + sy)
+                        if not nb_is_belt:
+                            continue
+                        i_flow_out = direction == side_dir
+                        n_flow_in = nb_dir == DIR_OPPOSITE[side_dir]
+                        if i_flow_out or n_flow_in:
+                            hide_map[side_lbl] = True
+                hide_n = hide_map["n"]
+                hide_e = hide_map["e"]
+                hide_s = hide_map["s"]
+                hide_w = hide_map["w"]
 
                 def _border_css(prefix, color):
                     return "; ".join(

--- a/scripts/visualise_sft_data.py
+++ b/scripts/visualise_sft_data.py
@@ -53,6 +53,10 @@ class VizArgs:
     """random seed"""
     output_path: str = "sft_training_data.html"
     """where to write the HTML"""
+    final_only: bool = False
+    """if set, render one solved (completed) factory per lesson instead of
+    each (state, action) pair — useful for eyeballing variety in
+    generated lessons rather than the SFT training stream"""
 
 
 
@@ -77,10 +81,27 @@ def main(args: VizArgs) -> None:
             solved, _ = generate_lesson(
                 size=args.size, kind=kind, num_missing_entities=0, seed=seed,
             )
-            task, _ = generate_lesson(
-                size=args.size, kind=kind, num_missing_entities=level, seed=seed,
-            )
+            if not args.final_only:
+                task, _ = generate_lesson(
+                    size=args.size, kind=kind, num_missing_entities=level, seed=seed,
+                )
         except Exception:
+            continue
+
+        if args.final_only:
+            world_html = world2html(solved.permute(1, 2, 0)).text
+            sections.append(
+                f"""
+                <div class="card">
+                  <div class="card-head">
+                    #{samples_so_far + 1} · {kind.name} · seed={seed}
+                  </div>
+                  {world_html}
+                </div>
+                """
+            )
+            kind_counts[kind.name] += 1
+            samples_so_far += 1
             continue
 
         pairs = extract_expert_actions(solved, task)

--- a/scripts/visualise_sft_data.py
+++ b/scripts/visualise_sft_data.py
@@ -53,6 +53,8 @@ class VizArgs:
     """random seed"""
     output_path: str = "sft_training_data.html"
     """where to write the HTML"""
+    kind: str = ""
+    """if set, only render this LessonKind (e.g. ASSEMBLE_1IN_1OUT)"""
     final_only: bool = False
     """if set, render one solved (completed) factory per lesson instead of
     each (state, action) pair — useful for eyeballing variety in
@@ -65,7 +67,10 @@ def main(args: VizArgs) -> None:
     random.seed(args.seed)
     torch.manual_seed(args.seed)
     max_level = args.max_level if args.max_level > 0 else 2 * args.size
-    kinds = list(LessonKind)
+    if args.kind:
+        kinds = [LessonKind[args.kind]]
+    else:
+        kinds = list(LessonKind)
 
     sections: list[str] = []
     kind_counts: dict[str, int] = {k.name: 0 for k in kinds}


### PR DESCRIPTION
## Summary
Three small follow-ups that didn't make it into #73 before it merged:

1. **Fix belt corner connections** — the previous rule only hid the trailing edge when the back-neighbor had the same direction as the current cell. That missed perpendicular feeds like
   ```
   _ll
   __u
   ```
   where the up-belt at (2,1) flows north into the west-chain at (2,0). Replaced with a per-side rule: for each side of a belt, hide it iff the neighbor on that side is a belt and either I flow toward it or it flows toward me. Symmetric, so both cells agree on the shared edge.

2. **Add `--final-only` to `visualise_sft_data.py`** — renders one solved factory per lesson instead of every (state, action) pair. Useful for eyeballing variety in generated lessons rather than the SFT training stream.

3. **Add `--kind` filter to `visualise_sft_data.py`** — restrict rendering to a single `LessonKind`. Cherry-picked from `sft-pretraining` (commit `6048e03`).

## Test plan
- [x] Pre-push hook (cargo fmt/clippy/test, maturin develop, ruff, pytest 1730 passed) green
- [x] Manual: rendered the `_ll/__u` corner case and confirmed the south border between (2,0) and (2,1) is now transparent
- [ ] Eyeball `python scripts/visualise_sft_data.py --kind ASSEMBLE_1IN_1OUT --final-only`

🤖 Generated with [Claude Code](https://claude.com/claude-code)