### PR TITLE
Assembler 1-in-1-out lessons + recipe/items SOT migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ summary.json
 .env
 sft_summary.json
 sft_checkpoint.pt
+claude-resume.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,23 @@ All six must pass before the work is considered complete.
 - Experiment runs are tracked with Weights & Biases.
 - The project uses pinned dependencies in `requirements.txt`.
 
+## Rust Type System
+
+**Make invalid states unrepresentable.** Anything that can be encoded in
+the Rust type system — non-empty collections, mutually exclusive states,
+pre/post-conditions on construction — should be expressed as types
+rather than checked at runtime. Compile-time guarantees are strictly
+preferable to runtime asserts or unit tests that re-check static data.
+
+Useful crates:
+- [`nonempty`](https://docs.rs/nonempty/) — `NonEmpty<T>` for collections
+  that must contain at least one element. Use this instead of
+  `Vec<T>` + a runtime `is_empty()` check.
+
+If a runtime test reads "this hardcoded data is non-empty / has positive
+values / has the right shape", that test is a smell — express the
+invariant in the type instead, and delete the test.
+
 ## Personal Preferences
 
 - Always run smoke tests before claiming work is done.

--- a/factorion.py
+++ b/factorion.py
@@ -1491,7 +1491,9 @@ def functions(
         return G
 
 
-    def _remove_entities(world_CWH, num_missing_entities, total_entities, protected_positions=None):
+    def _remove_entities(
+        world_CWH, num_missing_entities, total_entities, protected_positions=None
+    ):
         """Remove entities from a completed lesson, respecting multi-tile units.
 
         Also sets the FOOTPRINT channel: cells empty in the completed layout
@@ -1500,10 +1502,12 @@ def functions(
         them as the buildable region the agent is meant to fill).
 
         protected_positions: optional set of (x, y) the lesson considers
-        structurally required (e.g. the central inserter in INSERTER_TRANSFER).
-        Any entity-group containing one of these tiles is excluded from the
-        removable pool, so the agent always sees those entities in its input.
-        Source/sink are protected unconditionally via the entity-id `skip` set.
+        structurally required (e.g. the central inserter in INSERTER_TRANSFER,
+        or the recipe-bearing assembler in ASSEMBLE_1IN_1OUT). Any
+        entity-group containing one of these tiles is excluded from the
+        removable pool, so the agent always sees those entities in its
+        input. Source/sink are protected unconditionally via the entity-id
+        `skip` set below.
 
         Returns min_entities_required (number of entity units removed).
         For multi-tile entities (e.g. splitters), all tiles are removed together
@@ -1516,6 +1520,7 @@ def functions(
         empty_id = str2ent("empty").value
         empty_mask = world_CWH[Channel.ENTITIES.value] == empty_id
         world_CWH[Channel.FOOTPRINT.value][empty_mask] = Footprint.UNAVAILABLE.value
+
 
         if num_missing_entities == float("inf"):
             return total_entities

--- a/factorion.py
+++ b/factorion.py
@@ -71,7 +71,7 @@ def _():
 
 
 @app.cell(hide_code=True)
-def datatypes(Enum, dataclass, mo):
+def datatypes(Enum, dataclass, factorion_rs, mo):
     class Channel(Enum):
         # What entity occupies this tile?
         ENTITIES = 0
@@ -111,63 +111,45 @@ def datatypes(Enum, dataclass, mo):
         WEST = 4
 
 
+    # Unified Item dataclass. Everything in the data model is an Item;
+    # `is_placeable=True` items can be placed on the grid as entities.
+    # Width/height/flow are entity properties — non-placeable items
+    # default to 1×1 and 0 flow.
     @dataclass
     class Item:
         name: str
         value: int
-
-
-    @dataclass
-    class Entity:
-        name: str
-        value: int
-        flow: float
+        is_placeable: bool
         width: int
         height: int
+        flow: float
 
 
-    # NOTE: Don't forget to update the "value" as well as the order
+    # Items are defined in Rust (factorion_rs/src/types.rs::all_items)
+    # and exposed to Python via PyO3. To add or change an item, edit
+    # the Rust enum + all_items() and rebuild the wheel.
+    #
+    # The dict additionally contains a synthetic 0 → "empty" entry used
+    # purely as a tensor-decode sentinel for cells with no item set.
+    # `Item` itself has no Empty variant in Rust — absence of an item
+    # is `Option::None`. The Python sentinel is just for `items[v]`
+    # lookups when reading the world tensor's ENTITIES or ITEMS channel.
     items = {
-        0: Item(name="empty", value=0),
-        1: Item(name="copper_cable", value=1),
-        2: Item(name="copper_plate", value=2),
-        3: Item(name="iron_plate", value=3),
-        4: Item(name="electronic_circuit", value=4),
+        0: Item(name="empty", value=0, is_placeable=False, width=1, height=1, flow=0.0),
     }
+    for _val, _props in factorion_rs.py_items().items():
+        items[_val] = Item(value=_val, **_props)
 
-    # Also update the pretty printer
-    entities = {
-        0: Entity(name="empty", value=0, width=1, height=1, flow=0.0),
-        1: Entity(name="transport_belt", value=1, width=1, height=1, flow=15.0),
-        2: Entity(name="inserter", value=2, width=1, height=1, flow=0.86),
-        3: Entity(
-            name="assembling_machine_1", value=3, width=3, height=3, flow=0.5
-        ),
-        # underground (which is identical to a transport belt)
-        4: Entity(name="underground_belt", value=4, width=1, height=1, flow=15.0),
-        # splitter: 2 tiles wide perpendicular to flow, 1 tile deep
-        # 2 input belts × 2 lanes × 7.5 i/s per lane = 30 i/s total
-        5: Entity(name="splitter", value=5, width=2, height=1, flow=30.0),
-        # sink and source live last so the agent's entity head can exclude
-        # them via num_entities = len(entities) - 2 (they are env-spawned,
-        # not agent-placeable).
-        6: Entity(
-            name="bulk_inserter", value=6, width=1, height=1, flow=float("inf")
-        ),
-        7: Entity(
-            name="stack_inserter", value=7, width=1, height=1, flow=float("inf")
-        ),
-        #     4:  Entity(name='copper_cable',          value=4,  width=1, height=1, flow=0.0),
-        #     6:  Entity(name='copper_plate',          value=6,  width=1, height=1, flow=0.0),
-        #     5:  Entity(name='copper_ore',            value=5,  width=1, height=1, flow=0.0),
-        #     7:  Entity(name='electric_mining_drill', value=7,  width=3, height=3, flow=0.5),
-        # 1:  Entity(name='electronic_circuit',    value=1,  width=1, height=1, flow=0.0),
-        #     9:  Entity(name='hazard_concrete',       value=9,  width=1, height=1, flow=0.0),
-        #     11: Entity(name='iron_ore',              value=11, width=1, height=1, flow=0.0),
-        #     12: Entity(name='iron_plate',            value=12, width=1, height=1, flow=0.0),
-        #     13: Entity(name='splitter',              value=13, width=2, height=1, flow=15.0),
-        #     14: Entity(name='steel_chest',           value=14, width=1, height=1, flow=0.0),
-    }
+    # `entities` is an alias for `items` for backwards compatibility.
+    # Post-unification, every grid-placeable entity is also an Item, so
+    # `entities[v]` returns the same dataclass as `items[v]`. The Rust
+    # binding hands us the canonical ordering: 1..5 = agent-placeable
+    # (TB, Inserter, AM1, UB, Splitter), 6..7 = env-spawned (Sink,
+    # Source — placed last so the policy head can exclude them via
+    # len(entities)-2), 8..12 = non-placeable items.
+    entities = items
+    # Backwards-compat alias for the now-unified Item dataclass.
+    Entity = Item
 
 
     @dataclass
@@ -176,15 +158,15 @@ def datatypes(Enum, dataclass, mo):
         produces: dict[str, float]
 
 
+    # Recipes are defined in Rust (factorion_rs/src/types.rs::all_recipes)
+    # and exposed to Python via PyO3. To add a recipe, edit the Rust
+    # function and rebuild the wheel — Python sees it automatically.
     recipes = {
-        "electronic_circuit": Recipe(
-            consumes={"copper_cable": 6.0, "iron_plate": 2.0},
-            produces={"electronic_circuit": 2.0},
-        ),
-        "copper_cable": Recipe(
-            consumes={"copper_plate": 2.0},
-            produces={"copper_cable": 4.0},
-        ),
+        name: Recipe(
+            consumes=dict(data["consumes"]),
+            produces=dict(data["produces"]),
+        )
+        for name, data in factorion_rs.py_recipes().items()
     }
 
 

--- a/factorion.py
+++ b/factorion.py
@@ -2377,8 +2377,13 @@ def functions(
                 if tp <= 0:
                     continue
 
+                # The assembler + its recipe is structurally required: the
+                # recipe channel cannot be inferred from belts alone, so
+                # without the assembler the lesson is ambiguous. Protect
+                # all 9 assembler tiles from blanking.
                 min_entities_required = _remove_entities(
-                    world_CWH, num_missing_entities, total_entities
+                    world_CWH, num_missing_entities, total_entities,
+                    protected_positions=asm_tiles,
                 )
 
                 break

--- a/factorion.py
+++ b/factorion.py
@@ -175,6 +175,7 @@ def datatypes(Enum, dataclass, factorion_rs, mo):
         INSERTER_TRANSFER = 2
         SPLITTER_SPLIT = 3
         SPLITTER_MERGE = 4
+        ASSEMBLE_1IN_1OUT = 5
 
 
     # Map Enum <--> grid deltas
@@ -2146,6 +2147,239 @@ def functions(
             if count == 0:
                 raise Exception(
                     f"Failed to find valid SPLITTER_MERGE lesson after {original_count} attempts"
+                )
+
+        elif kind.value == LessonKind.ASSEMBLE_1IN_1OUT.value:
+            # source → belt → input inserter → 3x3 assembler (with recipe) →
+            # output inserter → belt → sink. Recipe is randomly chosen from
+            # all 1-input 1-output recipes (copper_cable, iron_gear_wheel
+            # at the time of writing).
+            one_in_one_out = [
+                (name, r)
+                for name, r in recipes.items()
+                if len(r.consumes) == 1 and len(r.produces) == 1
+            ]
+            if not one_in_one_out:
+                raise Exception("No 1-input 1-output recipes available")
+
+            original_count = max(500, size * size * 12)
+            count = original_count
+            asm_ent = str2ent("assembling_machine_1")
+
+            # The 12 non-corner perimeter slots around a 3×3 assembler
+            # anchored at (ax, ay), expressed as (offset_x, offset_y,
+            # input_dir, output_dir). Input inserter direction faces
+            # *into* the assembler body; output direction faces *out*.
+            perim_slots = [
+                # North side (ddy = -1): above the top row
+                (0, -1, Direction.SOUTH, Direction.NORTH),
+                (1, -1, Direction.SOUTH, Direction.NORTH),
+                (2, -1, Direction.SOUTH, Direction.NORTH),
+                # South side (ddy = 3): below the bottom row
+                (0, 3, Direction.NORTH, Direction.SOUTH),
+                (1, 3, Direction.NORTH, Direction.SOUTH),
+                (2, 3, Direction.NORTH, Direction.SOUTH),
+                # West side (ddx = -1)
+                (-1, 0, Direction.EAST, Direction.WEST),
+                (-1, 1, Direction.EAST, Direction.WEST),
+                (-1, 2, Direction.EAST, Direction.WEST),
+                # East side (ddx = 3)
+                (3, 0, Direction.WEST, Direction.EAST),
+                (3, 1, Direction.WEST, Direction.EAST),
+                (3, 2, Direction.WEST, Direction.EAST),
+            ]
+
+            while count > 0:
+                count -= 1
+                world_CWH = torch.tensor(new_world(width=size, height=size)).permute(
+                    2, 0, 1
+                )
+                C, W, H = world_CWH.shape
+
+                # 3×3 assembler can't fit
+                if W < 3 or H < 3:
+                    raise Exception(
+                        f"Grid {W}×{H} too small for ASSEMBLE_1IN_1OUT (need ≥ 3×3)"
+                    )
+
+                # Pick recipe + items
+                recipe_name, recipe = random.choice(one_in_one_out)
+                input_item_name = next(iter(recipe.consumes.keys()))
+                output_item_name = next(iter(recipe.produces.keys()))
+                recipe_item_value = str2item(recipe_name).value
+                input_item_value = str2item(input_item_name).value
+                output_item_value = str2item(output_item_name).value
+
+                # Pick assembler anchor
+                ax = random.randint(0, W - 3)
+                ay = random.randint(0, H - 3)
+                asm_tiles = {
+                    (ax + dx, ay + dy) for dx in range(3) for dy in range(3)
+                }
+
+                # Pick distinct input + output perimeter slots
+                in_slot, out_slot = random.sample(perim_slots, 2)
+                in_dx, in_dy, in_inserter_dir, _ = in_slot
+                out_dx, out_dy, _, out_inserter_dir = out_slot
+
+                in_inserter_pos = (ax + in_dx, ay + in_dy)
+                out_inserter_pos = (ax + out_dx, ay + out_dy)
+
+                in_dir_delta = DIR_TO_DELTA[in_inserter_dir]
+                out_dir_delta = DIR_TO_DELTA[out_inserter_dir]
+
+                # Belt cell that feeds the input inserter (its pickup):
+                in_pickup = (
+                    in_inserter_pos[0] - in_dir_delta[0],
+                    in_inserter_pos[1] - in_dir_delta[1],
+                )
+                # Belt cell where the output inserter drops:
+                out_drop = (
+                    out_inserter_pos[0] + out_dir_delta[0],
+                    out_inserter_pos[1] + out_dir_delta[1],
+                )
+
+                # All key cells in bounds
+                key_cells = [in_inserter_pos, out_inserter_pos, in_pickup, out_drop]
+                if any(not (0 <= c[0] < W and 0 <= c[1] < H) for c in key_cells):
+                    continue
+                # Distinct + outside assembler body
+                if len(set(key_cells)) != len(key_cells):
+                    continue
+                if any(c in asm_tiles for c in key_cells):
+                    continue
+
+                # Pick source + sink positions outside everything reserved
+                reserved = asm_tiles | set(key_cells)
+                available = [
+                    (x, y)
+                    for x in range(W)
+                    for y in range(H)
+                    if (x, y) not in reserved
+                ]
+                if len(available) < 2:
+                    continue
+
+                source_pos, sink_pos = random.sample(available, 2)
+                dirs = [d for d in Direction if d != Direction.NONE]
+                source_dir = random.choice(dirs)
+                sink_dir = random.choice(dirs)
+
+                ds = DIR_TO_DELTA[source_dir]
+                dk = DIR_TO_DELTA[sink_dir]
+                source_output = (source_pos[0] + ds[0], source_pos[1] + ds[1])
+                sink_input = (sink_pos[0] - dk[0], sink_pos[1] - dk[1])
+
+                # Source-output / sink-input must be in bounds and not overlap reserved
+                if not (0 <= source_output[0] < W and 0 <= source_output[1] < H):
+                    continue
+                if not (0 <= sink_input[0] < W and 0 <= sink_input[1] < H):
+                    continue
+                if source_output in reserved or sink_input in reserved:
+                    continue
+                if source_output == sink_input:
+                    continue
+
+                all_fixed = reserved | {source_pos, sink_pos}
+
+                # Path 1: source_output → in_pickup. Last belt orients toward
+                # the input inserter (matching INSERTER_TRANSFER convention).
+                blocked1 = (
+                    asm_tiles
+                    | {in_inserter_pos, out_inserter_pos, source_pos, sink_pos,
+                       sink_input, out_drop}
+                )
+                path1 = find_belt_path(
+                    W, H, source_output, in_pickup, in_inserter_dir, blocked1
+                )
+                if path1 is None:
+                    continue
+                path1_cells = {(x, y) for x, y, _ in path1}
+
+                # Path 2: out_drop → sink_input. Last belt orients toward sink.
+                blocked2 = (
+                    asm_tiles
+                    | {in_inserter_pos, out_inserter_pos, source_pos, sink_pos,
+                       in_pickup, source_output}
+                    | path1_cells
+                )
+                path2 = find_belt_path(
+                    W, H, out_drop, sink_input, sink_dir, blocked2
+                )
+                if path2 is None:
+                    continue
+
+                # 1 assembler + 2 inserters + belts (assembler counts as 1
+                # entity even though it occupies 9 tiles).
+                total_entities = len(path1) + len(path2) + 3
+                if total_entities > max_entities:
+                    continue
+
+                # Place source
+                world_CWH[Channel.ENTITIES.value, source_pos[0], source_pos[1]] = (
+                    str2ent("source").value
+                )
+                world_CWH[Channel.DIRECTION.value, source_pos[0], source_pos[1]] = (
+                    source_dir.value
+                )
+                world_CWH[Channel.ITEMS.value, source_pos[0], source_pos[1]] = (
+                    input_item_value
+                )
+
+                # Place sink
+                world_CWH[Channel.ENTITIES.value, sink_pos[0], sink_pos[1]] = (
+                    str2ent("sink").value
+                )
+                world_CWH[Channel.DIRECTION.value, sink_pos[0], sink_pos[1]] = (
+                    sink_dir.value
+                )
+                world_CWH[Channel.ITEMS.value, sink_pos[0], sink_pos[1]] = (
+                    output_item_value
+                )
+
+                # Place assembler (3×3, all tiles tagged with the recipe item)
+                for tx, ty in asm_tiles:
+                    world_CWH[Channel.ENTITIES.value, tx, ty] = asm_ent.value
+                    world_CWH[Channel.DIRECTION.value, tx, ty] = (
+                        Direction.NORTH.value
+                    )
+                    world_CWH[Channel.ITEMS.value, tx, ty] = recipe_item_value
+
+                # Place input + output inserters
+                world_CWH[
+                    Channel.ENTITIES.value, in_inserter_pos[0], in_inserter_pos[1]
+                ] = str2ent("inserter").value
+                world_CWH[
+                    Channel.DIRECTION.value, in_inserter_pos[0], in_inserter_pos[1]
+                ] = in_inserter_dir.value
+
+                world_CWH[
+                    Channel.ENTITIES.value, out_inserter_pos[0], out_inserter_pos[1]
+                ] = str2ent("inserter").value
+                world_CWH[
+                    Channel.DIRECTION.value, out_inserter_pos[0], out_inserter_pos[1]
+                ] = out_inserter_dir.value
+
+                # Place belt paths
+                for x, y, d in path1 + path2:
+                    world_CWH[Channel.ENTITIES.value, x, y] = str2ent(
+                        "transport_belt"
+                    ).value
+                    world_CWH[Channel.DIRECTION.value, x, y] = d.value
+
+                # Verify throughput > 0
+                tp, _ = funge_throughput(world_CWH.permute(1, 2, 0))
+                if tp <= 0:
+                    continue
+
+                min_entities_required = _remove_entities(
+                    world_CWH, num_missing_entities, total_entities
+                )
+
+                break
+            if count == 0:
+                raise Exception(
+                    f"Failed to find valid ASSEMBLE_1IN_1OUT lesson after {original_count} attempts"
                 )
         else:
             raise Exception(f"Can't handle {kind}")

--- a/factorion_rs/Cargo.lock
+++ b/factorion_rs/Cargo.lock
@@ -18,6 +18,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 name = "factorion_rs"
 version = "0.1.0"
 dependencies = [
+ "nonempty",
  "numpy",
  "pyo3",
 ]
@@ -76,6 +77,12 @@ dependencies = [
  "portable-atomic-util",
  "rawpointer",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "549e471b99ccaf2f89101bec68f4d244457d5a95a9c3d0672e9564124397741d"
 
 [[package]]
 name = "num-complex"

--- a/factorion_rs/Cargo.toml
+++ b/factorion_rs/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 pyo3 = { version = "0.23", optional = true }
 numpy = { version = "0.23", optional = true }
+nonempty = "0.11"
 
 [features]
 default = ["pyo3-bindings"]

--- a/factorion_rs/src/entities.rs
+++ b/factorion_rs/src/entities.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::types::{get_recipe, Direction, EntityKind, Item, Misc, NodeId, Pos};
+use crate::types::{get_recipe, Direction, Item, Misc, NodeId, Pos};
 use crate::world::World;
 
 /// An edge in the factory graph: (source_node, destination_node).
@@ -14,8 +14,8 @@ pub type Edge = (NodeId, NodeId);
 /// - Its maximum throughput rate
 pub trait FactoryEntity {
     /// Which entity kind this is. Used to look up flow_rate from the
-    /// single source of truth in EntityKind::flow_rate().
-    fn kind(&self) -> EntityKind;
+    /// single source of truth in Item::flow_rate().
+    fn kind(&self) -> Item;
 
     /// Return the edges this entity contributes to the graph.
     fn connections(&self, pos: (usize, usize), dir: Direction, world: &World) -> Vec<Edge>;
@@ -24,13 +24,14 @@ pub trait FactoryEntity {
     fn transform_flow(&self, input: &HashMap<Item, f64>) -> HashMap<Item, f64>;
 
     /// Maximum items/second this entity can transfer.
-    /// Default delegates to EntityKind::flow_rate().
+    /// Default delegates to Item::flow_rate().
     fn flow_rate(&self) -> f64 {
         self.kind().flow_rate()
     }
 }
 
 /// Stack-allocated entity dispatch. Wraps concrete entity structs.
+/// Only constructible from placeable Items.
 pub enum EntityEnum {
     TransportBelt(TransportBelt),
     Inserter(Inserter),
@@ -39,28 +40,30 @@ pub enum EntityEnum {
     Sink(Sink),
     Source(Source),
     Splitter(Splitter),
-    Empty(EmptyEntity),
 }
 
 impl EntityEnum {
-    pub fn new(kind: EntityKind, item: Item, misc: Misc) -> Self {
-        match kind {
-            EntityKind::TransportBelt => Self::TransportBelt(TransportBelt),
-            EntityKind::Inserter => Self::Inserter(Inserter),
-            EntityKind::AssemblingMachine1 => {
+    /// Build an EntityEnum from a placeable Item. Returns `None` for
+    /// non-placeable items (caller-side data error — non-placeable
+    /// items should never appear in the entities channel).
+    pub fn new(kind: Item, item: Option<Item>, misc: Misc) -> Option<Self> {
+        Some(match kind {
+            Item::TransportBelt => Self::TransportBelt(TransportBelt),
+            Item::Inserter => Self::Inserter(Inserter),
+            Item::AssemblingMachine1 => {
                 Self::AssemblingMachine(AssemblingMachine { recipe_item: item })
             }
-            EntityKind::UndergroundBelt => Self::UndergroundBelt(UndergroundBelt { misc }),
-            EntityKind::Sink => Self::Sink(Sink),
-            EntityKind::Source => Self::Source(Source { item }),
-            EntityKind::Splitter => Self::Splitter(Splitter),
-            EntityKind::Empty => Self::Empty(EmptyEntity),
-        }
+            Item::UndergroundBelt => Self::UndergroundBelt(UndergroundBelt { misc }),
+            Item::Sink => Self::Sink(Sink),
+            Item::Source => Self::Source(Source { item }),
+            Item::Splitter => Self::Splitter(Splitter),
+            _ => return None,
+        })
     }
 }
 
 impl FactoryEntity for EntityEnum {
-    fn kind(&self) -> EntityKind {
+    fn kind(&self) -> Item {
         match self {
             Self::TransportBelt(e) => e.kind(),
             Self::Inserter(e) => e.kind(),
@@ -69,7 +72,6 @@ impl FactoryEntity for EntityEnum {
             Self::Sink(e) => e.kind(),
             Self::Source(e) => e.kind(),
             Self::Splitter(e) => e.kind(),
-            Self::Empty(e) => e.kind(),
         }
     }
 
@@ -82,7 +84,6 @@ impl FactoryEntity for EntityEnum {
             Self::Sink(e) => e.connections(pos, dir, world),
             Self::Source(e) => e.connections(pos, dir, world),
             Self::Splitter(e) => e.connections(pos, dir, world),
-            Self::Empty(e) => e.connections(pos, dir, world),
         }
     }
 
@@ -95,7 +96,6 @@ impl FactoryEntity for EntityEnum {
             Self::Sink(e) => e.transform_flow(input),
             Self::Source(e) => e.transform_flow(input),
             Self::Splitter(e) => e.transform_flow(input),
-            Self::Empty(e) => e.transform_flow(input),
         }
     }
 }
@@ -105,15 +105,15 @@ impl FactoryEntity for EntityEnum {
 pub struct TransportBelt;
 
 impl FactoryEntity for TransportBelt {
-    fn kind(&self) -> EntityKind {
-        EntityKind::TransportBelt
+    fn kind(&self) -> Item {
+        Item::TransportBelt
     }
 
     fn connections(&self, pos: (usize, usize), dir: Direction, world: &World) -> Vec<Edge> {
         let mut edges = Vec::new();
         let (x, y) = pos;
         let (dx, dy) = dir.delta();
-        let self_id = NodeId::new(EntityKind::TransportBelt, x, y);
+        let self_id = NodeId::new(Item::TransportBelt, x, y);
 
         // Source: the cell behind this belt (opposite of facing direction)
         let src_x = x as i64 - dx;
@@ -121,20 +121,21 @@ impl FactoryEntity for TransportBelt {
         if world.in_bounds(src_x, src_y) {
             let sx = src_x as usize;
             let sy = src_y as usize;
-            let src_entity = world.entity_at(sx, sy);
-            let src_dir = world.direction_at(sx, sy);
-            let src_misc = world.misc_at(sx, sy);
+            if let Some(src_entity) = world.entity_at(sx, sy) {
+                let src_dir = world.direction_at(sx, sy);
+                let src_misc = world.misc_at(sx, sy);
 
-            let src_is_beltish = matches!(
-                src_entity,
-                EntityKind::TransportBelt | EntityKind::UndergroundBelt
-            ) && src_dir == dir
-                // Don't connect from a downwards underground belt
-                && !(src_entity == EntityKind::UndergroundBelt
-                    && src_misc == Misc::UndergroundDown);
+                let src_is_beltish = matches!(
+                    src_entity,
+                    Item::TransportBelt | Item::UndergroundBelt
+                ) && src_dir == dir
+                    // Don't connect from a downwards underground belt
+                    && !(src_entity == Item::UndergroundBelt
+                        && src_misc == Misc::UndergroundDown);
 
-            if src_is_beltish {
-                edges.push((NodeId::new(src_entity, sx, sy), self_id.clone()));
+                if src_is_beltish {
+                    edges.push((NodeId::new(src_entity, sx, sy), self_id.clone()));
+                }
             }
         }
 
@@ -144,18 +145,16 @@ impl FactoryEntity for TransportBelt {
         if world.in_bounds(dst_x, dst_y) {
             let dx_u = dst_x as usize;
             let dy_u = dst_y as usize;
-            let dst_entity = world.entity_at(dx_u, dy_u);
-            let dst_dir = world.direction_at(dx_u, dy_u);
+            if let Some(dst_entity) = world.entity_at(dx_u, dy_u) {
+                let dst_dir = world.direction_at(dx_u, dy_u);
 
-            let dst_is_belt = matches!(
-                dst_entity,
-                EntityKind::TransportBelt | EntityKind::UndergroundBelt
-            );
-            // Don't connect to a belt facing the opposite direction
-            let dst_opposing = dst_is_belt && dst_dir == dir.opposite();
+                let dst_is_belt = matches!(dst_entity, Item::TransportBelt | Item::UndergroundBelt);
+                // Don't connect to a belt facing the opposite direction
+                let dst_opposing = dst_is_belt && dst_dir == dir.opposite();
 
-            if dst_is_belt && !dst_opposing {
-                edges.push((self_id, NodeId::new(dst_entity, dx_u, dy_u)));
+                if dst_is_belt && !dst_opposing {
+                    edges.push((self_id, NodeId::new(dst_entity, dx_u, dy_u)));
+                }
             }
         }
 
@@ -175,12 +174,12 @@ impl FactoryEntity for TransportBelt {
 pub struct Inserter;
 
 impl FactoryEntity for Inserter {
-    fn kind(&self) -> EntityKind {
-        EntityKind::Inserter
+    fn kind(&self) -> Item {
+        Item::Inserter
     }
 
     fn connections(&self, pos: (usize, usize), dir: Direction, world: &World) -> Vec<Edge> {
-        inserter_connections(EntityKind::Inserter, pos, dir, world)
+        inserter_connections(Item::Inserter, pos, dir, world)
     }
 
     fn transform_flow(&self, input: &HashMap<Item, f64>) -> HashMap<Item, f64> {
@@ -194,18 +193,18 @@ impl FactoryEntity for Inserter {
 // ── Assembling Machine ──────────────────────────────────────────────────────
 
 pub struct AssemblingMachine {
-    recipe_item: Item,
+    recipe_item: Option<Item>,
 }
 
 impl FactoryEntity for AssemblingMachine {
-    fn kind(&self) -> EntityKind {
-        EntityKind::AssemblingMachine1
+    fn kind(&self) -> Item {
+        Item::AssemblingMachine1
     }
 
     fn connections(&self, pos: (usize, usize), _dir: Direction, world: &World) -> Vec<Edge> {
         let mut edges = Vec::new();
         let (x, y) = pos;
-        let self_id = NodeId::new(EntityKind::AssemblingMachine1, x, y);
+        let self_id = NodeId::new(Item::AssemblingMachine1, x, y);
 
         // Assembling machines are 3x3. The anchor is the top-left corner.
         // Search the perimeter (ring around the 3x3) for inserters.
@@ -230,15 +229,15 @@ impl FactoryEntity for AssemblingMachine {
 
                 let nx_u = nx as usize;
                 let ny_u = ny as usize;
-                let other_entity = world.entity_at(nx_u, ny_u);
+                let other_entity = match world.entity_at(nx_u, ny_u) {
+                    Some(e) => e,
+                    None => continue,
+                };
 
                 // Only inserter-like entities can interact with assembling machines.
                 // In Python, Source (stack_inserter) and Sink (bulk_inserter)
                 // both contain "inserter" in their name, so they match too.
-                if !matches!(
-                    other_entity,
-                    EntityKind::Inserter | EntityKind::Source | EntityKind::Sink
-                ) {
+                if !matches!(other_entity, Item::Inserter | Item::Source | Item::Sink) {
                     continue;
                 }
 
@@ -268,19 +267,20 @@ impl FactoryEntity for AssemblingMachine {
     }
 
     fn transform_flow(&self, input: &HashMap<Item, f64>) -> HashMap<Item, f64> {
-        if self.recipe_item == Item::Empty {
-            return HashMap::new();
-        }
+        let recipe_item = match self.recipe_item {
+            Some(i) => i,
+            None => return HashMap::new(),
+        };
 
-        let recipe = match get_recipe(self.recipe_item) {
+        let recipe = match get_recipe(recipe_item) {
             Some(r) => r,
             None => return HashMap::new(),
         };
 
         // Find the minimum ratio of available input to required input
         let mut min_ratio: f64 = 1.0;
-        for (item, &required) in &recipe.consumes {
-            let available = input.get(item).copied().unwrap_or(0.0);
+        for &(item, required) in recipe.consumes.iter() {
+            let available = input.get(&item).copied().unwrap_or(0.0);
             let ratio = available / required;
             min_ratio = min_ratio.min(ratio);
         }
@@ -289,7 +289,7 @@ impl FactoryEntity for AssemblingMachine {
         recipe
             .produces
             .iter()
-            .map(|(&item, &rate)| (item, rate * min_ratio))
+            .map(|&(item, rate)| (item, rate * min_ratio))
             .collect()
     }
 }
@@ -301,14 +301,14 @@ pub struct UndergroundBelt {
 }
 
 impl FactoryEntity for UndergroundBelt {
-    fn kind(&self) -> EntityKind {
-        EntityKind::UndergroundBelt
+    fn kind(&self) -> Item {
+        Item::UndergroundBelt
     }
 
     fn connections(&self, pos: (usize, usize), dir: Direction, world: &World) -> Vec<Edge> {
         let mut edges = Vec::new();
         let (x, y) = pos;
-        let self_id = NodeId::new(EntityKind::UndergroundBelt, x, y);
+        let self_id = NodeId::new(Item::UndergroundBelt, x, y);
 
         let max_delta = match self.misc {
             Misc::UndergroundDown => 6usize,
@@ -331,13 +331,16 @@ impl FactoryEntity for UndergroundBelt {
 
             let dst_xu = dst_x as usize;
             let dst_yu = dst_y as usize;
-            let dst_entity = world.entity_at(dst_xu, dst_yu);
+            let dst_entity = match world.entity_at(dst_xu, dst_yu) {
+                Some(e) => e,
+                None => continue,
+            };
 
             let going_underground =
-                dst_entity == EntityKind::UndergroundBelt && self.misc == Misc::UndergroundDown;
+                dst_entity == Item::UndergroundBelt && self.misc == Misc::UndergroundDown;
 
             let cxn_to_belt =
-                matches!(dst_entity, EntityKind::TransportBelt) && self.misc == Misc::UndergroundUp;
+                matches!(dst_entity, Item::TransportBelt) && self.misc == Misc::UndergroundUp;
 
             if going_underground || cxn_to_belt {
                 edges.push((self_id.clone(), NodeId::new(dst_entity, dst_xu, dst_yu)));
@@ -362,23 +365,26 @@ impl FactoryEntity for UndergroundBelt {
 // belts/assemblers ahead. Its special behavior is that it has infinite output.
 
 pub struct Source {
-    item: Item,
+    item: Option<Item>,
 }
 
 impl FactoryEntity for Source {
-    fn kind(&self) -> EntityKind {
-        EntityKind::Source
+    fn kind(&self) -> Item {
+        Item::Source
     }
 
     fn connections(&self, pos: (usize, usize), dir: Direction, world: &World) -> Vec<Edge> {
         // Same connection logic as inserter
-        inserter_connections(EntityKind::Source, pos, dir, world)
+        inserter_connections(Item::Source, pos, dir, world)
     }
 
     fn transform_flow(&self, _input: &HashMap<Item, f64>) -> HashMap<Item, f64> {
-        // Sources produce infinite items
+        // A Source with no item set produces nothing. With one set,
+        // it produces an infinite flow of that item.
         let mut output = HashMap::new();
-        output.insert(self.item, f64::INFINITY);
+        if let Some(item) = self.item {
+            output.insert(item, f64::INFINITY);
+        }
         output
     }
 }
@@ -391,12 +397,12 @@ impl FactoryEntity for Source {
 pub struct Sink;
 
 impl FactoryEntity for Sink {
-    fn kind(&self) -> EntityKind {
-        EntityKind::Sink
+    fn kind(&self) -> Item {
+        Item::Sink
     }
 
     fn connections(&self, pos: (usize, usize), dir: Direction, world: &World) -> Vec<Edge> {
-        inserter_connections(EntityKind::Sink, pos, dir, world)
+        inserter_connections(Item::Sink, pos, dir, world)
     }
 
     fn transform_flow(&self, input: &HashMap<Item, f64>) -> HashMap<Item, f64> {
@@ -410,7 +416,7 @@ impl FactoryEntity for Sink {
 /// Picks up from the entity behind (any non-empty entity), drops onto the
 /// entity ahead (only belts or assembling machines).
 fn inserter_connections(
-    self_kind: EntityKind,
+    self_kind: Item,
     pos: (usize, usize),
     dir: Direction,
     world: &World,
@@ -426,8 +432,7 @@ fn inserter_connections(
     if world.in_bounds(src_x, src_y) {
         let sx = src_x as usize;
         let sy = src_y as usize;
-        let src_entity = world.entity_at(sx, sy);
-        if src_entity != EntityKind::Empty {
+        if let Some(src_entity) = world.entity_at(sx, sy) {
             edges.push((NodeId::new(src_entity, sx, sy), self_id.clone()));
         }
     }
@@ -438,16 +443,15 @@ fn inserter_connections(
     if world.in_bounds(dst_x, dst_y) {
         let dx_u = dst_x as usize;
         let dy_u = dst_y as usize;
-        let dst_entity = world.entity_at(dx_u, dy_u);
-        // Can only insert into belts or assembling machines
-        let dst_is_insertable = matches!(
-            dst_entity,
-            EntityKind::TransportBelt
-                | EntityKind::UndergroundBelt
-                | EntityKind::AssemblingMachine1
-        );
-        if dst_is_insertable {
-            edges.push((self_id, NodeId::new(dst_entity, dx_u, dy_u)));
+        if let Some(dst_entity) = world.entity_at(dx_u, dy_u) {
+            // Can only insert into belts or assembling machines
+            let dst_is_insertable = matches!(
+                dst_entity,
+                Item::TransportBelt | Item::UndergroundBelt | Item::AssemblingMachine1
+            );
+            if dst_is_insertable {
+                edges.push((self_id, NodeId::new(dst_entity, dx_u, dy_u)));
+            }
         }
     }
 
@@ -504,15 +508,15 @@ pub fn entity_tiles(
 pub struct Splitter;
 
 impl FactoryEntity for Splitter {
-    fn kind(&self) -> EntityKind {
-        EntityKind::Splitter
+    fn kind(&self) -> Item {
+        Item::Splitter
     }
 
     fn connections(&self, pos: (usize, usize), dir: Direction, world: &World) -> Vec<Edge> {
         let mut edges = Vec::new();
         let (x, y) = pos;
         let (dx, dy) = dir.delta();
-        let self_id = NodeId::new(EntityKind::Splitter, x, y);
+        let self_id = NodeId::new(Item::Splitter, x, y);
 
         let tiles = match entity_tiles(x, y, dir, 2, 1) {
             Some(t) => t,
@@ -525,19 +529,18 @@ impl FactoryEntity for Splitter {
             let in_pos = Pos::new(tile.x - dx, tile.y - dy);
             if let Some((ix, iy)) = in_pos.to_usize() {
                 if world.in_bounds(in_pos.x, in_pos.y) {
-                    let src_entity = world.entity_at(ix, iy);
-                    let src_dir = world.direction_at(ix, iy);
-                    // Only accept belt-like entities pointing into the splitter
-                    let src_is_belt = matches!(
-                        src_entity,
-                        EntityKind::TransportBelt | EntityKind::UndergroundBelt
-                    ) && src_dir == dir;
-                    // Also accept sources/sinks (they use inserter-style connections)
-                    let src_is_source_sink =
-                        matches!(src_entity, EntityKind::Source | EntityKind::Sink)
-                            && src_dir == dir;
-                    if (src_is_belt || src_is_source_sink) && !tile_set.contains(&in_pos) {
-                        edges.push((NodeId::new(src_entity, ix, iy), self_id.clone()));
+                    if let Some(src_entity) = world.entity_at(ix, iy) {
+                        let src_dir = world.direction_at(ix, iy);
+                        // Only accept belt-like entities pointing into the splitter
+                        let src_is_belt =
+                            matches!(src_entity, Item::TransportBelt | Item::UndergroundBelt)
+                                && src_dir == dir;
+                        // Also accept sources/sinks (they use inserter-style connections)
+                        let src_is_source_sink =
+                            matches!(src_entity, Item::Source | Item::Sink) && src_dir == dir;
+                        if (src_is_belt || src_is_source_sink) && !tile_set.contains(&in_pos) {
+                            edges.push((NodeId::new(src_entity, ix, iy), self_id.clone()));
+                        }
                     }
                 }
             }
@@ -546,20 +549,19 @@ impl FactoryEntity for Splitter {
             let out_pos = Pos::new(tile.x + dx, tile.y + dy);
             if let Some((ox, oy)) = out_pos.to_usize() {
                 if world.in_bounds(out_pos.x, out_pos.y) {
-                    let dst_entity = world.entity_at(ox, oy);
-                    let dst_dir = world.direction_at(ox, oy);
-                    // Only connect to belt-like entities or sinks, not opposing
-                    let dst_is_belt = matches!(
-                        dst_entity,
-                        EntityKind::TransportBelt | EntityKind::UndergroundBelt
-                    );
-                    let dst_is_sink = matches!(dst_entity, EntityKind::Source | EntityKind::Sink);
-                    let dst_not_opposing = dst_dir != dir.opposite();
-                    if (dst_is_belt || dst_is_sink)
-                        && dst_not_opposing
-                        && !tile_set.contains(&out_pos)
-                    {
-                        edges.push((self_id.clone(), NodeId::new(dst_entity, ox, oy)));
+                    if let Some(dst_entity) = world.entity_at(ox, oy) {
+                        let dst_dir = world.direction_at(ox, oy);
+                        // Only connect to belt-like entities or sinks, not opposing
+                        let dst_is_belt =
+                            matches!(dst_entity, Item::TransportBelt | Item::UndergroundBelt);
+                        let dst_is_sink = matches!(dst_entity, Item::Source | Item::Sink);
+                        let dst_not_opposing = dst_dir != dir.opposite();
+                        if (dst_is_belt || dst_is_sink)
+                            && dst_not_opposing
+                            && !tile_set.contains(&out_pos)
+                        {
+                            edges.push((self_id.clone(), NodeId::new(dst_entity, ox, oy)));
+                        }
                     }
                 }
             }
@@ -573,24 +575,6 @@ impl FactoryEntity for Splitter {
             .iter()
             .map(|(&item, &rate)| (item, rate.min(self.flow_rate())))
             .collect()
-    }
-}
-
-// ── Empty ───────────────────────────────────────────────────────────────────
-
-pub struct EmptyEntity;
-
-impl FactoryEntity for EmptyEntity {
-    fn kind(&self) -> EntityKind {
-        EntityKind::Empty
-    }
-
-    fn connections(&self, _pos: (usize, usize), _dir: Direction, _world: &World) -> Vec<Edge> {
-        Vec::new()
-    }
-
-    fn transform_flow(&self, _input: &HashMap<Item, f64>) -> HashMap<Item, f64> {
-        HashMap::new()
     }
 }
 
@@ -695,22 +679,10 @@ mod tests {
     fn make_belt_chain_world() -> World {
         // 5x1 world: Source(east) -> Belt(east) -> Belt(east) -> Sink(east)
         let mut w = World::empty(5, 1);
-        w.place(0, 0, EntityKind::Source, Direction::East, Item::CopperCable);
-        w.place(
-            1,
-            0,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
-        w.place(
-            2,
-            0,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
-        w.place(3, 0, EntityKind::Sink, Direction::East, Item::CopperCable);
+        w.place(0, 0, Item::Source, Direction::East, Some(Item::CopperCable));
+        w.place(1, 0, Item::TransportBelt, Direction::East, None);
+        w.place(2, 0, Item::TransportBelt, Direction::East, None);
+        w.place(3, 0, Item::Sink, Direction::East, Some(Item::CopperCable));
         w
     }
 
@@ -725,8 +697,8 @@ mod tests {
         // Source is behind but it's not a belt, so belt doesn't create that edge
         // Belt at (2,0) is ahead and is a belt with same direction → edge created
         assert_eq!(edges.len(), 1);
-        assert_eq!(edges[0].0, NodeId::new(EntityKind::TransportBelt, 1, 0));
-        assert_eq!(edges[0].1, NodeId::new(EntityKind::TransportBelt, 2, 0));
+        assert_eq!(edges[0].0, NodeId::new(Item::TransportBelt, 1, 0));
+        assert_eq!(edges[0].1, NodeId::new(Item::TransportBelt, 2, 0));
     }
 
     #[test]
@@ -740,28 +712,16 @@ mod tests {
         // Belt at (1,0) behind → edge from (1,0) to (2,0)
         // Sink at (3,0) ahead is not a belt → no forward edge
         assert_eq!(edges.len(), 1);
-        assert_eq!(edges[0].0, NodeId::new(EntityKind::TransportBelt, 1, 0));
-        assert_eq!(edges[0].1, NodeId::new(EntityKind::TransportBelt, 2, 0));
+        assert_eq!(edges[0].0, NodeId::new(Item::TransportBelt, 1, 0));
+        assert_eq!(edges[0].1, NodeId::new(Item::TransportBelt, 2, 0));
     }
 
     #[test]
     fn test_transport_belt_no_opposing_connection() {
         // Two belts facing each other should not connect
         let mut w = World::empty(3, 1);
-        w.place(
-            0,
-            0,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
-        w.place(
-            1,
-            0,
-            EntityKind::TransportBelt,
-            Direction::West,
-            Item::Empty,
-        );
+        w.place(0, 0, Item::TransportBelt, Direction::East, None);
+        w.place(1, 0, Item::TransportBelt, Direction::West, None);
 
         let belt = TransportBelt;
         let edges = belt.connections((0, 0), Direction::East, &w);
@@ -773,15 +733,9 @@ mod tests {
     fn test_inserter_connections() {
         // Inserter at (1,0) facing east, source at (0,0), belt at (2,0)
         let mut w = World::empty(3, 1);
-        w.place(0, 0, EntityKind::Source, Direction::East, Item::Empty);
-        w.place(1, 0, EntityKind::Inserter, Direction::East, Item::Empty);
-        w.place(
-            2,
-            0,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
+        w.place(0, 0, Item::Source, Direction::East, None);
+        w.place(1, 0, Item::Inserter, Direction::East, None);
+        w.place(2, 0, Item::TransportBelt, Direction::East, None);
 
         let inserter = Inserter;
         let edges = inserter.connections((1, 0), Direction::East, &w);
@@ -789,13 +743,13 @@ mod tests {
         assert_eq!(edges.len(), 2);
         // Source → Inserter
         assert!(edges.contains(&(
-            NodeId::new(EntityKind::Source, 0, 0),
-            NodeId::new(EntityKind::Inserter, 1, 0),
+            NodeId::new(Item::Source, 0, 0),
+            NodeId::new(Item::Inserter, 1, 0),
         )));
         // Inserter → Belt
         assert!(edges.contains(&(
-            NodeId::new(EntityKind::Inserter, 1, 0),
-            NodeId::new(EntityKind::TransportBelt, 2, 0),
+            NodeId::new(Item::Inserter, 1, 0),
+            NodeId::new(Item::TransportBelt, 2, 0),
         )));
     }
 
@@ -803,8 +757,8 @@ mod tests {
     fn test_inserter_wont_drop_on_empty() {
         // Inserter facing east, source behind, empty ahead
         let mut w = World::empty(3, 1);
-        w.place(0, 0, EntityKind::Source, Direction::None, Item::Empty);
-        w.place(1, 0, EntityKind::Inserter, Direction::East, Item::Empty);
+        w.place(0, 0, Item::Source, Direction::None, None);
+        w.place(1, 0, Item::Inserter, Direction::East, None);
 
         let inserter = Inserter;
         let edges = inserter.connections((1, 0), Direction::East, &w);
@@ -820,19 +774,19 @@ mod tests {
         w.place(
             1,
             1,
-            EntityKind::AssemblingMachine1,
+            Item::AssemblingMachine1,
             Direction::None,
-            Item::ElectronicCircuit,
+            Some(Item::ElectronicCircuit),
         );
 
         // Inserter at (0,1) facing east → inserting into assembler
-        w.place(0, 1, EntityKind::Inserter, Direction::East, Item::Empty);
+        w.place(0, 1, Item::Inserter, Direction::East, None);
 
         // Inserter at (4,2) facing east → taking from assembler (facing away)
-        w.place(4, 2, EntityKind::Inserter, Direction::East, Item::Empty);
+        w.place(4, 2, Item::Inserter, Direction::East, None);
 
         let asm = AssemblingMachine {
-            recipe_item: Item::ElectronicCircuit,
+            recipe_item: Some(Item::ElectronicCircuit),
         };
         let edges = asm.connections((1, 1), Direction::None, &w);
 
@@ -857,7 +811,7 @@ mod tests {
     #[test]
     fn test_source_transform_flow() {
         let source = Source {
-            item: Item::CopperCable,
+            item: Some(Item::CopperCable),
         };
         let output = source.transform_flow(&HashMap::new());
         assert_eq!(output[&Item::CopperCable], f64::INFINITY);
@@ -866,21 +820,21 @@ mod tests {
     #[test]
     fn test_assembler_transform_flow() {
         let asm = AssemblingMachine {
-            recipe_item: Item::ElectronicCircuit,
+            recipe_item: Some(Item::ElectronicCircuit),
         };
 
-        // Full input: 6 copper cable + 2 iron plate → 2 electronic circuits
-        let input = HashMap::from([(Item::CopperCable, 6.0), (Item::IronPlate, 2.0)]);
-        let output = asm.transform_flow(&input);
-        assert!((output[&Item::ElectronicCircuit] - 2.0).abs() < 1e-9);
-
-        // Half input: 3 copper cable + 2 iron plate → ratio = min(3/6, 2/2) = 0.5
-        let input = HashMap::from([(Item::CopperCable, 3.0), (Item::IronPlate, 2.0)]);
+        // Full input matches recipe exactly: 3 copper cable + 1 iron plate → 1 EC
+        let input = HashMap::from([(Item::CopperCable, 3.0), (Item::IronPlate, 1.0)]);
         let output = asm.transform_flow(&input);
         assert!((output[&Item::ElectronicCircuit] - 1.0).abs() < 1e-9);
 
-        // Missing ingredient
-        let input = HashMap::from([(Item::CopperCable, 6.0)]);
+        // Half copper cable available: ratio = min(1.5/3, 1/1) = 0.5 → 0.5 EC
+        let input = HashMap::from([(Item::CopperCable, 1.5), (Item::IronPlate, 1.0)]);
+        let output = asm.transform_flow(&input);
+        assert!((output[&Item::ElectronicCircuit] - 0.5).abs() < 1e-9);
+
+        // Missing ingredient → 0 output
+        let input = HashMap::from([(Item::CopperCable, 3.0)]);
         let output = asm.transform_flow(&input);
         assert!((output[&Item::ElectronicCircuit] - 0.0).abs() < 1e-9);
     }
@@ -912,8 +866,8 @@ mod tests {
 
         // Should find the underground belt at (3,0)
         assert_eq!(edges.len(), 1);
-        assert_eq!(edges[0].0, NodeId::new(EntityKind::UndergroundBelt, 1, 0));
-        assert_eq!(edges[0].1, NodeId::new(EntityKind::UndergroundBelt, 3, 0));
+        assert_eq!(edges[0].0, NodeId::new(Item::UndergroundBelt, 1, 0));
+        assert_eq!(edges[0].1, NodeId::new(Item::UndergroundBelt, 3, 0));
     }
 
     #[test]
@@ -921,13 +875,7 @@ mod tests {
         // Underground up at (3,0) facing east, belt at (4,0) facing east
         let mut w = World::empty(5, 1);
         w.place_underground(3, 0, Direction::East, Misc::UndergroundUp);
-        w.place(
-            4,
-            0,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
+        w.place(4, 0, Item::TransportBelt, Direction::East, None);
 
         let ub = UndergroundBelt {
             misc: Misc::UndergroundUp,
@@ -947,48 +895,21 @@ mod tests {
         // East-facing splitter at (2,0)/(2,1), belts feeding in and out
         let mut w = World::empty(5, 3);
         // Input belt behind splitter tile (2,0) → at (1,0)
-        w.place(
-            1,
-            0,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
+        w.place(1, 0, Item::TransportBelt, Direction::East, None);
         // Splitter at (2,0) and (2,1)
-        w.place_splitter(2, 0, Direction::East, Item::Empty);
+        w.place_splitter(2, 0, Direction::East, None);
         // Output belts ahead of splitter tiles
-        w.place(
-            3,
-            0,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
-        w.place(
-            3,
-            1,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
+        w.place(3, 0, Item::TransportBelt, Direction::East, None);
+        w.place(3, 1, Item::TransportBelt, Direction::East, None);
 
         let splitter = Splitter;
         let edges = splitter.connections((2, 0), Direction::East, &w);
 
         // Should have: belt(1,0)->splitter, splitter->belt(3,0), splitter->belt(3,1)
-        let self_id = NodeId::new(EntityKind::Splitter, 2, 0);
-        assert!(edges.contains(&(
-            NodeId::new(EntityKind::TransportBelt, 1, 0),
-            self_id.clone()
-        )));
-        assert!(edges.contains(&(
-            self_id.clone(),
-            NodeId::new(EntityKind::TransportBelt, 3, 0)
-        )));
-        assert!(edges.contains(&(
-            self_id.clone(),
-            NodeId::new(EntityKind::TransportBelt, 3, 1)
-        )));
+        let self_id = NodeId::new(Item::Splitter, 2, 0);
+        assert!(edges.contains(&(NodeId::new(Item::TransportBelt, 1, 0), self_id.clone())));
+        assert!(edges.contains(&(self_id.clone(), NodeId::new(Item::TransportBelt, 3, 0))));
+        assert!(edges.contains(&(self_id.clone(), NodeId::new(Item::TransportBelt, 3, 1))));
         assert_eq!(edges.len(), 3);
     }
 
@@ -997,47 +918,20 @@ mod tests {
         // North-facing splitter at (0,2)/(1,2), belts feeding in and out
         let mut w = World::empty(3, 5);
         // Input belt behind splitter tile (0,2) → at (0,3) (south of anchor, since facing north)
-        w.place(
-            0,
-            3,
-            EntityKind::TransportBelt,
-            Direction::North,
-            Item::Empty,
-        );
+        w.place(0, 3, Item::TransportBelt, Direction::North, None);
         // Splitter at (0,2) and (1,2)
-        w.place_splitter(0, 2, Direction::North, Item::Empty);
+        w.place_splitter(0, 2, Direction::North, None);
         // Output belts ahead
-        w.place(
-            0,
-            1,
-            EntityKind::TransportBelt,
-            Direction::North,
-            Item::Empty,
-        );
-        w.place(
-            1,
-            1,
-            EntityKind::TransportBelt,
-            Direction::North,
-            Item::Empty,
-        );
+        w.place(0, 1, Item::TransportBelt, Direction::North, None);
+        w.place(1, 1, Item::TransportBelt, Direction::North, None);
 
         let splitter = Splitter;
         let edges = splitter.connections((0, 2), Direction::North, &w);
 
-        let self_id = NodeId::new(EntityKind::Splitter, 0, 2);
-        assert!(edges.contains(&(
-            NodeId::new(EntityKind::TransportBelt, 0, 3),
-            self_id.clone()
-        )));
-        assert!(edges.contains(&(
-            self_id.clone(),
-            NodeId::new(EntityKind::TransportBelt, 0, 1)
-        )));
-        assert!(edges.contains(&(
-            self_id.clone(),
-            NodeId::new(EntityKind::TransportBelt, 1, 1)
-        )));
+        let self_id = NodeId::new(Item::Splitter, 0, 2);
+        assert!(edges.contains(&(NodeId::new(Item::TransportBelt, 0, 3), self_id.clone())));
+        assert!(edges.contains(&(self_id.clone(), NodeId::new(Item::TransportBelt, 0, 1))));
+        assert!(edges.contains(&(self_id.clone(), NodeId::new(Item::TransportBelt, 1, 1))));
         assert_eq!(edges.len(), 3);
     }
 
@@ -1056,11 +950,9 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_entity() {
-        let e = EmptyEntity;
-        let w = World::empty(3, 3);
-        assert!(e.connections((0, 0), Direction::None, &w).is_empty());
-        assert!(e.transform_flow(&HashMap::new()).is_empty());
-        assert_eq!(e.flow_rate(), 0.0);
+    fn test_entity_enum_new_returns_none_for_non_placeable() {
+        assert!(EntityEnum::new(Item::CopperCable, None, Misc::None).is_none());
+        assert!(EntityEnum::new(Item::IronGearWheel, None, Misc::None).is_none());
+        assert!(EntityEnum::new(Item::TransportBelt, None, Misc::None).is_some());
     }
 }

--- a/factorion_rs/src/graph.rs
+++ b/factorion_rs/src/graph.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::entities::{entity_tiles, EntityEnum, FactoryEntity};
-use crate::types::{EntityKind, Item, Misc, NodeId};
+use crate::types::{Item, Misc, NodeId};
 use crate::world::World;
 
 /// A node in the factory graph.
@@ -9,11 +9,14 @@ use crate::world::World;
 pub struct GraphNode {
     #[allow(dead_code)]
     pub id: NodeId,
-    pub entity_kind: EntityKind,
-    pub item: Item,
+    pub entity_kind: Item,
+    /// The item carried/produced/configured at this tile, if any. `None`
+    /// means the items channel was 0 (no item set).
+    pub item: Option<Item>,
     pub misc: Misc,
-    /// Recipe item for assembling machines (determines what they craft).
-    pub recipe_item: Item,
+    /// Recipe for assembling machines (determines what they craft).
+    /// `None` for non-assemblers and assemblers with no recipe set.
+    pub recipe_item: Option<Item>,
     /// Accumulated input flow rates per item type.
     pub input: HashMap<Item, f64>,
     /// Computed output flow rates per item type.
@@ -71,10 +74,12 @@ pub fn build_graph(world: &World) -> FactoryGraph {
     // First pass: create one node per entity (anchor tile only for multi-tile)
     for x in 0..world.width() {
         for y in 0..world.height() {
-            let entity_kind = world.entity_at(x, y);
-            if entity_kind == EntityKind::Empty {
-                continue;
-            }
+            // Empty cell, or a stray non-placeable item in the entities
+            // channel (data error). Either way, no graph node.
+            let entity_kind = match world.entity_at(x, y) {
+                Some(k) if k.is_placeable() => k,
+                _ => continue,
+            };
 
             if anchor_of.contains_key(&(x, y)) {
                 continue;
@@ -101,9 +106,11 @@ pub fn build_graph(world: &World) -> FactoryGraph {
 
             let node_id = NodeId::new(entity_kind, x, y);
 
-            let output = if entity_kind == EntityKind::Source {
+            let output = if entity_kind == Item::Source {
                 let mut m = HashMap::new();
-                m.insert(item, f64::INFINITY);
+                if let Some(i) = item {
+                    m.insert(i, f64::INFINITY);
+                }
                 m
             } else {
                 HashMap::new()
@@ -115,19 +122,23 @@ pub fn build_graph(world: &World) -> FactoryGraph {
                 entity_kind,
                 item,
                 misc,
-                recipe_item: if entity_kind == EntityKind::AssemblingMachine1 {
+                recipe_item: if entity_kind == Item::AssemblingMachine1 {
                     item
                 } else {
-                    Item::Empty
+                    None
                 },
                 input: HashMap::new(),
                 output,
             });
             node_index.insert(node_id, idx);
 
-            let entity = EntityEnum::new(entity_kind, item, misc);
-            let edges = entity.connections((x, y), direction, world);
-            edge_list.extend(edges);
+            // entity_kind is guaranteed placeable by the loop guard, so
+            // EntityEnum::new always returns Some here. We still match
+            // defensively rather than unwrap.
+            if let Some(entity) = EntityEnum::new(entity_kind, item, misc) {
+                let edges = entity.connections((x, y), direction, world);
+                edge_list.extend(edges);
+            }
         }
     }
 
@@ -186,13 +197,7 @@ mod tests {
     #[test]
     fn test_single_belt_no_edges() {
         let mut w = World::empty(3, 3);
-        w.place(
-            1,
-            1,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
+        w.place(1, 1, Item::TransportBelt, Direction::East, None);
 
         let g = build_graph(&w);
         assert_eq!(g.node_count(), 1);
@@ -204,42 +209,30 @@ mod tests {
     fn test_belt_chain_graph() {
         // Source → Belt → Belt → Sink
         let mut w = World::empty(5, 1);
-        w.place(0, 0, EntityKind::Source, Direction::East, Item::CopperCable);
-        w.place(
-            1,
-            0,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
-        w.place(
-            2,
-            0,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
-        w.place(3, 0, EntityKind::Sink, Direction::East, Item::CopperCable);
+        w.place(0, 0, Item::Source, Direction::East, Some(Item::CopperCable));
+        w.place(1, 0, Item::TransportBelt, Direction::East, None);
+        w.place(2, 0, Item::TransportBelt, Direction::East, None);
+        w.place(3, 0, Item::Sink, Direction::East, Some(Item::CopperCable));
 
         let g = build_graph(&w);
         assert_eq!(g.node_count(), 4);
 
         // Belt(1,0) → Belt(2,0) edge should exist
         let belt1 = g
-            .get_index(&NodeId::new(EntityKind::TransportBelt, 1, 0))
+            .get_index(&NodeId::new(Item::TransportBelt, 1, 0))
             .unwrap();
         let belt2 = g
-            .get_index(&NodeId::new(EntityKind::TransportBelt, 2, 0))
+            .get_index(&NodeId::new(Item::TransportBelt, 2, 0))
             .unwrap();
         assert!(g.successors[belt1].contains(&belt2));
         assert!(g.predecessors[belt2].contains(&belt1));
 
         // Source uses inserter-style connections: drops onto belt at (1,0)
-        let source = g.get_index(&NodeId::new(EntityKind::Source, 0, 0)).unwrap();
+        let source = g.get_index(&NodeId::new(Item::Source, 0, 0)).unwrap();
         assert!(g.successors[source].contains(&belt1));
 
         // Sink picks up from belt at (2,0)
-        let sink = g.get_index(&NodeId::new(EntityKind::Sink, 3, 0)).unwrap();
+        let sink = g.get_index(&NodeId::new(Item::Sink, 3, 0)).unwrap();
         assert!(g.predecessors[sink].contains(&belt2));
     }
 
@@ -247,38 +240,28 @@ mod tests {
     fn test_inserter_chain_graph() {
         // Source → Inserter → Belt → Inserter → Sink
         let mut w = World::empty(5, 1);
-        w.place(0, 0, EntityKind::Source, Direction::East, Item::CopperCable);
-        w.place(1, 0, EntityKind::Inserter, Direction::East, Item::Empty);
-        w.place(
-            2,
-            0,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
-        w.place(3, 0, EntityKind::Inserter, Direction::East, Item::Empty);
-        w.place(4, 0, EntityKind::Sink, Direction::East, Item::CopperCable);
+        w.place(0, 0, Item::Source, Direction::East, Some(Item::CopperCable));
+        w.place(1, 0, Item::Inserter, Direction::East, None);
+        w.place(2, 0, Item::TransportBelt, Direction::East, None);
+        w.place(3, 0, Item::Inserter, Direction::East, None);
+        w.place(4, 0, Item::Sink, Direction::East, Some(Item::CopperCable));
 
         let g = build_graph(&w);
         assert_eq!(g.node_count(), 5);
 
         // Source → Inserter(1,0)
-        let source = g.get_index(&NodeId::new(EntityKind::Source, 0, 0)).unwrap();
-        let ins1 = g
-            .get_index(&NodeId::new(EntityKind::Inserter, 1, 0))
-            .unwrap();
+        let source = g.get_index(&NodeId::new(Item::Source, 0, 0)).unwrap();
+        let ins1 = g.get_index(&NodeId::new(Item::Inserter, 1, 0)).unwrap();
         assert!(g.successors[source].contains(&ins1) || g.predecessors[ins1].contains(&source));
 
         // Inserter(1,0) → Belt(2,0)
         let belt = g
-            .get_index(&NodeId::new(EntityKind::TransportBelt, 2, 0))
+            .get_index(&NodeId::new(Item::TransportBelt, 2, 0))
             .unwrap();
         assert!(g.successors[ins1].contains(&belt));
 
         // Belt(2,0) → Inserter(3,0)
-        let ins2 = g
-            .get_index(&NodeId::new(EntityKind::Inserter, 3, 0))
-            .unwrap();
+        let ins2 = g.get_index(&NodeId::new(Item::Inserter, 3, 0)).unwrap();
         assert!(g.predecessors[ins2].contains(&belt));
     }
 
@@ -286,32 +269,20 @@ mod tests {
     fn test_underground_belt_graph() {
         // Belt → Underground(down) ... Underground(up) → Belt
         let mut w = World::empty(6, 1);
-        w.place(
-            0,
-            0,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
+        w.place(0, 0, Item::TransportBelt, Direction::East, None);
         w.place_underground(1, 0, Direction::East, Misc::UndergroundDown);
         w.place_underground(4, 0, Direction::East, Misc::UndergroundUp);
-        w.place(
-            5,
-            0,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
+        w.place(5, 0, Item::TransportBelt, Direction::East, None);
 
         let g = build_graph(&w);
         assert_eq!(g.node_count(), 4);
 
         // Underground(down,1,0) → Underground(up,4,0)
         let ug_down = g
-            .get_index(&NodeId::new(EntityKind::UndergroundBelt, 1, 0))
+            .get_index(&NodeId::new(Item::UndergroundBelt, 1, 0))
             .unwrap();
         let ug_up = g
-            .get_index(&NodeId::new(EntityKind::UndergroundBelt, 4, 0))
+            .get_index(&NodeId::new(Item::UndergroundBelt, 4, 0))
             .unwrap();
         assert!(g.successors[ug_down].contains(&ug_up));
 
@@ -321,7 +292,7 @@ mod tests {
         // The belt's connections check dst: is it a belt? UndergroundBelt is belt-ish → dst_is_belt = true.
         // Not opposing direction → should connect.
         let belt0 = g
-            .get_index(&NodeId::new(EntityKind::TransportBelt, 0, 0))
+            .get_index(&NodeId::new(Item::TransportBelt, 0, 0))
             .unwrap();
         assert!(g.successors[belt0].contains(&ug_down));
     }

--- a/factorion_rs/src/lib.rs
+++ b/factorion_rs/src/lib.rs
@@ -7,6 +7,10 @@
 #![deny(clippy::unwrap_used)]
 #![deny(clippy::expect_used)]
 
+// `nonempty::nonempty![...]` expands to a path through `::alloc::vec`, which
+// requires `alloc` to be visible at the crate root.
+extern crate alloc;
+
 mod entities;
 mod graph;
 mod throughput;
@@ -17,6 +21,8 @@ mod world;
 use numpy::PyReadonlyArray3;
 #[cfg(feature = "pyo3-bindings")]
 use pyo3::prelude::*;
+#[cfg(feature = "pyo3-bindings")]
+use pyo3::types::PyDict;
 
 #[cfg(feature = "pyo3-bindings")]
 use entities::entity_tiles;
@@ -25,7 +31,7 @@ use graph::build_graph;
 #[cfg(feature = "pyo3-bindings")]
 use throughput::calc_throughput;
 #[cfg(feature = "pyo3-bindings")]
-use types::Direction;
+use types::{all_items, all_recipes, Direction};
 #[cfg(feature = "pyo3-bindings")]
 use world::World;
 
@@ -84,10 +90,66 @@ fn py_entity_tiles(
         .map(|tiles| tiles.into_iter().map(|p| (p.x, p.y)).collect()))
 }
 
+/// Return every Item as a dict keyed by integer value, with full
+/// per-item properties.
+///
+/// Shape: `{int_value: {"name": str, "is_placeable": bool,
+///                      "width": int, "height": int, "flow": float}}`.
+///
+/// Single source of truth for item identity and entity properties —
+/// Python's `items` dict (and the older `entities` dict) are built from
+/// this at module load.
+#[cfg(feature = "pyo3-bindings")]
+#[pyfunction]
+fn py_items(py: Python<'_>) -> PyResult<Py<PyDict>> {
+    let outer = PyDict::new(py);
+    for &item in all_items() {
+        let entry = PyDict::new(py);
+        let (w, h) = item.size();
+        entry.set_item("name", item.name())?;
+        entry.set_item("is_placeable", item.is_placeable())?;
+        entry.set_item("width", w)?;
+        entry.set_item("height", h)?;
+        entry.set_item("flow", item.flow_rate())?;
+        outer.set_item(item as i64, entry)?;
+    }
+    Ok(outer.into())
+}
+
+/// Return all crafting recipes as a Python dict.
+///
+/// Shape: `{item_name: {"consumes": {item_name: rate, ...},
+///                      "produces": {item_name: rate, ...}}}`.
+///
+/// This is the single source of truth for recipe data — Python builds its
+/// `recipes` dict from this at module load.
+#[cfg(feature = "pyo3-bindings")]
+#[pyfunction]
+fn py_recipes(py: Python<'_>) -> PyResult<Py<PyDict>> {
+    let outer = PyDict::new(py);
+    for (item, recipe) in all_recipes() {
+        let entry = PyDict::new(py);
+        let consumes = PyDict::new(py);
+        for &(i, rate) in recipe.consumes.iter() {
+            consumes.set_item(i.name(), rate)?;
+        }
+        let produces = PyDict::new(py);
+        for &(i, rate) in recipe.produces.iter() {
+            produces.set_item(i.name(), rate)?;
+        }
+        entry.set_item("consumes", consumes)?;
+        entry.set_item("produces", produces)?;
+        outer.set_item(item.name(), entry)?;
+    }
+    Ok(outer.into())
+}
+
 #[cfg(feature = "pyo3-bindings")]
 #[pymodule]
 fn factorion_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(simulate_throughput, m)?)?;
     m.add_function(wrap_pyfunction!(py_entity_tiles, m)?)?;
+    m.add_function(wrap_pyfunction!(py_items, m)?)?;
+    m.add_function(wrap_pyfunction!(py_recipes, m)?)?;
     Ok(())
 }

--- a/factorion_rs/src/throughput.rs
+++ b/factorion_rs/src/throughput.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::entities::{EntityEnum, FactoryEntity};
 use crate::graph::FactoryGraph;
-use crate::types::{EntityKind, Item};
+use crate::types::Item;
 
 /// Calculate the throughput of a factory graph.
 ///
@@ -19,17 +19,17 @@ pub fn calc_throughput(graph: &FactoryGraph) -> (HashMap<Item, f64>, usize) {
         return (HashMap::new(), 0);
     }
 
-    // 1. Cycle detection
+    // 1. Cycle detection — return empty map (downstream treats as 0 throughput).
     if has_cycle(graph) {
-        return (HashMap::from([(Item::Empty, 0.0)]), 0);
+        return (HashMap::new(), 0);
     }
 
     // Identify sources and sinks
     let sources: Vec<usize> = (0..graph.node_count())
-        .filter(|&i| graph.nodes[i].entity_kind == EntityKind::Source)
+        .filter(|&i| graph.nodes[i].entity_kind == Item::Source)
         .collect();
     let sinks: Vec<usize> = (0..graph.node_count())
-        .filter(|&i| graph.nodes[i].entity_kind == EntityKind::Sink)
+        .filter(|&i| graph.nodes[i].entity_kind == Item::Sink)
         .collect();
 
     if sources.is_empty() || sinks.is_empty() {
@@ -91,17 +91,20 @@ pub fn calc_throughput(graph: &FactoryGraph) -> (HashMap<Item, f64>, usize) {
             node_inputs[node_idx] = accumulated_input.clone();
 
             // Compute output using stack-allocated enum dispatch (no heap allocation)
-            let item = if entity_kind == EntityKind::AssemblingMachine1 {
+            let item = if entity_kind == Item::AssemblingMachine1 {
                 graph.nodes[node_idx].recipe_item
             } else {
                 graph.nodes[node_idx].item
             };
             let misc = graph.nodes[node_idx].misc;
-            let entity = EntityEnum::new(entity_kind, item, misc);
-            node_outputs[node_idx] = entity.transform_flow(&accumulated_input);
+            // entity_kind comes from a graph node, which only contains
+            // placeable items, so new() always returns Some here.
+            if let Some(entity) = EntityEnum::new(entity_kind, item, misc) {
+                node_outputs[node_idx] = entity.transform_flow(&accumulated_input);
+            }
 
             // For splitters, divide output evenly among successors
-            if entity_kind == EntityKind::Splitter {
+            if entity_kind == Item::Splitter {
                 let num_successors = graph.successors[node_idx].len();
                 if num_successors > 1 {
                     for rate in node_outputs[node_idx].values_mut() {
@@ -233,22 +236,10 @@ mod tests {
         // Throughput limited by belt rate (15.0).
         let mut w = World::empty(4, 1);
 
-        w.place(0, 0, EntityKind::Source, Direction::East, Item::CopperCable);
-        w.place(
-            1,
-            0,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
-        w.place(
-            2,
-            0,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
-        w.place(3, 0, EntityKind::Sink, Direction::East, Item::CopperCable);
+        w.place(0, 0, Item::Source, Direction::East, Some(Item::CopperCable));
+        w.place(1, 0, Item::TransportBelt, Direction::East, None);
+        w.place(2, 0, Item::TransportBelt, Direction::East, None);
+        w.place(3, 0, Item::Sink, Direction::East, Some(Item::CopperCable));
 
         let g = build_graph(&w);
         let (output, unreachable) = calc_throughput(&g);
@@ -274,16 +265,10 @@ mod tests {
         // Throughput limited by inserter rate (0.86).
         let mut w = World::empty(4, 1);
 
-        w.place(0, 0, EntityKind::Source, Direction::East, Item::CopperCable);
-        w.place(1, 0, EntityKind::Inserter, Direction::East, Item::Empty);
-        w.place(
-            2,
-            0,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
-        w.place(3, 0, EntityKind::Sink, Direction::East, Item::CopperCable);
+        w.place(0, 0, Item::Source, Direction::East, Some(Item::CopperCable));
+        w.place(1, 0, Item::Inserter, Direction::East, None);
+        w.place(2, 0, Item::TransportBelt, Direction::East, None);
+        w.place(3, 0, Item::Sink, Direction::East, Some(Item::CopperCable));
 
         let g = build_graph(&w);
         let (output, unreachable) = calc_throughput(&g);
@@ -307,15 +292,9 @@ mod tests {
         // Source and sink exist but aren't connected. A lone belt sits in the middle.
         let mut w = World::empty(5, 5);
 
-        w.place(0, 0, EntityKind::Source, Direction::East, Item::CopperCable);
-        w.place(4, 4, EntityKind::Sink, Direction::East, Item::CopperCable);
-        w.place(
-            2,
-            2,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
+        w.place(0, 0, Item::Source, Direction::East, Some(Item::CopperCable));
+        w.place(4, 4, Item::Sink, Direction::East, Some(Item::CopperCable));
+        w.place(2, 2, Item::TransportBelt, Direction::East, None);
 
         let g = build_graph(&w);
         let (output, unreachable) = calc_throughput(&g);
@@ -341,27 +320,27 @@ mod tests {
         let mut g = FactoryGraph {
             nodes: vec![
                 crate::graph::GraphNode {
-                    id: NodeId::new(EntityKind::TransportBelt, 0, 0),
-                    entity_kind: EntityKind::TransportBelt,
-                    item: Item::Empty,
+                    id: NodeId::new(Item::TransportBelt, 0, 0),
+                    entity_kind: Item::TransportBelt,
+                    item: None,
                     misc: Misc::None,
-                    recipe_item: Item::Empty,
+                    recipe_item: None,
                     input: HashMap::new(),
                     output: HashMap::new(),
                 },
                 crate::graph::GraphNode {
-                    id: NodeId::new(EntityKind::TransportBelt, 1, 0),
-                    entity_kind: EntityKind::TransportBelt,
-                    item: Item::Empty,
+                    id: NodeId::new(Item::TransportBelt, 1, 0),
+                    entity_kind: Item::TransportBelt,
+                    item: None,
                     misc: Misc::None,
-                    recipe_item: Item::Empty,
+                    recipe_item: None,
                     input: HashMap::new(),
                     output: HashMap::new(),
                 },
             ],
             node_index: HashMap::from([
-                (NodeId::new(EntityKind::TransportBelt, 0, 0), 0),
-                (NodeId::new(EntityKind::TransportBelt, 1, 0), 1),
+                (NodeId::new(Item::TransportBelt, 0, 0), 0),
+                (NodeId::new(Item::TransportBelt, 1, 0), 1),
             ]),
             successors: vec![vec![1], vec![0]], // 0→1→0 cycle
             predecessors: vec![vec![1], vec![0]],
@@ -379,23 +358,11 @@ mod tests {
     fn test_splitter_passthrough() {
         // Source → Belt → Splitter → Belt → Sink (1 input, 1 output = no splitting)
         let mut w = World::empty(6, 2);
-        w.place(0, 0, EntityKind::Source, Direction::East, Item::CopperCable);
-        w.place(
-            1,
-            0,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
-        w.place_splitter(2, 0, Direction::East, Item::Empty);
-        w.place(
-            3,
-            0,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
-        w.place(4, 0, EntityKind::Sink, Direction::East, Item::CopperCable);
+        w.place(0, 0, Item::Source, Direction::East, Some(Item::CopperCable));
+        w.place(1, 0, Item::TransportBelt, Direction::East, None);
+        w.place_splitter(2, 0, Direction::East, None);
+        w.place(3, 0, Item::TransportBelt, Direction::East, None);
+        w.place(4, 0, Item::Sink, Direction::East, Some(Item::CopperCable));
 
         let g = build_graph(&w);
         let (output, unreachable) = calc_throughput(&g);
@@ -414,33 +381,15 @@ mod tests {
         //                          → Belt → Sink2
         // Each sink should get 7.5
         let mut w = World::empty(6, 2);
-        w.place(0, 0, EntityKind::Source, Direction::East, Item::CopperCable);
-        w.place(
-            1,
-            0,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
-        w.place_splitter(2, 0, Direction::East, Item::Empty);
+        w.place(0, 0, Item::Source, Direction::East, Some(Item::CopperCable));
+        w.place(1, 0, Item::TransportBelt, Direction::East, None);
+        w.place_splitter(2, 0, Direction::East, None);
         // Two output belts, one per splitter tile
-        w.place(
-            3,
-            0,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
-        w.place(
-            3,
-            1,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
+        w.place(3, 0, Item::TransportBelt, Direction::East, None);
+        w.place(3, 1, Item::TransportBelt, Direction::East, None);
         // Two sinks
-        w.place(4, 0, EntityKind::Sink, Direction::East, Item::CopperCable);
-        w.place(4, 1, EntityKind::Sink, Direction::East, Item::CopperCable);
+        w.place(4, 0, Item::Sink, Direction::East, Some(Item::CopperCable));
+        w.place(4, 1, Item::Sink, Direction::East, Some(Item::CopperCable));
 
         let g = build_graph(&w);
         let (output, unreachable) = calc_throughput(&g);
@@ -460,31 +409,13 @@ mod tests {
         // Source2 → Belt ↗
         let mut w = World::empty(6, 2);
         // Two sources feeding into both input lanes
-        w.place(0, 0, EntityKind::Source, Direction::East, Item::CopperCable);
-        w.place(0, 1, EntityKind::Source, Direction::East, Item::CopperCable);
-        w.place(
-            1,
-            0,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
-        w.place(
-            1,
-            1,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
-        w.place_splitter(2, 0, Direction::East, Item::Empty);
-        w.place(
-            3,
-            0,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
-        w.place(4, 0, EntityKind::Sink, Direction::East, Item::CopperCable);
+        w.place(0, 0, Item::Source, Direction::East, Some(Item::CopperCable));
+        w.place(0, 1, Item::Source, Direction::East, Some(Item::CopperCable));
+        w.place(1, 0, Item::TransportBelt, Direction::East, None);
+        w.place(1, 1, Item::TransportBelt, Direction::East, None);
+        w.place_splitter(2, 0, Direction::East, None);
+        w.place(3, 0, Item::TransportBelt, Direction::East, None);
+        w.place(4, 0, Item::Sink, Direction::East, Some(Item::CopperCable));
 
         let g = build_graph(&w);
         let (output, unreachable) = calc_throughput(&g);
@@ -502,39 +433,15 @@ mod tests {
     fn test_splitter_full_throughput() {
         // 2 inputs + 2 outputs = full 30 i/s throughput (15 per output)
         let mut w = World::empty(6, 2);
-        w.place(0, 0, EntityKind::Source, Direction::East, Item::CopperCable);
-        w.place(0, 1, EntityKind::Source, Direction::East, Item::CopperCable);
-        w.place(
-            1,
-            0,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
-        w.place(
-            1,
-            1,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
-        w.place_splitter(2, 0, Direction::East, Item::Empty);
-        w.place(
-            3,
-            0,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
-        w.place(
-            3,
-            1,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
-        w.place(4, 0, EntityKind::Sink, Direction::East, Item::CopperCable);
-        w.place(4, 1, EntityKind::Sink, Direction::East, Item::CopperCable);
+        w.place(0, 0, Item::Source, Direction::East, Some(Item::CopperCable));
+        w.place(0, 1, Item::Source, Direction::East, Some(Item::CopperCable));
+        w.place(1, 0, Item::TransportBelt, Direction::East, None);
+        w.place(1, 1, Item::TransportBelt, Direction::East, None);
+        w.place_splitter(2, 0, Direction::East, None);
+        w.place(3, 0, Item::TransportBelt, Direction::East, None);
+        w.place(3, 1, Item::TransportBelt, Direction::East, None);
+        w.place(4, 0, Item::Sink, Direction::East, Some(Item::CopperCable));
+        w.place(4, 1, Item::Sink, Direction::East, Some(Item::CopperCable));
 
         let g = build_graph(&w);
         let (output, unreachable) = calc_throughput(&g);
@@ -551,7 +458,7 @@ mod tests {
     #[test]
     fn test_source_only_no_sink() {
         let mut w = World::empty(3, 1);
-        w.place(0, 0, EntityKind::Source, Direction::East, Item::CopperCable);
+        w.place(0, 0, Item::Source, Direction::East, Some(Item::CopperCable));
 
         let g = build_graph(&w);
         let (output, _) = calc_throughput(&g);

--- a/factorion_rs/src/types.rs
+++ b/factorion_rs/src/types.rs
@@ -96,8 +96,12 @@ impl Misc {
 /// There is no `Empty` variant: absence of an item is encoded as
 /// channel value 0 and decoded to `Option::<Item>::None`.
 ///
-/// Integer values are arranged so placeable items occupy ids 1..=7 and
-/// non-placeable items 8..=12.
+/// Integer-id layout:
+///   1..=5   — agent-placeable entities (TB, Inserter, AM1, UB, Splitter)
+///   6..=10  — non-placeable items (CC, CP, IP, EC, IGW)
+///   11..=12 — env-spawned (Sink, Source) — MUST remain the last two
+///             ids; ppo.py sizes its entity head to `len(items)-2` to
+///             structurally exclude them. See `test_source_and_sink_are_last_two_ids`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Item {
     // Placeable, agent-buildable (1..=5)
@@ -463,6 +467,57 @@ mod tests {
                 non_placeable
             );
         }
+    }
+
+    /// LOAD-BEARING INVARIANT — DO NOT REMOVE.
+    ///
+    /// Source and Sink MUST be the last two ids in the Item enum (and the
+    /// last two entries in `all_items()`). The PPO policy in ppo.py sizes
+    /// its entity head to `len(items) - 2` to structurally exclude
+    /// env-spawned source/sink from agent placement (`ppo.py` line 780).
+    /// If anyone reorders the enum and breaks this invariant, the head
+    /// will start sampling Source/Sink as agent actions, the env will
+    /// reject them, and training will silently regress.
+    ///
+    /// Mirror tests live in tests/test_recipes.py — keep both. If you
+    /// genuinely need to remove this protection, you must also rewrite
+    /// `AgentCNN.__init__`'s entity-head sizing in ppo.py.
+    #[test]
+    fn test_source_and_sink_are_last_two_ids() {
+        let all = all_items();
+        let n = all.len();
+        assert!(n >= 2, "all_items() must contain at least Source and Sink");
+        assert_eq!(
+            all[n - 2],
+            Item::Sink,
+            "Item::Sink must be the second-to-last entry in all_items() — \
+             ppo.py's entity-head sizing depends on this"
+        );
+        assert_eq!(
+            all[n - 1],
+            Item::Source,
+            "Item::Source must be the last entry in all_items() — \
+             ppo.py's entity-head sizing depends on this"
+        );
+
+        // The integer values must also be the two highest. Using `as i64`
+        // here is the canonical way to read the discriminant.
+        let max_id = all.iter().map(|&i| i as i64).max().unwrap();
+        let second_max_id = {
+            let mut ids: Vec<i64> = all.iter().map(|&i| i as i64).collect();
+            ids.sort();
+            ids[ids.len() - 2]
+        };
+        assert_eq!(
+            Item::Source as i64,
+            max_id,
+            "Item::Source must have the highest id"
+        );
+        assert_eq!(
+            Item::Sink as i64,
+            second_max_id,
+            "Item::Sink must have the second-highest id"
+        );
     }
 
     #[test]

--- a/factorion_rs/src/types.rs
+++ b/factorion_rs/src/types.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use nonempty::{nonempty, NonEmpty};
 
 /// Channels in the WHC tensor (3rd dimension).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -82,108 +82,147 @@ impl Misc {
     }
 }
 
-/// Item identifier.
+/// The unified entity-and-item identifier.
+///
+/// In Factorion's data model, **everything is an Item**. Some items are
+/// *placeable* (they can sit on the grid as entities); the rest are pure
+/// inventory items (raw materials and intermediates). The world tensor
+/// has two channels:
+///   - `ENTITIES` channel: stores the Item id of the placeable item at
+///     this tile, or 0 if no entity is placed here.
+///   - `ITEMS` channel: stores the Item id of the carried/recipe/filter
+///     item at this tile, or 0 if none.
+///
+/// There is no `Empty` variant: absence of an item is encoded as
+/// channel value 0 and decoded to `Option::<Item>::None`.
+///
+/// Integer values are arranged so placeable items occupy ids 1..=7 and
+/// non-placeable items 8..=12.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Item {
-    Empty = 0,
-    CopperCable = 1,
-    CopperPlate = 2,
-    IronPlate = 3,
-    ElectronicCircuit = 4,
-}
-
-impl Item {
-    pub fn from_i64(v: i64) -> Self {
-        match v {
-            1 => Item::CopperCable,
-            2 => Item::CopperPlate,
-            3 => Item::IronPlate,
-            4 => Item::ElectronicCircuit,
-            _ => Item::Empty,
-        }
-    }
-
-    #[allow(dead_code)]
-    pub fn name(self) -> &'static str {
-        match self {
-            Item::Empty => "empty",
-            Item::CopperCable => "copper_cable",
-            Item::CopperPlate => "copper_plate",
-            Item::IronPlate => "iron_plate",
-            Item::ElectronicCircuit => "electronic_circuit",
-        }
-    }
-}
-
-/// Entity type on the grid.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum EntityKind {
-    Empty = 0,
+    // Placeable, agent-buildable (1..=5)
     TransportBelt = 1,
     Inserter = 2,
     AssemblingMachine1 = 3,
     UndergroundBelt = 4,
     Splitter = 5,
-    // Source/Sink are placed by the env, not the agent. They live last so
-    // the policy's entity head can be sized to exclude them (last two IDs).
+    // Placeable, env-only — Source/Sink are placed by the env, not the
+    // agent. They live last among placeables so the policy's entity head
+    // can be sized to exclude them.
     Sink = 6,   // bulk_inserter in Python
     Source = 7, // stack_inserter in Python
+    // Non-placeable (8..=12) — recipe ingredients / products
+    CopperCable = 8,
+    CopperPlate = 9,
+    IronPlate = 10,
+    ElectronicCircuit = 11,
+    IronGearWheel = 12,
 }
 
-impl EntityKind {
-    pub fn from_i64(v: i64) -> Self {
+impl Item {
+    /// Decode a tensor value into an Item. Returns `None` for value 0
+    /// (the "no item" sentinel) and any unknown value.
+    pub fn from_i64(v: i64) -> Option<Self> {
         match v {
-            1 => EntityKind::TransportBelt,
-            2 => EntityKind::Inserter,
-            3 => EntityKind::AssemblingMachine1,
-            4 => EntityKind::UndergroundBelt,
-            5 => EntityKind::Splitter,
-            6 => EntityKind::Sink,
-            7 => EntityKind::Source,
-            _ => EntityKind::Empty,
+            1 => Some(Item::TransportBelt),
+            2 => Some(Item::Inserter),
+            3 => Some(Item::AssemblingMachine1),
+            4 => Some(Item::UndergroundBelt),
+            5 => Some(Item::Splitter),
+            6 => Some(Item::Sink),
+            7 => Some(Item::Source),
+            8 => Some(Item::CopperCable),
+            9 => Some(Item::CopperPlate),
+            10 => Some(Item::IronPlate),
+            11 => Some(Item::ElectronicCircuit),
+            12 => Some(Item::IronGearWheel),
+            _ => None,
         }
     }
 
+    pub fn name(self) -> &'static str {
+        match self {
+            Item::TransportBelt => "transport_belt",
+            Item::Inserter => "inserter",
+            Item::AssemblingMachine1 => "assembling_machine_1",
+            Item::UndergroundBelt => "underground_belt",
+            Item::Sink => "bulk_inserter",
+            Item::Source => "stack_inserter",
+            Item::Splitter => "splitter",
+            Item::CopperCable => "copper_cable",
+            Item::CopperPlate => "copper_plate",
+            Item::IronPlate => "iron_plate",
+            Item::ElectronicCircuit => "electronic_circuit",
+            Item::IronGearWheel => "iron_gear_wheel",
+        }
+    }
+
+    /// Whether this item can be placed on the grid as an entity.
+    /// Non-placeable items only ever live in the ITEMS channel
+    /// (carried on belts, set as recipes, etc.).
+    pub fn is_placeable(self) -> bool {
+        matches!(
+            self,
+            Item::TransportBelt
+                | Item::Inserter
+                | Item::AssemblingMachine1
+                | Item::UndergroundBelt
+                | Item::Sink
+                | Item::Source
+                | Item::Splitter
+        )
+    }
+
+    /// Maximum items/second this item can transfer when placed as an
+    /// entity. Returns 0.0 for non-placeable items.
     #[allow(dead_code)]
     pub fn flow_rate(self) -> f64 {
         match self {
-            EntityKind::Empty => 0.0,
-            EntityKind::TransportBelt => 15.0,
-            EntityKind::Inserter => 0.86,
-            EntityKind::AssemblingMachine1 => 0.5,
-            EntityKind::UndergroundBelt => 15.0,
-            EntityKind::Sink => f64::INFINITY,
-            EntityKind::Source => f64::INFINITY,
-            EntityKind::Splitter => 30.0, // 2 lanes × 15 i/s
+            Item::TransportBelt => 15.0,
+            Item::Inserter => 0.86,
+            Item::AssemblingMachine1 => 0.5,
+            Item::UndergroundBelt => 15.0,
+            Item::Sink => f64::INFINITY,
+            Item::Source => f64::INFINITY,
+            Item::Splitter => 30.0, // 2 lanes × 15 i/s
+            // Non-placeable: cannot transfer flow on its own.
+            Item::CopperCable
+            | Item::CopperPlate
+            | Item::IronPlate
+            | Item::ElectronicCircuit
+            | Item::IronGearWheel => 0.0,
         }
     }
 
-    /// Entity footprint (width, height) where width = perpendicular to flow,
-    /// height = along flow. Returns (1, 1) for single-tile entities.
-    // TODO: Define all entity properties (name, size, flow_rate) in a single
-    // Rust registry and expose to Python, replacing the duplicated Python
-    // `entities` dict.
+    /// Footprint (width, height) for placeable items.
+    /// Width = perpendicular to flow, height = along flow.
+    /// Non-placeable items return (1, 1).
     pub fn size(self) -> (usize, usize) {
         match self {
-            EntityKind::AssemblingMachine1 => (3, 3),
-            EntityKind::Splitter => (2, 1),
+            Item::AssemblingMachine1 => (3, 3),
+            Item::Splitter => (2, 1),
             _ => (1, 1),
         }
     }
+}
 
-    #[allow(dead_code)]
-    pub fn name(self) -> &'static str {
-        match self {
-            EntityKind::Empty => "empty",
-            EntityKind::TransportBelt => "transport_belt",
-            EntityKind::Inserter => "inserter",
-            EntityKind::AssemblingMachine1 => "assembling_machine_1",
-            EntityKind::UndergroundBelt => "underground_belt",
-            EntityKind::Sink => "bulk_inserter",
-            EntityKind::Source => "stack_inserter",
-            EntityKind::Splitter => "splitter",
-        }
-    }
+/// Every Item variant. The single source of truth — Python's `items`
+/// dict is built from this via the PyO3 `py_items` binding.
+pub fn all_items() -> &'static [Item] {
+    &[
+        Item::TransportBelt,
+        Item::Inserter,
+        Item::AssemblingMachine1,
+        Item::UndergroundBelt,
+        Item::Sink,
+        Item::Source,
+        Item::Splitter,
+        Item::CopperCable,
+        Item::CopperPlate,
+        Item::IronPlate,
+        Item::ElectronicCircuit,
+        Item::IronGearWheel,
+    ]
 }
 
 /// A signed grid position. Used for multi-tile entity offsets where
@@ -209,39 +248,124 @@ impl Pos {
     }
 }
 
-/// A crafting recipe.
+/// A crafting recipe. `consumes` and `produces` are `NonEmpty` so an
+/// empty recipe (no inputs or no outputs) is unrepresentable at compile
+/// time — there is no need for runtime checks of these invariants.
 #[derive(Debug, Clone)]
 pub struct Recipe {
-    pub consumes: HashMap<Item, f64>,
-    pub produces: HashMap<Item, f64>,
+    pub consumes: NonEmpty<(Item, f64)>,
+    pub produces: NonEmpty<(Item, f64)>,
+}
+
+impl Recipe {
+    /// Look up the consumption rate for `item`, if present.
+    #[allow(dead_code)]
+    pub fn consumes_rate(&self, item: Item) -> Option<f64> {
+        self.consumes
+            .iter()
+            .find(|(i, _)| *i == item)
+            .map(|(_, r)| *r)
+    }
+
+    /// Look up the production rate for `item`, if present.
+    #[allow(dead_code)]
+    pub fn produces_rate(&self, item: Item) -> Option<f64> {
+        self.produces
+            .iter()
+            .find(|(i, _)| *i == item)
+            .map(|(_, r)| *r)
+    }
+}
+
+/// All crafting recipes in the game. The single source of truth — both
+/// `get_recipe` and the Python-facing PyO3 binding read from this.
+///
+/// Quantities are the canonical wiki recipe values (per craft, not
+/// per-second). Throughput math (`transform_flow`) is scale-invariant
+/// under uniform multiplication of consumes and produces.
+pub fn all_recipes() -> Vec<(Item, Recipe)> {
+    vec![
+        // 1 copper plate -> 2 copper cables, 0.5s
+        (
+            Item::CopperCable,
+            Recipe {
+                consumes: nonempty![(Item::CopperPlate, 1.0)],
+                produces: nonempty![(Item::CopperCable, 2.0)],
+            },
+        ),
+        // 3 copper cable + 1 iron plate -> 1 electronic circuit, 0.5s
+        (
+            Item::ElectronicCircuit,
+            Recipe {
+                consumes: nonempty![(Item::CopperCable, 3.0), (Item::IronPlate, 1.0)],
+                produces: nonempty![(Item::ElectronicCircuit, 1.0)],
+            },
+        ),
+        // 2 iron plates -> 1 iron gear wheel, 0.5s
+        (
+            Item::IronGearWheel,
+            Recipe {
+                consumes: nonempty![(Item::IronPlate, 2.0)],
+                produces: nonempty![(Item::IronGearWheel, 1.0)],
+            },
+        ),
+        // 1 iron gear wheel + 1 iron plate -> 2 transport belts, 0.5s
+        (
+            Item::TransportBelt,
+            Recipe {
+                consumes: nonempty![(Item::IronGearWheel, 1.0), (Item::IronPlate, 1.0)],
+                produces: nonempty![(Item::TransportBelt, 2.0)],
+            },
+        ),
+        // 1 EC + 1 IGW + 1 iron plate -> 1 inserter, 0.5s
+        (
+            Item::Inserter,
+            Recipe {
+                consumes: nonempty![
+                    (Item::ElectronicCircuit, 1.0),
+                    (Item::IronGearWheel, 1.0),
+                    (Item::IronPlate, 1.0)
+                ],
+                produces: nonempty![(Item::Inserter, 1.0)],
+            },
+        ),
+        // 3 EC + 5 IGW + 9 iron plates -> 1 assembling machine 1, 0.5s
+        (
+            Item::AssemblingMachine1,
+            Recipe {
+                consumes: nonempty![
+                    (Item::ElectronicCircuit, 3.0),
+                    (Item::IronGearWheel, 5.0),
+                    (Item::IronPlate, 9.0)
+                ],
+                produces: nonempty![(Item::AssemblingMachine1, 1.0)],
+            },
+        ),
+    ]
 }
 
 /// Get the recipe for a given item, if one exists.
 pub fn get_recipe(item: Item) -> Option<Recipe> {
-    match item {
-        Item::ElectronicCircuit => Some(Recipe {
-            consumes: HashMap::from([(Item::CopperCable, 6.0), (Item::IronPlate, 2.0)]),
-            produces: HashMap::from([(Item::ElectronicCircuit, 2.0)]),
-        }),
-        Item::CopperCable => Some(Recipe {
-            consumes: HashMap::from([(Item::CopperPlate, 2.0)]),
-            produces: HashMap::from([(Item::CopperCable, 4.0)]),
-        }),
-        _ => None,
-    }
+    all_recipes()
+        .into_iter()
+        .find(|(i, _)| *i == item)
+        .map(|(_, r)| r)
 }
 
 /// Unique identifier for a node in the factory graph.
-/// Matches the Python format: "entity_name\n@x,y"
+/// Matches the Python format: "entity_name\n@x,y".
+///
+/// `entity_kind` is an `Item` (post-unification) and should always be
+/// placeable — only placeable items become graph nodes.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct NodeId {
-    pub entity_kind: EntityKind,
+    pub entity_kind: Item,
     pub x: usize,
     pub y: usize,
 }
 
 impl NodeId {
-    pub fn new(entity_kind: EntityKind, x: usize, y: usize) -> Self {
+    pub fn new(entity_kind: Item, x: usize, y: usize) -> Self {
         Self { entity_kind, x, y }
     }
 
@@ -284,48 +408,111 @@ mod tests {
     }
 
     #[test]
-    fn test_entity_kind_from_i64() {
-        assert_eq!(EntityKind::from_i64(0), EntityKind::Empty);
-        assert_eq!(EntityKind::from_i64(1), EntityKind::TransportBelt);
-        assert_eq!(EntityKind::from_i64(2), EntityKind::Inserter);
-        assert_eq!(EntityKind::from_i64(3), EntityKind::AssemblingMachine1);
-        assert_eq!(EntityKind::from_i64(4), EntityKind::UndergroundBelt);
-        assert_eq!(EntityKind::from_i64(5), EntityKind::Splitter);
-        assert_eq!(EntityKind::from_i64(6), EntityKind::Sink);
-        assert_eq!(EntityKind::from_i64(7), EntityKind::Source);
-        assert_eq!(EntityKind::from_i64(-1), EntityKind::Empty);
-    }
-
-    #[test]
-    fn test_entity_flow_rates() {
-        assert_eq!(EntityKind::TransportBelt.flow_rate(), 15.0);
-        assert_eq!(EntityKind::Inserter.flow_rate(), 0.86);
-        assert_eq!(EntityKind::AssemblingMachine1.flow_rate(), 0.5);
-        assert_eq!(EntityKind::UndergroundBelt.flow_rate(), 15.0);
-        assert!(EntityKind::Sink.flow_rate().is_infinite());
-        assert!(EntityKind::Source.flow_rate().is_infinite());
-    }
-
-    #[test]
     fn test_item_from_i64() {
-        assert_eq!(Item::from_i64(0), Item::Empty);
-        assert_eq!(Item::from_i64(1), Item::CopperCable);
-        assert_eq!(Item::from_i64(4), Item::ElectronicCircuit);
+        assert_eq!(Item::from_i64(0), None);
+        assert_eq!(Item::from_i64(1), Some(Item::TransportBelt));
+        assert_eq!(Item::from_i64(2), Some(Item::Inserter));
+        assert_eq!(Item::from_i64(3), Some(Item::AssemblingMachine1));
+        assert_eq!(Item::from_i64(4), Some(Item::UndergroundBelt));
+        assert_eq!(Item::from_i64(5), Some(Item::Splitter));
+        assert_eq!(Item::from_i64(6), Some(Item::Sink));
+        assert_eq!(Item::from_i64(7), Some(Item::Source));
+        assert_eq!(Item::from_i64(8), Some(Item::CopperCable));
+        assert_eq!(Item::from_i64(11), Some(Item::ElectronicCircuit));
+        assert_eq!(Item::from_i64(12), Some(Item::IronGearWheel));
+        assert_eq!(Item::from_i64(99), None);
+        assert_eq!(Item::from_i64(-1), None);
+    }
+
+    #[test]
+    fn test_item_flow_rates() {
+        assert_eq!(Item::TransportBelt.flow_rate(), 15.0);
+        assert_eq!(Item::Inserter.flow_rate(), 0.86);
+        assert_eq!(Item::AssemblingMachine1.flow_rate(), 0.5);
+        assert_eq!(Item::UndergroundBelt.flow_rate(), 15.0);
+        assert!(Item::Sink.flow_rate().is_infinite());
+        assert!(Item::Source.flow_rate().is_infinite());
+        assert_eq!(Item::CopperCable.flow_rate(), 0.0);
+        assert_eq!(Item::IronPlate.flow_rate(), 0.0);
+    }
+
+    #[test]
+    fn test_item_is_placeable() {
+        for placeable in [
+            Item::TransportBelt,
+            Item::Inserter,
+            Item::AssemblingMachine1,
+            Item::UndergroundBelt,
+            Item::Sink,
+            Item::Source,
+            Item::Splitter,
+        ] {
+            assert!(
+                placeable.is_placeable(),
+                "{:?} should be placeable",
+                placeable
+            );
+        }
+        for non_placeable in [
+            Item::CopperCable,
+            Item::CopperPlate,
+            Item::IronPlate,
+            Item::ElectronicCircuit,
+            Item::IronGearWheel,
+        ] {
+            assert!(
+                !non_placeable.is_placeable(),
+                "{:?} should not be placeable",
+                non_placeable
+            );
+        }
     }
 
     #[test]
     fn test_recipes() {
         let ec = get_recipe(Item::ElectronicCircuit).unwrap();
-        assert_eq!(ec.consumes[&Item::CopperCable], 6.0);
-        assert_eq!(ec.consumes[&Item::IronPlate], 2.0);
-        assert_eq!(ec.produces[&Item::ElectronicCircuit], 2.0);
+        assert_eq!(ec.consumes_rate(Item::CopperCable), Some(3.0));
+        assert_eq!(ec.consumes_rate(Item::IronPlate), Some(1.0));
+        assert_eq!(ec.produces_rate(Item::ElectronicCircuit), Some(1.0));
 
         let cc = get_recipe(Item::CopperCable).unwrap();
-        assert_eq!(cc.consumes[&Item::CopperPlate], 2.0);
-        assert_eq!(cc.produces[&Item::CopperCable], 4.0);
+        assert_eq!(cc.consumes_rate(Item::CopperPlate), Some(1.0));
+        assert_eq!(cc.produces_rate(Item::CopperCable), Some(2.0));
 
-        assert!(get_recipe(Item::Empty).is_none());
+        let igw = get_recipe(Item::IronGearWheel).unwrap();
+        assert_eq!(igw.consumes_rate(Item::IronPlate), Some(2.0));
+        assert_eq!(igw.produces_rate(Item::IronGearWheel), Some(1.0));
+
+        let tb = get_recipe(Item::TransportBelt).unwrap();
+        assert_eq!(tb.consumes_rate(Item::IronGearWheel), Some(1.0));
+        assert_eq!(tb.consumes_rate(Item::IronPlate), Some(1.0));
+        assert_eq!(tb.produces_rate(Item::TransportBelt), Some(2.0));
+
+        let ins = get_recipe(Item::Inserter).unwrap();
+        assert_eq!(ins.consumes_rate(Item::ElectronicCircuit), Some(1.0));
+        assert_eq!(ins.consumes_rate(Item::IronGearWheel), Some(1.0));
+        assert_eq!(ins.consumes_rate(Item::IronPlate), Some(1.0));
+        assert_eq!(ins.produces_rate(Item::Inserter), Some(1.0));
+
+        let am1 = get_recipe(Item::AssemblingMachine1).unwrap();
+        assert_eq!(am1.consumes_rate(Item::ElectronicCircuit), Some(3.0));
+        assert_eq!(am1.consumes_rate(Item::IronGearWheel), Some(5.0));
+        assert_eq!(am1.consumes_rate(Item::IronPlate), Some(9.0));
+        assert_eq!(am1.produces_rate(Item::AssemblingMachine1), Some(1.0));
+
         assert!(get_recipe(Item::IronPlate).is_none());
+        assert!(get_recipe(Item::CopperPlate).is_none());
+    }
+
+    #[test]
+    fn test_all_recipes_lists_known_items() {
+        let items: Vec<Item> = all_recipes().into_iter().map(|(i, _)| i).collect();
+        assert!(items.contains(&Item::ElectronicCircuit));
+        assert!(items.contains(&Item::CopperCable));
+        assert!(items.contains(&Item::IronGearWheel));
+        assert!(items.contains(&Item::TransportBelt));
+        assert!(items.contains(&Item::Inserter));
+        assert!(items.contains(&Item::AssemblingMachine1));
     }
 
     #[test]
@@ -338,7 +525,7 @@ mod tests {
 
     #[test]
     fn test_node_id_label() {
-        let id = NodeId::new(EntityKind::TransportBelt, 3, 5);
+        let id = NodeId::new(Item::TransportBelt, 3, 5);
         assert_eq!(id.label(), "transport_belt\n@3,5");
     }
 }

--- a/factorion_rs/src/types.rs
+++ b/factorion_rs/src/types.rs
@@ -106,17 +106,17 @@ pub enum Item {
     AssemblingMachine1 = 3,
     UndergroundBelt = 4,
     Splitter = 5,
-    // Placeable, env-only — Source/Sink are placed by the env, not the
-    // agent. They live last among placeables so the policy's entity head
-    // can be sized to exclude them.
-    Sink = 6,   // bulk_inserter in Python
-    Source = 7, // stack_inserter in Python
-    // Non-placeable (8..=12) — recipe ingredients / products
-    CopperCable = 8,
-    CopperPlate = 9,
-    IronPlate = 10,
-    ElectronicCircuit = 11,
-    IronGearWheel = 12,
+    // Non-placeable (6..=10) — recipe ingredients / products
+    CopperCable = 6,
+    CopperPlate = 7,
+    IronPlate = 8,
+    ElectronicCircuit = 9,
+    IronGearWheel = 10,
+    // Env-spawned, not agent-placeable — must remain the LAST two ids so
+    // the policy's entity head can be sized to `len(items) - 2` and
+    // structurally exclude them from sampling (see ppo.py).
+    Sink = 11,   // bulk_inserter in Python
+    Source = 12, // stack_inserter in Python
 }
 
 impl Item {
@@ -129,13 +129,13 @@ impl Item {
             3 => Some(Item::AssemblingMachine1),
             4 => Some(Item::UndergroundBelt),
             5 => Some(Item::Splitter),
-            6 => Some(Item::Sink),
-            7 => Some(Item::Source),
-            8 => Some(Item::CopperCable),
-            9 => Some(Item::CopperPlate),
-            10 => Some(Item::IronPlate),
-            11 => Some(Item::ElectronicCircuit),
-            12 => Some(Item::IronGearWheel),
+            6 => Some(Item::CopperCable),
+            7 => Some(Item::CopperPlate),
+            8 => Some(Item::IronPlate),
+            9 => Some(Item::ElectronicCircuit),
+            10 => Some(Item::IronGearWheel),
+            11 => Some(Item::Sink),
+            12 => Some(Item::Source),
             _ => None,
         }
     }
@@ -214,14 +214,14 @@ pub fn all_items() -> &'static [Item] {
         Item::Inserter,
         Item::AssemblingMachine1,
         Item::UndergroundBelt,
-        Item::Sink,
-        Item::Source,
         Item::Splitter,
         Item::CopperCable,
         Item::CopperPlate,
         Item::IronPlate,
         Item::ElectronicCircuit,
         Item::IronGearWheel,
+        Item::Sink,
+        Item::Source,
     ]
 }
 
@@ -411,15 +411,12 @@ mod tests {
     fn test_item_from_i64() {
         assert_eq!(Item::from_i64(0), None);
         assert_eq!(Item::from_i64(1), Some(Item::TransportBelt));
-        assert_eq!(Item::from_i64(2), Some(Item::Inserter));
-        assert_eq!(Item::from_i64(3), Some(Item::AssemblingMachine1));
-        assert_eq!(Item::from_i64(4), Some(Item::UndergroundBelt));
         assert_eq!(Item::from_i64(5), Some(Item::Splitter));
-        assert_eq!(Item::from_i64(6), Some(Item::Sink));
-        assert_eq!(Item::from_i64(7), Some(Item::Source));
-        assert_eq!(Item::from_i64(8), Some(Item::CopperCable));
-        assert_eq!(Item::from_i64(11), Some(Item::ElectronicCircuit));
-        assert_eq!(Item::from_i64(12), Some(Item::IronGearWheel));
+        assert_eq!(Item::from_i64(6), Some(Item::CopperCable));
+        assert_eq!(Item::from_i64(10), Some(Item::IronGearWheel));
+        // Source/Sink must remain the LAST two ids — see Item enum docs.
+        assert_eq!(Item::from_i64(11), Some(Item::Sink));
+        assert_eq!(Item::from_i64(12), Some(Item::Source));
         assert_eq!(Item::from_i64(99), None);
         assert_eq!(Item::from_i64(-1), None);
     }

--- a/factorion_rs/src/world.rs
+++ b/factorion_rs/src/world.rs
@@ -1,4 +1,4 @@
-use crate::types::{Channel, Direction, EntityKind, Item, Misc, NUM_CHANNELS};
+use crate::types::{Channel, Direction, Item, Misc, NUM_CHANNELS};
 
 /// A wrapper around a 3D array representing a factory world.
 ///
@@ -110,17 +110,18 @@ impl World {
     }
 
     /// Place an entity at (x, y) with the given direction and item.
+    /// `item = None` writes 0 to the items channel (no item set).
     #[allow(dead_code)]
-    pub fn place(&mut self, x: usize, y: usize, entity: EntityKind, dir: Direction, item: Item) {
+    pub fn place(&mut self, x: usize, y: usize, entity: Item, dir: Direction, item: Option<Item>) {
         self.set(x, y, Channel::Entities, entity as i64);
         self.set(x, y, Channel::Direction, dir as i64);
-        self.set(x, y, Channel::Items, item as i64);
+        self.set(x, y, Channel::Items, item.map_or(0, |i| i as i64));
     }
 
     /// Place an underground belt at (x, y) with the given direction and misc state.
     #[allow(dead_code)]
     pub fn place_underground(&mut self, x: usize, y: usize, dir: Direction, misc: Misc) {
-        self.set(x, y, Channel::Entities, EntityKind::UndergroundBelt as i64);
+        self.set(x, y, Channel::Entities, Item::UndergroundBelt as i64);
         self.set(x, y, Channel::Direction, dir as i64);
         self.set(x, y, Channel::Misc, misc as i64);
     }
@@ -132,9 +133,9 @@ impl World {
         &mut self,
         x: usize,
         y: usize,
-        entity: EntityKind,
+        entity: Item,
         dir: Direction,
-        item: Item,
+        item: Option<Item>,
         width: usize,
         height: usize,
     ) -> bool {
@@ -146,7 +147,7 @@ impl World {
         for tile in &tiles {
             match tile.to_usize() {
                 Some((tx, ty)) if self.in_bounds(tile.x, tile.y) => {
-                    if self.entity_at(tx, ty) != EntityKind::Empty {
+                    if self.entity_at(tx, ty).is_some() {
                         return false;
                     }
                 }
@@ -163,13 +164,22 @@ impl World {
 
     /// Place a splitter at (x, y). Convenience wrapper around place_multi_tile.
     #[allow(dead_code)]
-    pub fn place_splitter(&mut self, x: usize, y: usize, dir: Direction, item: Item) -> bool {
-        self.place_multi_tile(x, y, EntityKind::Splitter, dir, item, 2, 1)
+    pub fn place_splitter(
+        &mut self,
+        x: usize,
+        y: usize,
+        dir: Direction,
+        item: Option<Item>,
+    ) -> bool {
+        self.place_multi_tile(x, y, Item::Splitter, dir, item, 2, 1)
     }
 
-    /// Get the entity kind at (x, y).
-    pub fn entity_at(&self, x: usize, y: usize) -> EntityKind {
-        EntityKind::from_i64(self.get(x, y, Channel::Entities))
+    /// Get the entity at (x, y). Returns `None` if the tile has no
+    /// entity placed (channel value 0). The returned Item, if any,
+    /// should always satisfy `is_placeable()`; non-placeable values in
+    /// the entities channel are a data error.
+    pub fn entity_at(&self, x: usize, y: usize) -> Option<Item> {
+        Item::from_i64(self.get(x, y, Channel::Entities))
     }
 
     /// Get the direction at (x, y).
@@ -177,8 +187,8 @@ impl World {
         Direction::from_i64(self.get(x, y, Channel::Direction))
     }
 
-    /// Get the item at (x, y).
-    pub fn item_at(&self, x: usize, y: usize) -> Item {
+    /// Get the item at (x, y). Returns `None` for cells with no item set.
+    pub fn item_at(&self, x: usize, y: usize) -> Option<Item> {
         Item::from_i64(self.get(x, y, Channel::Items))
     }
 
@@ -219,9 +229,9 @@ mod tests {
         assert_eq!(w.height(), 3);
         for x in 0..3 {
             for y in 0..3 {
-                assert_eq!(w.entity_at(x, y), EntityKind::Empty);
+                assert_eq!(w.entity_at(x, y), None);
                 assert_eq!(w.direction_at(x, y), Direction::None);
-                assert_eq!(w.item_at(x, y), Item::Empty);
+                assert_eq!(w.item_at(x, y), None);
                 assert_eq!(w.misc_at(x, y), Misc::None);
             }
         }
@@ -233,17 +243,17 @@ mod tests {
         w.place(
             1,
             2,
-            EntityKind::TransportBelt,
+            Item::TransportBelt,
             Direction::East,
-            Item::CopperCable,
+            Some(Item::CopperCable),
         );
 
-        assert_eq!(w.entity_at(1, 2), EntityKind::TransportBelt);
+        assert_eq!(w.entity_at(1, 2), Some(Item::TransportBelt));
         assert_eq!(w.direction_at(1, 2), Direction::East);
-        assert_eq!(w.item_at(1, 2), Item::CopperCable);
+        assert_eq!(w.item_at(1, 2), Some(Item::CopperCable));
 
         // Other cells still empty
-        assert_eq!(w.entity_at(0, 0), EntityKind::Empty);
+        assert_eq!(w.entity_at(0, 0), None);
     }
 
     #[test]
@@ -265,33 +275,27 @@ mod tests {
         w.place(
             0,
             0,
-            EntityKind::Source,
+            Item::Source,
             Direction::East,
-            Item::ElectronicCircuit,
+            Some(Item::ElectronicCircuit),
         );
 
-        // Place a belt at (1,0) facing east
-        w.place(
-            1,
-            0,
-            EntityKind::TransportBelt,
-            Direction::East,
-            Item::Empty,
-        );
+        // Place a belt at (1,0) facing east — no item carried
+        w.place(1, 0, Item::TransportBelt, Direction::East, None);
 
         // Place a sink at (2,0) facing east
         w.place(
             2,
             0,
-            EntityKind::Sink,
+            Item::Sink,
             Direction::East,
-            Item::ElectronicCircuit,
+            Some(Item::ElectronicCircuit),
         );
 
-        assert_eq!(w.entity_at(0, 0), EntityKind::Source);
-        assert_eq!(w.entity_at(1, 0), EntityKind::TransportBelt);
-        assert_eq!(w.entity_at(2, 0), EntityKind::Sink);
-        assert_eq!(w.item_at(0, 0), Item::ElectronicCircuit);
+        assert_eq!(w.entity_at(0, 0), Some(Item::Source));
+        assert_eq!(w.entity_at(1, 0), Some(Item::TransportBelt));
+        assert_eq!(w.entity_at(2, 0), Some(Item::Sink));
+        assert_eq!(w.item_at(0, 0), Some(Item::ElectronicCircuit));
     }
 
     #[test]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -27,6 +27,7 @@ Misc = _objs["Misc"]
 LessonKind = _objs["LessonKind"]
 entities = _objs["entities"]
 items = _objs["items"]
+recipes = _objs["recipes"]
 
 find_belt_path = _fns["find_belt_path"]
 find_belt_paths_with_source_sink_orient = _fns["find_belt_paths_with_source_sink_orient"]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -22,6 +22,7 @@ _, _fns = factorion.functions.run()
 
 Channel = _objs["Channel"]
 Direction = _objs["Direction"]
+DIR_TO_DELTA = _objs["DIR_TO_DELTA"]
 Footprint = _objs["Footprint"]
 Misc = _objs["Misc"]
 LessonKind = _objs["LessonKind"]

--- a/tests/test_handcrafted.py
+++ b/tests/test_handcrafted.py
@@ -669,6 +669,177 @@ class TestAssemblerPerimeterThroughput:
         )
 
 
+# ── Canonical 2-in-1-out tileable factory ──────────────────────────────────
+#
+# Verbatim translation of the user-provided 7×8 tile blueprint. Two
+# assembling machines side-by-side (3×3 each at x=1..3 and x=4..6), fed by
+# two east-flowing ingredient belts that share row y=1: one regular belt
+# (A) snakes through y=0→y=1→y=0, and one belt (B) crosses under it using
+# a 5-tile underground pair. Each assembler receives one inserter from
+# each belt. Two output inserters at y=6 drop onto a single west-flowing
+# output belt at y=7 that terminates at a sink.
+#
+# The user specified that bulk/stack inserters in blueprints should always
+# be translated to Factorion native source/sink entities.
+#
+# Layout (R = source, K = sink, A = assembler tile, v/^/</>  = belt/inserter dir,
+#         u = underground entry, n = underground exit):
+#
+#          x: 0 1 2 3 4 5 6
+#     y=0:    R > v . . > >       (R=iron_plate source → belt A east)
+#     y=1:    R u > > > ^ n       (R=copper_cable source → underground belt B east)
+#     y=2:    . v v . . v v       (4 input inserters, all facing south)
+#     y=3:    . A A A A A A       (asm1 body: x=1..3; asm2 body: x=4..6)
+#     y=4:    . A A A A A A       (both assemblers: recipe=electronic_circuit)
+#     y=5:    . A A A A A A
+#     y=6:    . . . v v . .       (2 output inserters, facing south)
+#     y=7:    K < < < < < <       (K=electronic_circuit sink ← output belt west)
+#
+# Belt A (regular) snake: (1,0)E → (2,0)S → (2,1)E → (3,1)E → (4,1)E →
+#   (5,1)N → (5,0)E → (6,0)E. The dip through y=1 lets input inserters at
+#   x=2 and x=5 pick from it.
+# Belt B (underground): entry at (1,1), exit at (6,1), 5 tiles apart.
+# Note: in Factorion (matching real Factorio), inserters can pick up items
+#   directly from an underground-belt tile, so inserters at (1,2) and (6,2)
+#   feed off belt B via its entry and exit tiles respectively.
+
+
+class TestCanonical2In1OutTile:
+    """Verbatim translation of the user's canonical 7×8 ASSEMBLE_2IN_1OUT tile."""
+
+    def _build_tile(self):
+        # 8×8 world (7-wide tile + 1 margin not strictly needed)
+        world = make_world(8, 8)
+
+        # Sources (west edge) — replace the blueprint's bulk-inserters with
+        # Factorion native source entities, facing east so they output onto
+        # the adjacent belt cell at x=1.
+        set_entity(world, 0, 0, "source", Direction.EAST, "iron_plate")     # belt A
+        set_entity(world, 0, 1, "source", Direction.EAST, "copper_cable")   # belt B
+
+        # Sink (west edge of output belt) — replaces the blueprint's
+        # stack-inserter, facing west to consume from belt cell at x=1.
+        set_entity(world, 0, 7, "sink", Direction.WEST, "electronic_circuit")
+
+        # Belt A: regular transport belts snaking across y=0 and y=1
+        set_entity(world, 1, 0, "transport_belt", Direction.EAST)
+        set_entity(world, 2, 0, "transport_belt", Direction.SOUTH)
+        set_entity(world, 2, 1, "transport_belt", Direction.EAST)
+        set_entity(world, 3, 1, "transport_belt", Direction.EAST)
+        set_entity(world, 4, 1, "transport_belt", Direction.EAST)
+        set_entity(world, 5, 1, "transport_belt", Direction.NORTH)
+        set_entity(world, 5, 0, "transport_belt", Direction.EAST)
+        set_entity(world, 6, 0, "transport_belt", Direction.EAST)
+
+        # Belt B: underground pair. Entry at (1,1), exit at (6,1). 5 tiles apart,
+        # which is within the yellow underground max range.
+        set_entity(world, 1, 1, "underground_belt", Direction.EAST,
+                   misc=Misc.UNDERGROUND_DOWN.value)
+        set_entity(world, 6, 1, "underground_belt", Direction.EAST,
+                   misc=Misc.UNDERGROUND_UP.value)
+
+        # Assemblers (3x3 each), recipe=electronic_circuit.
+        # Anchors (top-left) at (1,3) and (4,3).
+        set_assembler(world, 1, 3, "electronic_circuit")
+        set_assembler(world, 4, 3, "electronic_circuit")
+
+        # Input inserters at y=2, all facing SOUTH (pick from y=1 belt,
+        # drop into y=3 assembler top row).
+        set_entity(world, 1, 2, "inserter", Direction.SOUTH)  # picks belt B, drops asm1 N_left
+        set_entity(world, 2, 2, "inserter", Direction.SOUTH)  # picks belt A, drops asm1 N_center
+        set_entity(world, 5, 2, "inserter", Direction.SOUTH)  # picks belt A, drops asm2 N_center
+        set_entity(world, 6, 2, "inserter", Direction.SOUTH)  # picks belt B, drops asm2 N_right
+
+        # Output inserters at y=6, facing SOUTH (pick from y=5 asm bottom row,
+        # drop onto y=7 output belt).
+        set_entity(world, 3, 6, "inserter", Direction.SOUTH)  # picks asm1 S_right
+        set_entity(world, 4, 6, "inserter", Direction.SOUTH)  # picks asm2 S_left
+
+        # Output belt at y=7, all facing WEST.
+        for x in range(1, 7):
+            set_entity(world, x, 7, "transport_belt", Direction.WEST)
+
+        return world
+
+    def test_produces_electronic_circuits(self):
+        """The tile should produce electronic circuits with nonzero throughput."""
+        world = self._build_tile()
+        tp, unreachable = compare_throughput(world)
+        assert tp > 0, f"expected > 0 throughput, got {tp}"
+        # Bottleneck analysis:
+        #   - 2 inserters per assembler, each capped at 0.86 i/s
+        #   - belt A/B each feeds 2 inserters; belt supply (15 i/s) >> demand (1.72 i/s)
+        #   - per assembler: 0.86 copper_cable + 0.86 iron_plate
+        #   - recipe: 6 CC + 2 IP → 2 EC; min_ratio = min(0.86/6, 0.86/2) = 0.86/6
+        #   - per-assembler output = 2 × 0.86/6 ≈ 0.2867 EC/s
+        #   - total = 2 × 0.2867 ≈ 0.5733 EC/s
+        #   - output inserters (2 × 0.86 = 1.72 i/s cap) and belt (15 i/s) not bottlenecked
+        expected = 2 * 2 * (0.86 / 6.0)
+        assert abs(tp - expected) < 1e-3, (
+            f"expected throughput ≈ {expected:.4f} (copper_cable-limited), got {tp}"
+        )
+
+    def test_removing_one_input_inserter_halves_throughput(self):
+        """Breaking one input feed should cut throughput of that assembler to 0.
+
+        Removing the N_left inserter of asm1 means asm1 gets no copper_cable
+        (its only belt-B feed), so asm1 produces 0. asm2 is unaffected.
+        Total throughput should drop to exactly half.
+        """
+        world = self._build_tile()
+        # Remove inserter at (1,2) (asm1's belt-B feed)
+        set_entity(world, 1, 2, "empty", Direction.NONE)
+        tp, _ = compare_throughput(world)
+        expected_full = 2 * 2 * (0.86 / 6.0)
+        expected_half = expected_full / 2
+        assert abs(tp - expected_half) < 1e-3, (
+            f"expected ≈ {expected_half:.4f} (half of {expected_full:.4f}), got {tp}"
+        )
+
+    def test_removing_underground_exit_only_breaks_asm2(self):
+        """Removing the underground EXIT at (6,1) breaks only asm2's belt-B feed.
+
+        In both real Factorio and Factorion, inserters can pick items
+        directly from an underground-belt tile (entry or exit). So
+        inserter at (1,2) picking from the underground ENTRY at (1,1)
+        still works — asm1 keeps producing. Only asm2, fed via inserter
+        (6,2) from the now-removed exit tile, loses its copper_cable.
+        Throughput halves.
+        """
+        world = self._build_tile()
+        set_entity(world, 6, 1, "empty", Direction.NONE)
+        tp, _ = compare_throughput(world)
+        expected_full = 2 * 2 * (0.86 / 6.0)
+        expected_half = expected_full / 2
+        assert abs(tp - expected_half) < 1e-3, (
+            f"expected ≈ {expected_half:.4f} (asm1 only), got {tp}"
+        )
+
+    def test_removing_underground_entry_kills_belt_b_entirely(self):
+        """Removing the underground ENTRY at (1,1) kills belt B for both assemblers.
+
+        With no entry, the source at (0,1) has no downstream cell, AND the
+        exit at (6,1) has no inflow. Both copper_cable-feeding inserters
+        ((1,2) and (6,2)) lose their pickup source → all assemblers starve
+        of copper_cable → total throughput drops to 0.
+        """
+        world = self._build_tile()
+        set_entity(world, 1, 1, "empty", Direction.NONE)
+        tp, _ = compare_throughput(world)
+        assert tp == 0, f"expected 0 (belt B fully broken), got {tp}"
+
+    def test_removing_output_inserter_halves_throughput(self):
+        """Removing one output inserter means one assembler's product is stranded."""
+        world = self._build_tile()
+        set_entity(world, 3, 6, "empty", Direction.NONE)  # asm1's output
+        tp, _ = compare_throughput(world)
+        expected_full = 2 * 2 * (0.86 / 6.0)
+        expected_half = expected_full / 2
+        assert abs(tp - expected_half) < 1e-3, (
+            f"expected ≈ {expected_half:.4f}, got {tp}"
+        )
+
+
 # ── Different items ──────────────────────────────────────────────────────────
 
 

--- a/tests/test_lesson_generation.py
+++ b/tests/test_lesson_generation.py
@@ -7,6 +7,7 @@ import torch
 
 from helpers import (
     Channel,
+    DIR_TO_DELTA,
     Direction,
     Footprint,
     LessonKind,
@@ -14,10 +15,12 @@ from helpers import (
     compare_throughput,
     entities,
     generate_lesson,
+    items,
     py_throughput_safe,
     rs_throughput,
     str2ent,
     str2item,
+    world2graph,
     world2html,
 )
 
@@ -1409,4 +1412,317 @@ class TestAssemble1In1OutRecipeSelection:
         expected = {str2item("copper_cable").value, str2item("iron_gear_wheel").value}
         assert seen_recipes == expected, (
             f"Expected to see both recipes across 100 seeds, got {seen_recipes}"
+        )
+
+
+# ── ASSEMBLE_1IN_1OUT — semantic-correctness coverage ───────────────────────
+
+
+def _asm_tiles(world):
+    """Return the set of (x, y) tiles occupied by the assembler."""
+    ent = world[Channel.ENTITIES.value]
+    asm_val = str2ent("assembling_machine_1").value
+    return {tuple(p.tolist()) for p in (ent == asm_val).nonzero(as_tuple=False)}
+
+
+def _inserters(world):
+    """Return [(pos, dir_value)] for each inserter on the grid."""
+    ent = world[Channel.ENTITIES.value]
+    dirs = world[Channel.DIRECTION.value]
+    ins_val = str2ent("inserter").value
+    out = []
+    for p in (ent == ins_val).nonzero(as_tuple=False):
+        x, y = p[0].item(), p[1].item()
+        out.append(((x, y), dirs[x, y].item()))
+    return out
+
+
+def _dir_from_value(d_val):
+    """Look up Direction enum from int value, or None for NONE."""
+    for d in Direction:
+        if d.value == d_val:
+            return d
+    return None
+
+
+class TestAssemble1In1OutInserterGeometry:
+    """Each lesson must have exactly one input inserter (drop into the
+    assembler body) and one output inserter (pickup from the assembler
+    body). Inserters must be on valid non-corner perimeter slots."""
+
+    @pytest.mark.parametrize("seed", range(30))
+    def test_exactly_one_input_one_output_inserter(self, seed):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT,
+            num_missing_entities=0, seed=seed,
+        )
+        asm = _asm_tiles(world)
+        assert len(asm) == 9
+
+        input_count = 0
+        output_count = 0
+        for (x, y), d_val in _inserters(world):
+            d = _dir_from_value(d_val)
+            assert d is not None, f"seed={seed}: inserter at ({x},{y}) has invalid dir"
+            dx, dy = DIR_TO_DELTA[d]
+            drop = (x + dx, y + dy)
+            pickup = (x - dx, y - dy)
+            drop_in_asm = drop in asm
+            pickup_in_asm = pickup in asm
+            assert drop_in_asm or pickup_in_asm, (
+                f"seed={seed}: inserter at ({x},{y}) dir={d.name} — neither "
+                f"drop {drop} nor pickup {pickup} is inside assembler"
+            )
+            assert not (drop_in_asm and pickup_in_asm), (
+                f"seed={seed}: inserter at ({x},{y}) has both pickup and drop "
+                f"inside assembler — impossible geometry"
+            )
+            if drop_in_asm:
+                input_count += 1
+            else:
+                output_count += 1
+
+        assert input_count == 1, f"seed={seed}: expected 1 input inserter, got {input_count}"
+        assert output_count == 1, f"seed={seed}: expected 1 output inserter, got {output_count}"
+
+    @pytest.mark.parametrize("seed", range(30))
+    def test_inserters_on_non_corner_perimeter(self, seed):
+        """Inserters must be on the 12 non-corner perimeter slots — not on
+        the 4 corner slots (which the engine ignores) and not anywhere else.
+        """
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT,
+            num_missing_entities=0, seed=seed,
+        )
+        asm = _asm_tiles(world)
+        # Anchor = min x, min y of the assembler tiles
+        ax = min(x for x, _ in asm)
+        ay = min(y for _, y in asm)
+
+        valid_slots = set()
+        # 12 non-corner perimeter slots: 3 per side
+        for d in range(3):
+            valid_slots.add((ax + d, ay - 1))     # north side
+            valid_slots.add((ax + d, ay + 3))     # south side
+            valid_slots.add((ax - 1, ay + d))     # west side
+            valid_slots.add((ax + 3, ay + d))     # east side
+
+        for (x, y), _ in _inserters(world):
+            assert (x, y) in valid_slots, (
+                f"seed={seed}: inserter at ({x},{y}) is not on a valid "
+                f"non-corner perimeter slot of the assembler at ({ax},{ay})"
+            )
+
+
+class TestAssemble1In1OutConnectivity:
+    """The graph must form a continuous source → … → sink path that passes
+    through the assembler. No orphaned belts."""
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_source_reaches_sink_through_assembler(self, seed):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT,
+            num_missing_entities=0, seed=seed,
+        )
+        G = world2graph(world.permute(1, 2, 0))
+
+        # Find source / sink / assembler nodes by name substring
+        source_nodes = [n for n in G.nodes if "stack_inserter" in n]
+        sink_nodes = [n for n in G.nodes if "bulk_inserter" in n]
+        asm_nodes = [n for n in G.nodes if "assembling_machine" in n]
+        assert len(source_nodes) == 1, f"seed={seed}: {len(source_nodes)} sources"
+        assert len(sink_nodes) == 1, f"seed={seed}: {len(sink_nodes)} sinks"
+        assert len(asm_nodes) == 1, f"seed={seed}: {len(asm_nodes)} assemblers"
+
+        import networkx as nx
+        # Source must reach assembler
+        assert nx.has_path(G, source_nodes[0], asm_nodes[0]), (
+            f"seed={seed}: source cannot reach assembler"
+        )
+        # Assembler must reach sink
+        assert nx.has_path(G, asm_nodes[0], sink_nodes[0]), (
+            f"seed={seed}: assembler cannot reach sink"
+        )
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_no_orphaned_belts(self, seed):
+        """Every placed belt should be on the source → sink chain (or at
+        least connected to either endpoint via the graph)."""
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT,
+            num_missing_entities=0, seed=seed,
+        )
+        G = world2graph(world.permute(1, 2, 0))
+        import networkx as nx
+
+        source_nodes = [n for n in G.nodes if "stack_inserter" in n]
+        sink_nodes = [n for n in G.nodes if "bulk_inserter" in n]
+        belt_nodes = [n for n in G.nodes if "transport_belt" in n]
+        assert source_nodes and sink_nodes
+        src, snk = source_nodes[0], sink_nodes[0]
+        for belt in belt_nodes:
+            assert nx.has_path(G, src, belt) or nx.has_path(G, belt, snk), (
+                f"seed={seed}: belt {belt} is orphaned — not reachable from "
+                f"source nor reaches sink"
+            )
+
+
+class TestAssemble1In1OutThroughputPerRecipe:
+    """Each recipe has a known closed-form throughput given a
+    1 input inserter + 1 output inserter cap of 0.86 i/s.
+
+      copper_cable: 1 cu_plate → 2 cu_cable, 0.5s
+        Input flow at full inserter cap:
+          0.86 cu_plate/s; recipe needs 1 per craft → ratio 0.86
+          produces 2 × 0.86 = 1.72 cu_cable/s
+          output inserter caps at 0.86 → final throughput = 0.86 cu_cable/s
+
+      iron_gear_wheel: 2 ir_plate → 1 ir_gear_wheel, 0.5s
+        Input flow at full inserter cap:
+          0.86 ir_plate/s; recipe needs 2 per craft → ratio 0.43
+          produces 1 × 0.43 = 0.43 ir_gear_wheel/s
+          output inserter cap (0.86) is not binding → final = 0.43
+    """
+
+    EXPECTED_TP = {
+        "copper_cable": 0.86,
+        "iron_gear_wheel": 0.43,
+    }
+
+    @pytest.mark.parametrize("seed", range(40))
+    def test_throughput_matches_recipe_closed_form(self, seed):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT,
+            num_missing_entities=0, seed=seed,
+        )
+        ent = world[Channel.ENTITIES.value]
+        item = world[Channel.ITEMS.value]
+        sink_pos = (ent == str2ent("sink").value).nonzero(as_tuple=False)[0]
+        recipe_name = items[item[sink_pos[0], sink_pos[1]].item()].name
+        expected = self.EXPECTED_TP[recipe_name]
+
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert abs(tp - expected) < 1e-3, (
+            f"seed={seed}, recipe={recipe_name}: expected ≈ {expected}, got {tp}"
+        )
+
+
+class TestAssemble1In1OutSourceSinkOrientation:
+    """Source / sink must face into the belt chain — the cell they output
+    to / take from must contain a belt (or directly the inserter pickup)."""
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_source_faces_belt(self, seed):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT,
+            num_missing_entities=0, seed=seed,
+        )
+        ent = world[Channel.ENTITIES.value]
+        dirs = world[Channel.DIRECTION.value]
+        src_pos = (ent == str2ent("source").value).nonzero(as_tuple=False)[0]
+        sx, sy = src_pos[0].item(), src_pos[1].item()
+        d = _dir_from_value(dirs[sx, sy].item())
+        dx, dy = DIR_TO_DELTA[d]
+        out_x, out_y = sx + dx, sy + dy
+        downstream = ent[out_x, out_y].item()
+        # Should be a belt or inserter (the source feeds into the belt chain)
+        valid = {str2ent("transport_belt").value, str2ent("inserter").value}
+        assert downstream in valid, (
+            f"seed={seed}: source at ({sx},{sy}) faces ({out_x},{out_y}) which "
+            f"holds entity {entities[downstream].name}, not a belt/inserter"
+        )
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_sink_faces_belt(self, seed):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT,
+            num_missing_entities=0, seed=seed,
+        )
+        ent = world[Channel.ENTITIES.value]
+        dirs = world[Channel.DIRECTION.value]
+        snk_pos = (ent == str2ent("sink").value).nonzero(as_tuple=False)[0]
+        sx, sy = snk_pos[0].item(), snk_pos[1].item()
+        d = _dir_from_value(dirs[sx, sy].item())
+        dx, dy = DIR_TO_DELTA[d]
+        # Sink takes from `pos - delta(dir)` (its input cell)
+        in_x, in_y = sx - dx, sy - dy
+        upstream = ent[in_x, in_y].item()
+        valid = {str2ent("transport_belt").value, str2ent("inserter").value}
+        assert upstream in valid, (
+            f"seed={seed}: sink at ({sx},{sy}) takes from ({in_x},{in_y}) which "
+            f"holds entity {entities[upstream].name}, not a belt/inserter"
+        )
+
+
+class TestAssemble1In1OutBeltItems:
+    """Belt tiles should not have items set in the ITEMS channel — items
+    only travel through belts at runtime; the channel is for source/sink/
+    recipe metadata, not transient cargo."""
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_belt_items_channel_is_empty(self, seed):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT,
+            num_missing_entities=0, seed=seed,
+        )
+        ent = world[Channel.ENTITIES.value]
+        item = world[Channel.ITEMS.value]
+        belt_val = str2ent("transport_belt").value
+        empty = str2item("empty").value
+        for p in (ent == belt_val).nonzero(as_tuple=False):
+            x, y = p[0].item(), p[1].item()
+            assert item[x, y].item() == empty, (
+                f"seed={seed}: belt at ({x},{y}) has unexpected item "
+                f"{items[item[x, y].item()].name}"
+            )
+
+
+class TestAssemble1In1OutEdgeCases:
+    """Edge cases: tiny grids, large grids."""
+
+    @pytest.mark.parametrize("size", [1, 2])
+    def test_grid_too_small_raises(self, size):
+        with pytest.raises(Exception):
+            generate_lesson(
+                size=size, kind=LessonKind.ASSEMBLE_1IN_1OUT,
+                num_missing_entities=0, seed=0,
+            )
+
+    @pytest.mark.parametrize("seed", range(5))
+    def test_large_grid_works(self, seed):
+        world, _ = generate_lesson(
+            size=20, kind=LessonKind.ASSEMBLE_1IN_1OUT,
+            num_missing_entities=0, seed=seed,
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0
+
+
+class TestAssemble1In1OutMaxEntities:
+    """The `max_entities` cap on belt-path length should be respected by
+    the generator (it retries until it finds a layout under the cap)."""
+
+    @pytest.mark.parametrize("seed", range(10))
+    def test_respects_max_entities(self, seed):
+        # Generate without a cap to find the natural entity count, then
+        # impose a cap of natural+5 and verify regeneration succeeds and
+        # respects the limit.
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT,
+            num_missing_entities=0, seed=seed,
+        )
+        ent = world[Channel.ENTITIES.value]
+        belts = (ent == str2ent("transport_belt").value).sum().item()
+        natural_total = belts + 3  # +1 assembler unit, +2 inserters
+
+        # Generation under the natural cap should still succeed.
+        world2, _ = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT,
+            num_missing_entities=0, seed=seed, max_entities=natural_total + 5,
+        )
+        ent2 = world2[Channel.ENTITIES.value]
+        belts2 = (ent2 == str2ent("transport_belt").value).sum().item()
+        total2 = belts2 + 3
+        assert total2 <= natural_total + 5, (
+            f"seed={seed}: generator placed {total2} entities (cap was {natural_total + 5})"
         )

--- a/tests/test_lesson_generation.py
+++ b/tests/test_lesson_generation.py
@@ -1030,3 +1030,347 @@ class TestWorld2HtmlMultiTile:
             f"splitter icon, got {full_count} (secondary tile is being "
             f"double-rendered)"
         )
+
+
+
+# ── ASSEMBLE_1IN_1OUT tests ──────────────────────────────────────────────────
+#
+# An ASSEMBLE_1IN_1OUT lesson is:
+#   source(input item) → belt → input inserter → 3×3 assembler (recipe) →
+#                                                output inserter → belt → sink(output item)
+# The recipe is randomly chosen from all 1-input 1-output recipes
+# (currently: copper_cable, iron_gear_wheel).
+
+
+# Recipes with one ingredient and one product type. Both 1-in-1-out
+# recipes available at the time of writing produce different output:
+#   copper_cable:    1 cu_plate → 2 cu_cable
+#   iron_gear_wheel: 2 ir_plate → 1 ir_gear_wheel
+ONE_IN_ONE_OUT_RECIPES = {
+    "copper_cable": ("copper_plate", "copper_cable"),
+    "iron_gear_wheel": ("iron_plate", "iron_gear_wheel"),
+}
+
+
+class TestAssemble1In1OutBasic:
+    """Basic sanity checks for ASSEMBLE_1IN_1OUT lesson generation."""
+
+    def test_generates_without_error(self):
+        world, min_ent = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT, num_missing_entities=0, seed=42
+        )
+        assert world is not None
+        assert min_ent is not None
+
+    def test_returns_cwh_tensor(self):
+        size = 10
+        world, _ = generate_lesson(
+            size=size, kind=LessonKind.ASSEMBLE_1IN_1OUT, num_missing_entities=0, seed=42
+        )
+        assert world.shape[0] == len(Channel)
+        assert world.shape[1] == size
+        assert world.shape[2] == size
+
+    def test_has_one_source_one_sink(self):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT, num_missing_entities=0, seed=42
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        assert (ent_layer == str2ent("source").value).sum().item() == 1
+        assert (ent_layer == str2ent("sink").value).sum().item() == 1
+
+    def test_has_one_assembler(self):
+        """The assembler is a 3×3 multi-tile entity, so 9 tiles."""
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT, num_missing_entities=0, seed=42
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        asm_count = (ent_layer == str2ent("assembling_machine_1").value).sum().item()
+        assert asm_count == 9, f"Expected 9 assembler tiles, got {asm_count}"
+
+    def test_has_two_inserters(self):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT, num_missing_entities=0, seed=42
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        inserter_count = (ent_layer == str2ent("inserter").value).sum().item()
+        assert inserter_count == 2, f"Expected 2 inserters, got {inserter_count}"
+
+    def test_has_belts(self):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT, num_missing_entities=0, seed=42
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        belt_count = (ent_layer == str2ent("transport_belt").value).sum().item()
+        assert belt_count >= 2, f"Expected at least 2 belts, got {belt_count}"
+
+    def test_nonzero_throughput(self):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT, num_missing_entities=0, seed=42
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0, f"Expected positive throughput, got {tp}"
+
+
+class TestAssemble1In1OutManySeeds:
+    """Generate many lessons with different seeds and verify all are valid."""
+
+    @pytest.mark.parametrize("seed", range(50))
+    def test_size_10_seed(self, seed):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT, num_missing_entities=0, seed=seed
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0, f"seed={seed}: throughput is {tp}"
+
+    @pytest.mark.parametrize("seed", range(30))
+    def test_size_8_seed(self, seed):
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.ASSEMBLE_1IN_1OUT, num_missing_entities=0, seed=seed
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0, f"seed={seed}: throughput is {tp}"
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_size_12_seed(self, seed):
+        world, _ = generate_lesson(
+            size=12, kind=LessonKind.ASSEMBLE_1IN_1OUT, num_missing_entities=0, seed=seed
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0, f"seed={seed}: throughput is {tp}"
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_size_15_seed(self, seed):
+        world, _ = generate_lesson(
+            size=15, kind=LessonKind.ASSEMBLE_1IN_1OUT, num_missing_entities=0, seed=seed
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0, f"seed={seed}: throughput is {tp}"
+
+
+class TestAssemble1In1OutParity:
+    """Python and Rust throughput must agree on generated factories."""
+
+    @pytest.mark.parametrize("seed", range(30))
+    def test_parity_size_10(self, seed):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT, num_missing_entities=0, seed=seed
+        )
+        world_whc = world.permute(1, 2, 0)
+        py_tp, py_ur = py_throughput_safe(world_whc)
+        rs_tp, rs_ur = rs_throughput(world_whc)
+        assert abs(py_tp - rs_tp) < 1e-6, (
+            f"seed={seed}: Python={py_tp}, Rust={rs_tp}"
+        )
+        assert py_ur == rs_ur, (
+            f"seed={seed}: unreachable Python={py_ur}, Rust={rs_ur}"
+        )
+
+
+class TestAssemble1In1OutGridSizes:
+    """Test across a range of grid sizes."""
+
+    @pytest.mark.parametrize("size", [8, 9, 10, 12, 15])
+    def test_valid_factory_per_size(self, size):
+        world, _ = generate_lesson(
+            size=size, kind=LessonKind.ASSEMBLE_1IN_1OUT, num_missing_entities=0, seed=7
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        assert (ent_layer == str2ent("source").value).sum().item() == 1
+        assert (ent_layer == str2ent("sink").value).sum().item() == 1
+        assert (ent_layer == str2ent("assembling_machine_1").value).sum().item() == 9
+        assert (ent_layer == str2ent("inserter").value).sum().item() == 2
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0
+
+    def test_too_small_grid_raises(self):
+        """A grid smaller than 3×3 cannot fit the assembler."""
+        with pytest.raises(Exception):
+            generate_lesson(
+                size=2, kind=LessonKind.ASSEMBLE_1IN_1OUT, num_missing_entities=0, seed=0
+            )
+
+
+class TestAssemble1In1OutEntityDirections:
+    """All placed entities must have a non-NONE direction."""
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_all_entities_have_directions(self, seed):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT, num_missing_entities=0, seed=seed
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        dir_layer = world[Channel.DIRECTION.value]
+
+        for x in range(world.shape[1]):
+            for y in range(world.shape[2]):
+                ent_val = ent_layer[x, y].item()
+                if ent_val != str2ent("empty").value:
+                    dir_val = dir_layer[x, y].item()
+                    assert dir_val != Direction.NONE.value, (
+                        f"seed={seed}: entity {entities[ent_val].name} at ({x},{y}) "
+                        f"has NONE direction"
+                    )
+
+
+class TestAssemble1In1OutNoOverlaps:
+    """Verify no entity overlaps in generated factories."""
+
+    @pytest.mark.parametrize("seed", range(30))
+    def test_no_double_placement(self, seed):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT, num_missing_entities=0, seed=seed
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        occupied = []
+        for x in range(world.shape[1]):
+            for y in range(world.shape[2]):
+                if ent_layer[x, y].item() != str2ent("empty").value:
+                    occupied.append((x, y))
+        assert len(occupied) == len(set(occupied)), (
+            f"seed={seed}: duplicate positions"
+        )
+
+
+class TestAssemble1In1OutItems:
+    """Item channels: source carries the ingredient, sink the product, assembler the recipe."""
+
+    @pytest.mark.parametrize("seed", range(30))
+    def test_source_sink_items_match_a_known_recipe(self, seed):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT, num_missing_entities=0, seed=seed
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        item_layer = world[Channel.ITEMS.value]
+
+        source_pos = (ent_layer == str2ent("source").value).nonzero(as_tuple=False)[0]
+        sink_pos = (ent_layer == str2ent("sink").value).nonzero(as_tuple=False)[0]
+
+        source_item = item_layer[source_pos[0], source_pos[1]].item()
+        sink_item = item_layer[sink_pos[0], sink_pos[1]].item()
+
+        assert source_item != str2item("empty").value, (
+            f"seed={seed}: source has no item set"
+        )
+        assert sink_item != str2item("empty").value, (
+            f"seed={seed}: sink has no item set"
+        )
+        assert source_item != sink_item, (
+            f"seed={seed}: source and sink items are equal — recipe must transform"
+        )
+
+        # The (input, output) pair must match exactly one of the known
+        # 1-in-1-out recipes.
+        valid_pairs = {
+            (str2item(inp).value, str2item(out).value)
+            for (inp, out) in ONE_IN_ONE_OUT_RECIPES.values()
+        }
+        assert (source_item, sink_item) in valid_pairs, (
+            f"seed={seed}: pair ({source_item}, {sink_item}) does not match any "
+            f"known 1-in-1-out recipe"
+        )
+
+    @pytest.mark.parametrize("seed", range(30))
+    def test_assembler_recipe_matches_output(self, seed):
+        """The assembler's ITEMS channel value (recipe) should be the same
+        item the sink consumes."""
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT, num_missing_entities=0, seed=seed
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        item_layer = world[Channel.ITEMS.value]
+        asm_positions = (ent_layer == str2ent("assembling_machine_1").value).nonzero(
+            as_tuple=False
+        )
+        sink_pos = (ent_layer == str2ent("sink").value).nonzero(as_tuple=False)[0]
+        sink_item = item_layer[sink_pos[0], sink_pos[1]].item()
+
+        for pos in asm_positions:
+            asm_item = item_layer[pos[0], pos[1]].item()
+            assert asm_item == sink_item, (
+                f"seed={seed}: assembler tile at ({pos[0].item()}, {pos[1].item()}) "
+                f"has recipe {asm_item}, sink expects {sink_item}"
+            )
+
+
+class TestAssemble1In1OutMissingEntities:
+    """Test entity removal."""
+
+    @pytest.mark.parametrize("num_missing", [1, 2, 3])
+    def test_removes_correct_count(self, num_missing):
+        world, min_ent = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT, num_missing_entities=num_missing,
+            seed=42,
+        )
+        assert min_ent == num_missing
+        ent_layer = world[Channel.ENTITIES.value]
+        # Source, sink remain
+        assert (ent_layer == str2ent("source").value).sum().item() == 1
+        assert (ent_layer == str2ent("sink").value).sum().item() == 1
+
+    @pytest.mark.parametrize("seed", range(10))
+    def test_missing_inf_returns_positive_count(self, seed):
+        world, min_ent = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT,
+            num_missing_entities=float("inf"), seed=seed,
+        )
+        assert world is not None
+        assert min_ent is not None and min_ent > 0
+
+
+class TestAssemble1In1OutDeterminism:
+    """Same seed → identical world."""
+
+    @pytest.mark.parametrize("seed", [0, 1, 7, 42, 100])
+    def test_same_seed_same_world(self, seed):
+        w1, m1 = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT, num_missing_entities=0, seed=seed
+        )
+        w2, m2 = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT, num_missing_entities=0, seed=seed
+        )
+        assert torch.equal(w1, w2), f"seed={seed}: regenerated world differs"
+        assert m1 == m2
+
+
+class TestAssemble1In1OutThroughputRange:
+    """Throughput should be positive and bounded by the assembler / inserter caps."""
+
+    @pytest.mark.parametrize("seed", range(30))
+    def test_throughput_in_expected_range(self, seed):
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT, num_missing_entities=0, seed=seed
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        # Lower bound: positive
+        assert tp > 0, f"seed={seed}: tp={tp}"
+        # Upper bound: an inserter caps at 0.86 i/s, and the output side
+        # has only one inserter, so output throughput cannot exceed 0.86 ×
+        # produces_per_craft. The two recipes give 2× (CC) and 1× (IGW)
+        # the ingredient cost, so the loosest bound is 0.86 × 2 = 1.72.
+        assert tp <= 1.72 + 1e-6, f"seed={seed}: tp={tp} exceeds inserter+recipe cap"
+
+
+class TestAssemble1In1OutRecipeSelection:
+    """Recipe is randomly picked across seeds — both known recipes should
+    appear at least once across many seeds."""
+
+    def test_both_recipes_appear(self):
+        seen_recipes = set()
+        for seed in range(100):
+            world, _ = generate_lesson(
+                size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT,
+                num_missing_entities=0, seed=seed,
+            )
+            ent_layer = world[Channel.ENTITIES.value]
+            item_layer = world[Channel.ITEMS.value]
+            sink_pos = (ent_layer == str2ent("sink").value).nonzero(as_tuple=False)[0]
+            sink_item = item_layer[sink_pos[0], sink_pos[1]].item()
+            seen_recipes.add(sink_item)
+
+        # We have 2 recipes; we should see both (probabilistically essentially
+        # certain across 100 seeds with uniform selection).
+        expected = {str2item("copper_cable").value, str2item("iron_gear_wheel").value}
+        assert seen_recipes == expected, (
+            f"Expected to see both recipes across 100 seeds, got {seen_recipes}"
+        )

--- a/tests/test_lesson_generation.py
+++ b/tests/test_lesson_generation.py
@@ -1317,6 +1317,42 @@ class TestAssemble1In1OutMissingEntities:
         assert world is not None
         assert min_ent is not None and min_ent > 0
 
+    @pytest.mark.parametrize("seed", range(10))
+    @pytest.mark.parametrize("num_missing", [1, 5, 20, float("inf")])
+    def test_assembler_always_present(self, seed, num_missing):
+        """The assembler is structurally required and must never be removed,
+        regardless of num_missing_entities."""
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT,
+            num_missing_entities=num_missing, seed=seed,
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        asm_count = (ent_layer == str2ent("assembling_machine_1").value).sum().item()
+        assert asm_count == 9, (
+            f"seed={seed}, num_missing={num_missing}: assembler removed "
+            f"({asm_count} tiles, expected 9)"
+        )
+
+    @pytest.mark.parametrize("seed", range(10))
+    @pytest.mark.parametrize("num_missing", [1, 5, 20, float("inf")])
+    def test_assembler_recipe_preserved_after_removal(self, seed, num_missing):
+        """The recipe channel on assembler tiles must survive blanking."""
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT,
+            num_missing_entities=num_missing, seed=seed,
+        )
+        ent_layer = world[Channel.ENTITIES.value]
+        item_layer = world[Channel.ITEMS.value]
+        asm_positions = (ent_layer == str2ent("assembling_machine_1").value).nonzero(
+            as_tuple=False
+        )
+        for pos in asm_positions:
+            recipe_val = item_layer[pos[0], pos[1]].item()
+            assert recipe_val != str2item("empty").value, (
+                f"seed={seed}, num_missing={num_missing}: assembler tile "
+                f"({pos[0].item()},{pos[1].item()}) lost its recipe"
+            )
+
 
 class TestAssemble1In1OutDeterminism:
     """Same seed → identical world."""

--- a/tests/test_parity.py
+++ b/tests/test_parity.py
@@ -220,18 +220,26 @@ class TestGeneratedLessons:
 class TestFuzz:
     """Fuzz test: generate random factory layouts and check parity."""
 
-    # All 1x1 entity IDs. Multi-tile entities (assembler=3, splitter=7) are
-    # excluded because random single-cell placement is invalid for them.
-    ENTITY_VALUES = [eid for eid, e in entities.items() if e.width == 1 and e.height == 1]
+    # All placeable 1x1 entity IDs. Multi-tile placeables (assembler=3,
+    # splitter=7) are excluded because random single-cell placement is
+    # invalid for them. Non-placeable items (CC, IP, etc.) are excluded
+    # because they don't belong in the ENTITIES channel.
+    ENTITY_VALUES = [
+        eid
+        for eid, e in entities.items()
+        if e.is_placeable and e.width == 1 and e.height == 1
+    ]
     DIRECTION_VALUES = [0, 1, 2, 3, 4]
-    ITEM_VALUES = [0, 1, 2, 3, 4]
+    # Non-placeable items + the "no item" sentinel (0). These are valid
+    # values for the ITEMS channel (recipe / carried item).
+    ITEM_VALUES = [0] + [eid for eid, e in entities.items() if not e.is_placeable]
     MISC_VALUES = [0, 1, 2]
 
-    # Multi-tile entity specs: (entity_id, width, height)
+    # Multi-tile placeable entity specs: (entity_id, width, height)
     MULTI_TILE_ENTITIES = [
         (eid, e.width, e.height)
         for eid, e in entities.items()
-        if e.width > 1 or e.height > 1
+        if e.is_placeable and (e.width > 1 or e.height > 1)
     ]
 
     @staticmethod

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -49,27 +49,31 @@ class TestPyItemsBinding:
 
     def test_integer_values_are_stable(self):
         """The integer encoding must not silently change — world tensors
-        on disk and trained models depend on it. Placeable items are 1..7,
-        non-placeable 8..12."""
+        on disk and trained models depend on it. Layout: 1..5 = agent-
+        placeable, 6..10 = non-placeable items, 11..12 = env-spawned
+        sink/source (the LAST two ids so the policy entity head can be
+        sized to len(items)-2 to exclude them)."""
         rs = factorion_rs.py_items()
         assert rs[1]["name"] == "transport_belt"
         assert rs[2]["name"] == "inserter"
         assert rs[3]["name"] == "assembling_machine_1"
         assert rs[4]["name"] == "underground_belt"
-        assert rs[5]["name"] == "bulk_inserter"
-        assert rs[6]["name"] == "stack_inserter"
-        assert rs[7]["name"] == "splitter"
-        assert rs[8]["name"] == "copper_cable"
-        assert rs[9]["name"] == "copper_plate"
-        assert rs[10]["name"] == "iron_plate"
-        assert rs[11]["name"] == "electronic_circuit"
-        assert rs[12]["name"] == "iron_gear_wheel"
+        assert rs[5]["name"] == "splitter"
+        assert rs[6]["name"] == "copper_cable"
+        assert rs[7]["name"] == "copper_plate"
+        assert rs[8]["name"] == "iron_plate"
+        assert rs[9]["name"] == "electronic_circuit"
+        assert rs[10]["name"] == "iron_gear_wheel"
+        assert rs[11]["name"] == "bulk_inserter"
+        assert rs[12]["name"] == "stack_inserter"
 
     def test_placeability_is_correct(self):
         rs = factorion_rs.py_items()
-        for value in range(1, 8):
+        # Placeable: agent-buildable (1..5) + env-spawned source/sink (11, 12)
+        for value in [1, 2, 3, 4, 5, 11, 12]:
             assert rs[value]["is_placeable"] is True, f"id {value} should be placeable"
-        for value in range(8, 13):
+        # Non-placeable items: 6..10
+        for value in range(6, 11):
             assert rs[value]["is_placeable"] is False, (
                 f"id {value} should not be placeable"
             )
@@ -82,7 +86,7 @@ class TestPyItemsBinding:
 
     def test_splitter_size_is_2x1(self):
         rs = factorion_rs.py_items()
-        sp = rs[7]
+        sp = rs[5]
         assert sp["width"] == 2
         assert sp["height"] == 1
 

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -1,0 +1,189 @@
+"""Tests for the Items + Recipes single-source-of-truth migration.
+
+Items and recipes are defined in factorion_rs/src/types.rs and exposed to
+Python via factorion_rs.py_items() and factorion_rs.py_recipes(). The
+Python `items` and `recipes` dicts in factorion.py are built from these
+bindings at module load.
+
+These tests cover:
+  1. Items: known variants are present and integer values match Rust.
+  2. Recipes: end-to-end value correctness for known recipes.
+  3. Parity between the Rust binding and the Python view.
+
+Recipe quantities are the canonical Factorio wiki values (per craft).
+"""
+
+import factorion_rs
+
+from helpers import items, recipes
+
+
+# ── Items SOT ────────────────────────────────────────────────────────────────
+
+
+class TestPyItemsBinding:
+    """py_items() returns {int_value: {name, is_placeable, width, height, flow}}."""
+
+    def test_known_items_present(self):
+        rs = factorion_rs.py_items()
+        names = {props["name"] for props in rs.values()}
+        for expected in [
+            "copper_cable",
+            "copper_plate",
+            "iron_plate",
+            "electronic_circuit",
+            "iron_gear_wheel",
+            "transport_belt",
+            "inserter",
+            "assembling_machine_1",
+            "underground_belt",
+            "splitter",
+            "stack_inserter",  # Source
+            "bulk_inserter",   # Sink
+        ]:
+            assert expected in names, f"missing item {expected}"
+        # No "empty" — absence of an item is encoded as channel value 0,
+        # not as an Item variant.
+        assert "empty" not in names
+        assert 0 not in rs
+
+    def test_integer_values_are_stable(self):
+        """The integer encoding must not silently change — world tensors
+        on disk and trained models depend on it. Placeable items are 1..7,
+        non-placeable 8..12."""
+        rs = factorion_rs.py_items()
+        assert rs[1]["name"] == "transport_belt"
+        assert rs[2]["name"] == "inserter"
+        assert rs[3]["name"] == "assembling_machine_1"
+        assert rs[4]["name"] == "underground_belt"
+        assert rs[5]["name"] == "bulk_inserter"
+        assert rs[6]["name"] == "stack_inserter"
+        assert rs[7]["name"] == "splitter"
+        assert rs[8]["name"] == "copper_cable"
+        assert rs[9]["name"] == "copper_plate"
+        assert rs[10]["name"] == "iron_plate"
+        assert rs[11]["name"] == "electronic_circuit"
+        assert rs[12]["name"] == "iron_gear_wheel"
+
+    def test_placeability_is_correct(self):
+        rs = factorion_rs.py_items()
+        for value in range(1, 8):
+            assert rs[value]["is_placeable"] is True, f"id {value} should be placeable"
+        for value in range(8, 13):
+            assert rs[value]["is_placeable"] is False, (
+                f"id {value} should not be placeable"
+            )
+
+    def test_assembler_size_is_3x3(self):
+        rs = factorion_rs.py_items()
+        am1 = rs[3]
+        assert am1["width"] == 3
+        assert am1["height"] == 3
+
+    def test_splitter_size_is_2x1(self):
+        rs = factorion_rs.py_items()
+        sp = rs[7]
+        assert sp["width"] == 2
+        assert sp["height"] == 1
+
+
+class TestPythonItemsDict:
+    def test_dict_has_synthetic_empty_sentinel(self):
+        # The Python `items` dict adds a synthetic 0 → "empty" entry on
+        # top of the Rust source for tensor-decode convenience. Rust
+        # itself has no Empty variant.
+        assert 0 in items
+        assert items[0].name == "empty"
+        assert items[0].is_placeable is False
+
+    def test_dict_built_from_rust(self):
+        # All Rust-side keys are present in the Python dict.
+        rs = factorion_rs.py_items()
+        for value in rs:
+            assert value in items
+
+    def test_each_item_has_matching_props(self):
+        rs = factorion_rs.py_items()
+        for value, props in rs.items():
+            item = items[value]
+            assert item.name == props["name"]
+            assert item.value == value
+            assert item.is_placeable == props["is_placeable"]
+            assert item.width == props["width"]
+            assert item.height == props["height"]
+            assert item.flow == props["flow"]
+
+
+# ── Recipes SOT ──────────────────────────────────────────────────────────────
+
+
+class TestPyRecipesBinding:
+    """Canonical wiki recipe values (per craft, not per second)."""
+
+    def test_copper_cable(self):
+        cc = factorion_rs.py_recipes()["copper_cable"]
+        assert cc["consumes"] == {"copper_plate": 1.0}
+        assert cc["produces"] == {"copper_cable": 2.0}
+
+    def test_electronic_circuit(self):
+        ec = factorion_rs.py_recipes()["electronic_circuit"]
+        assert ec["consumes"] == {"copper_cable": 3.0, "iron_plate": 1.0}
+        assert ec["produces"] == {"electronic_circuit": 1.0}
+
+    def test_iron_gear_wheel(self):
+        igw = factorion_rs.py_recipes()["iron_gear_wheel"]
+        assert igw["consumes"] == {"iron_plate": 2.0}
+        assert igw["produces"] == {"iron_gear_wheel": 1.0}
+
+    def test_transport_belt(self):
+        tb = factorion_rs.py_recipes()["transport_belt"]
+        assert tb["consumes"] == {"iron_gear_wheel": 1.0, "iron_plate": 1.0}
+        assert tb["produces"] == {"transport_belt": 2.0}
+
+    def test_inserter(self):
+        ins = factorion_rs.py_recipes()["inserter"]
+        assert ins["consumes"] == {
+            "electronic_circuit": 1.0,
+            "iron_gear_wheel": 1.0,
+            "iron_plate": 1.0,
+        }
+        assert ins["produces"] == {"inserter": 1.0}
+
+    def test_assembling_machine_1(self):
+        am1 = factorion_rs.py_recipes()["assembling_machine_1"]
+        assert am1["consumes"] == {
+            "electronic_circuit": 3.0,
+            "iron_gear_wheel": 5.0,
+            "iron_plate": 9.0,
+        }
+        assert am1["produces"] == {"assembling_machine_1": 1.0}
+
+
+class TestPythonRecipesDict:
+    def test_recipe_is_dataclass_with_attributes(self):
+        ec = recipes["electronic_circuit"]
+        assert hasattr(ec, "consumes")
+        assert hasattr(ec, "produces")
+
+    def test_canonical_electronic_circuit(self):
+        ec = recipes["electronic_circuit"]
+        assert ec.consumes == {"copper_cable": 3.0, "iron_plate": 1.0}
+        assert ec.produces == {"electronic_circuit": 1.0}
+
+
+# ── Parity ───────────────────────────────────────────────────────────────────
+
+
+class TestRustPythonRecipeParity:
+    def test_same_recipe_names(self):
+        assert set(recipes.keys()) == set(factorion_rs.py_recipes().keys())
+
+    def test_same_consumes_and_produces(self):
+        rs = factorion_rs.py_recipes()
+        for name, py_recipe in recipes.items():
+            assert py_recipe.consumes == rs[name]["consumes"], (
+                f"{name}.consumes mismatch"
+            )
+            assert py_recipe.produces == rs[name]["produces"], (
+                f"{name}.produces mismatch"
+            )

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -91,6 +91,55 @@ class TestPyItemsBinding:
         assert sp["height"] == 1
 
 
+class TestSourceSinkAreLastTwoIds:
+    """LOAD-BEARING INVARIANT — DO NOT REMOVE.
+
+    Source and Sink MUST be the last two ids in the unified Item enum.
+    The PPO policy in ppo.py sizes its entity head to ``len(entities) - 2``
+    to structurally exclude env-spawned source/sink from agent placement
+    (see ppo.py line ~780). If anyone reorders the enum and breaks this
+    invariant, the head will sample Source/Sink as agent actions, the
+    env will reject them, and training will silently regress.
+
+    The Rust mirror is `test_source_and_sink_are_last_two_ids` in
+    factorion_rs/src/types.rs — keep both. If you genuinely need to
+    remove this protection, you must also rewrite AgentCNN.__init__'s
+    entity-head sizing in ppo.py.
+    """
+
+    def test_source_is_last_id(self):
+        rs = factorion_rs.py_items()
+        max_id = max(rs.keys())
+        assert rs[max_id]["name"] == "stack_inserter", (
+            f"the highest item id ({max_id}) must be Source/stack_inserter, "
+            f"got {rs[max_id]['name']!r}. ppo.py:780 depends on this."
+        )
+
+    def test_sink_is_second_last_id(self):
+        rs = factorion_rs.py_items()
+        ids = sorted(rs.keys())
+        second_last_id = ids[-2]
+        assert rs[second_last_id]["name"] == "bulk_inserter", (
+            f"the second-highest item id ({second_last_id}) must be Sink/"
+            f"bulk_inserter, got {rs[second_last_id]['name']!r}. "
+            f"ppo.py:780 depends on this."
+        )
+
+    def test_excluding_last_two_gives_no_source_or_sink(self):
+        """Simulate ppo.py's `len(entities) - 2` slice and verify the
+        remaining id range contains no source or sink."""
+        rs = factorion_rs.py_items()
+        ids = sorted(rs.keys())
+        # The agent's entity head sees ids[0:len(ids)-2] (the last two are
+        # excluded). After unification we have an extra synthetic 0=empty
+        # in the Python dict, but this slice is a sanity check that the
+        # `entities[:len-2]` pattern keeps the env-only entities out.
+        agent_visible = ids[:-2]
+        names = {rs[i]["name"] if i in rs else "empty" for i in agent_visible}
+        assert "stack_inserter" not in names
+        assert "bulk_inserter" not in names
+
+
 class TestPythonItemsDict:
     def test_dict_has_synthetic_empty_sentinel(self):
         # The Python `items` dict adds a synthetic 0 → "empty" entry on

--- a/wiki/inserter.md
+++ b/wiki/inserter.md
@@ -96,6 +96,31 @@ shared by Inserter, Source, and Sink:
 
 An inserter cannot drop onto empty tiles or onto other inserters.
 
+### Blueprint Direction Convention (gotcha)
+
+**Factorio blueprint strings encode an inserter's `direction` as the
+direction the arm points toward its *pickup* tile**, not the drop tile.
+This is the **opposite** of the Factorion convention (where `Direction`
+points toward the drop tile, matching "facing direction").
+
+Example: an inserter in a Factorio blueprint with `direction: 0` (NORTH)
+picks from its north neighbour and drops to its south neighbour. The
+same inserter inside Factorion would be stored with `Direction::South`.
+
+`blueprint2world` in `factorion.py` handles this by flipping inserter
+directions 180° on decode:
+
+```python
+if "inserter" in e["name"]:
+    e["direction"] = (e.get("direction", 0) + 8) % 16
+```
+
+When manually reading blueprint JSON without going through
+`blueprint2world`, always apply this flip before comparing to Factorion
+semantics. Non-inserter entities (belts, assemblers, etc.) do not need
+the flip — only inserters (including Source/Sink, which are bulk/stack
+inserters in the blueprint namespace).
+
 ### Source & Sink
 
 Source (`EntityKind::Source = 6`) and Sink (`EntityKind::Sink = 5`) are

--- a/wiki/items-and-recipes.md
+++ b/wiki/items-and-recipes.md
@@ -1,93 +1,128 @@
 # Items and Recipes
 
-The items and crafting recipes currently modeled in Factorion.
+The items and crafting recipes currently modeled in Factorion. Quantities
+match the canonical Factorio wiki values exactly (per craft).
 
 **Sources:**
 - https://wiki.factorio.com/Copper_cable
 - https://wiki.factorio.com/Electronic_circuit
+- https://wiki.factorio.com/Iron_gear_wheel
+- https://wiki.factorio.com/Transport_belt
+- https://wiki.factorio.com/Assembling_machine_1
+- https://wiki.factorio.com/Inserter
+
+**Single source of truth:** items and recipes are defined in
+`factorion_rs/src/types.rs` (`all_items()`, `all_recipes()`) and
+exposed to Python via the `factorion_rs.py_items()` / `py_recipes()`
+PyO3 bindings. To add or change an item or recipe, edit the Rust source
+and rebuild the wheel — Python sees it automatically.
 
 ## Items
 
-| Item | Enum value | Raw material? | Notes |
+| Item | Enum value | Raw input? | Notes |
 |---|---|---|---|
+| Empty | `Item::Empty = 0` | — | Sentinel "no item" value |
+| Copper Cable | `Item::CopperCable = 1` | No | Crafted from copper plates |
 | Copper Plate | `Item::CopperPlate = 2` | Yes | Smelted from copper ore (smelting not modeled) |
 | Iron Plate | `Item::IronPlate = 3` | Yes | Smelted from iron ore (smelting not modeled) |
-| Copper Cable | `Item::CopperCable = 1` | No | Crafted from copper plates |
-| Electronic Circuit | `Item::ElectronicCircuit = 4` | No | Crafted from copper cable + iron plates |
+| Electronic Circuit | `Item::ElectronicCircuit = 4` | No | Crafted from copper cable + iron plate |
+| Iron Gear Wheel | `Item::IronGearWheel = 5` | No | Crafted from iron plate; gates several build recipes |
+| Transport Belt | `Item::TransportBelt = 6` | No | The belt entity, as an inventory item |
+| Inserter | `Item::Inserter = 7` | No | The inserter entity, as an inventory item |
+| Assembling Machine 1 | `Item::AssemblingMachine1 = 8` | No | The assembler entity, as an inventory item |
 
-Copper plate and iron plate are treated as **raw inputs** in Factorion — they
-appear from Source entities. The smelting step (ore → plate) is not modeled.
+Copper plate and iron plate are treated as **raw inputs** in Factorion —
+they appear from `Source` entities. The smelting step (ore → plate) is
+not modeled.
+
+**Item-vs-entity name overlap.** Three items share their string name with
+an entity (`transport_belt`, `inserter`, `assembling_machine_1`). They
+live in *separate* enums on purpose — `Item::Inserter` (= 7) and
+`EntityKind::Inserter` (= 2) have different integer values. The `ITEMS`
+and `ENTITIES` channels of the world tensor disambiguate at runtime.
+This mirrors Factorio's data model where each placeable entity also
+exists as an inventory item.
 
 ## Recipes
 
+All recipes are 0.5s craft time on an `Assembling Machine 1`
+(`crafting_speed = 0.5`). Throughput math (`transform_flow`) operates on
+ratios, so absolute scaling is not material; we keep the wiki values
+verbatim.
+
 ### Copper Cable
 
-| | Real Factorio | Factorion |
+| Input | Output | Craft time |
 |---|---|---|
-| **Input** | 1 copper plate | 2 copper plates |
-| **Output** | 2 copper cables | 4 copper cables |
-| **Craft time** | 0.5s | Not modeled (continuous flow) |
-| **Ratio** | 1:2 | 1:2 (same) |
-
-The Factorion recipe doubles both input and output quantities but preserves the
-same ratio. This may be to make flow rates work out to nice numbers in the
-throughput graph.
-
-**In code** (`types.rs`):
-```rust
-Item::CopperCable => Recipe {
-    consumes: { CopperPlate: 2.0 },
-    produces: { CopperCable: 4.0 },
-}
-```
+| 1 copper plate | 2 copper cables | 0.5s |
 
 ### Electronic Circuit (Green Circuit)
 
-| | Real Factorio | Factorion |
+| Inputs | Output | Craft time |
 |---|---|---|
-| **Input** | 3 copper cable + 1 iron plate | 6 copper cable + 2 iron plates |
-| **Output** | 1 electronic circuit | 2 electronic circuits |
-| **Craft time** | 0.5s | Not modeled (continuous flow) |
-| **Ratio** | (3:1):1 | (3:1):1 (same) |
+| 3 copper cable + 1 iron plate | 1 electronic circuit | 0.5s |
 
-Again, quantities are doubled but ratios are preserved.
+### Iron Gear Wheel
 
-**In code** (`types.rs`):
-```rust
-Item::ElectronicCircuit => Recipe {
-    consumes: { CopperCable: 6.0, IronPlate: 2.0 },
-    produces: { ElectronicCircuit: 2.0 },
-}
-```
+| Input | Output | Craft time |
+|---|---|---|
+| 2 iron plates | 1 iron gear wheel | 0.5s |
 
-### Why the doubled quantities?
+The simplest 1-in-1-out recipe in the table. Useful as the bottom rung
+of any assembler-lesson curriculum.
 
-The recipes in Factorion use doubled quantities compared to real Factorio. The
-ratios are identical, so the game mechanics are equivalent. The doubling likely
-simplifies flow rate calculations — with an [[assembling-machine]] crafting
-speed of 0.5, the effective output rates become whole numbers.
+### Transport Belt (build recipe)
+
+| Inputs | Output | Craft time |
+|---|---|---|
+| 1 iron gear wheel + 1 iron plate | 2 transport belts | 0.5s |
+
+This is the recipe to *craft* a transport belt as an inventory item, not
+to operate one. It's modeled as a recipe so an assembler can produce
+transport-belt items on a belt.
+
+### Inserter (build recipe)
+
+| Inputs | Output | Craft time |
+|---|---|---|
+| 1 electronic circuit + 1 iron gear wheel + 1 iron plate | 1 inserter | 0.5s |
+
+### Assembling Machine 1 (build recipe)
+
+| Inputs | Output | Craft time |
+|---|---|---|
+| 3 electronic circuits + 5 iron gear wheels + 9 iron plates | 1 assembling machine 1 | 0.5s |
+
+The 3:5:9 ratio is awkward and unlikely to be the focus of a single
+lesson; mostly recorded for completeness.
 
 ## The Green Circuit Factory
 
-The project's intermediate goal is building a complete **green circuit
-(electronic circuit) production line**. This requires:
+The project's intermediate goal is a complete **green circuit production
+line**:
 
 1. **Copper plate** Source → [[transport-belt]] → [[inserter]] →
-   [[assembling-machine]] (copper cable recipe)
+   [[assembling-machine]] (copper_cable recipe)
 2. [[Inserter]] → [[transport-belt]] carrying copper cables
 3. **Iron plate** Source → [[transport-belt]] → [[inserter]] →
-   [[assembling-machine]] (electronic circuit recipe)
+   [[assembling-machine]] (electronic_circuit recipe)
 4. Copper cable belt → [[inserter]] → same [[assembling-machine]]
 5. [[Inserter]] → [[transport-belt]] → Sink consuming electronic circuits
 
-This fits in an **11x11 grid** and requires all currently modeled entities
-working together.
+This fits in an **11×11 grid** and exercises every entity currently
+modeled.
 
-## Items Not Yet Modeled
+## Operational Specs (entities)
 
-The real Factorio has hundreds of items. Items that might be added as the
-project grows:
+Reference values from the wiki for entity behavior — not all are
+currently used by Factorion's throughput model.
 
-- **Iron gear wheel** — intermediate used in many recipes
-- **Science packs** — the ultimate goal of most factories
-- **Ores** — if mining is ever modeled (copper ore, iron ore)
+| Entity | Speed / craft speed | Other | Source |
+|---|---|---|---|
+| Transport belt | 15 i/s combined (2 lanes × 7.5 i/s) | tile speed 1.875 t/s, density 8/tile | [wiki](https://wiki.factorio.com/Transport_belt) |
+| Inserter (basic) | ~0.83 i/s (not in infobox) | rotation 302°/s, energy 15.1 kW | [wiki](https://wiki.factorio.com/Inserter) |
+| Assembling machine 1 | `0.5×` crafting speed | 0 module slots, 75 kW, 4 pollution/m, no fluid recipes | [wiki](https://wiki.factorio.com/Assembling_machine_1) |
+
+The 0.5× crafting speed of AM1 is why the Rust `assembling_machine_1`
+flow rate is `0.5` (`EntityKind::AssemblingMachine1.flow_rate()` in
+`factorion_rs/src/types.rs`).


### PR DESCRIPTION
## Summary

Builds out `LessonKind::ASSEMBLE_1IN_1OUT` end-to-end: a generator that
randomly picks a 1-input-1-output recipe (currently `copper_cable` or
`iron_gear_wheel`), places a 3×3 assembler with input/output inserters
on its perimeter, routes belts from a source and to a sink, and
verifies the factory has positive throughput.

Built on top of the assembler-lessons branch (now superseded). The
foundational refactors in that branch are included here:

- **Recipe + items single source of truth** in Rust, exposed to Python
  via PyO3 (`py_recipes`, `py_items`)
- **Unified `Item` enum** — dropped `EntityKind`; all 12 variants
  (5 agent-placeable, 5 non-placeable, 2 env-spawned) live in one enum
- **`Recipe.consumes/produces`** are `NonEmpty<(Item, f64)>` — empty
  recipes are unrepresentable at compile time
- Canonical Factorio wiki recipe values

## What's new in this branch

- `LessonKind::ASSEMBLE_1IN_1OUT` lesson generator
- `_remove_entities` accepts `protected_positions` so the assembler is
  never blanked (matches the same pattern used for INSERTER_TRANSFER)
- `--kind` and `--final-only` filters on `scripts/visualise_sft_data.py`
- **Source/Sink ordering invariant locked in** — they must remain the
  last two ids in the unified `Item` enum so `ppo.py:780`'s
  `len(items)-2` slice keeps them out of the agent's entity head. Both
  Rust and Python tests are pinned with `LOAD-BEARING INVARIANT — DO
  NOT REMOVE` comments

## Test status

- Rust: **48 passed**
- Python: **2536 passed, 148 skipped**
- Pre-completion checklist: cargo fmt/clippy/test ✅, maturin develop ✅,
  pytest ✅, ruff ✅
- 217 new semantic-correctness tests for ASSEMBLE_1IN_1OUT covering
  inserter geometry, graph connectivity, throughput per recipe,
  source/sink orientation, belt items, edge cases, max_entities

## Test plan

- [ ] Maintainer smoke test
- [ ] Code review
- [x] Branch rebased onto latest origin/main
- [x] Source/Sink invariant tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)