### PR TITLE
Stop FOOTPRINT from leaking the placement set in default lessons

### DIFF
--- a/factorion.py
+++ b/factorion.py
@@ -1496,11 +1496,6 @@ def functions(
     ):
         """Remove entities from a completed lesson, respecting multi-tile units.
 
-        Also sets the FOOTPRINT channel: cells empty in the completed layout
-        become UNAVAILABLE (the agent has no business placing there); cells
-        with entities stay AVAILABLE (and remain so after blanking, marking
-        them as the buildable region the agent is meant to fill).
-
         protected_positions: optional set of (x, y) the lesson considers
         structurally required (e.g. the central inserter in INSERTER_TRANSFER,
         or the recipe-bearing assembler in ASSEMBLE_1IN_1OUT). Any
@@ -1509,18 +1504,20 @@ def functions(
         input. Source/sink are protected unconditionally via the entity-id
         `skip` set below.
 
+        FOOTPRINT is left as new_world() set it (all-AVAILABLE). A previous
+        version marked every empty cell in the completed layout as
+        UNAVAILABLE, but that effectively gave away the answer: the
+        AVAILABLE cells were exactly the optimal placement set, so the
+        agent's task collapsed to "place anything in any AVAILABLE-and-empty
+        cell." Specific lessons can override FOOTPRINT to model bounded
+        build regions (e.g. hazard-concrete imports), but the *default*
+        must not encode the solution.
+
         Returns min_entities_required (number of entity units removed).
         For multi-tile entities (e.g. splitters), all tiles are removed together
         as a single unit.
         """
         protected_positions = protected_positions or set()
-        # Mark non-buildable region from the completed layout, before any
-        # blanking. Blanked cells keep FOOTPRINT=AVAILABLE so the agent
-        # knows they are placement targets.
-        empty_id = str2ent("empty").value
-        empty_mask = world_CWH[Channel.ENTITIES.value] == empty_id
-        world_CWH[Channel.FOOTPRINT.value][empty_mask] = Footprint.UNAVAILABLE.value
-
 
         if num_missing_entities == float("inf"):
             return total_entities

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ output_max_bytes = 15_000_000
 # Existing code has many pre-existing violations in the marimo notebook
 # and training script. Ignoring rules that are pervasive but low-risk,
 # while keeping rules that catch real bugs.
+extend-exclude = [
+    ".claude",  # local Claude Code state and per-agent worktrees
+]
 lint.select = ["E", "F", "W"]
 lint.ignore = [
     "E501",  # line too long (pervasive in existing code)

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -54,16 +54,19 @@ class TestFootprintChannel:
         assert world.shape[2] == len(Channel)
         assert world.shape[2] == 5
 
-    def test_lesson_marks_buildable_region(self, env):
-        """After reset, FOOTPRINT=AVAILABLE iff the solved layout had an
-        entity at that cell. Cells empty in the completed lesson are
-        UNAVAILABLE so the agent can't place there."""
+    def test_default_lesson_footprint_is_all_available(self, env):
+        """Default lessons must NOT touch FOOTPRINT — every cell stays
+        AVAILABLE. A prior version marked every empty cell in the
+        completed layout as UNAVAILABLE, which gave the optimal
+        placement set away to the agent (AVAILABLE cells were exactly
+        the cells the agent needed to fill). Bounded build regions are
+        an opt-in per-lesson override, not a default."""
         obs, _ = env.reset(options={"num_missing_entities": 1})
         footprint = obs[Channel.FOOTPRINT.value]
-        # At least one of each value must be present for an interesting
-        # lesson (the solved factory has both entities and empty space).
-        assert (footprint == 1).any(), "Expected some AVAILABLE cells"
-        assert (footprint == 0).any(), "Expected some UNAVAILABLE cells (empty in solved)"
+        assert (footprint == 1).all(), (
+            "FOOTPRINT must be all-AVAILABLE for default lessons; "
+            "leaking the placement set is the regression."
+        )
 
     def test_observation_space_shape(self, env):
         """Observation space should have 5 channels."""
@@ -95,14 +98,10 @@ class TestMaskedPlacement:
     def test_placement_on_available_tile_succeeds(self, env):
         """Placing an entity on a FOOTPRINT=1 tile should work normally."""
         env.reset(options={"num_missing_entities": 1})
-        # Find an empty cell that's still AVAILABLE (i.e. blanked from solved,
-        # not always-empty). With num_missing_entities=1 there's exactly one.
-        empty_id = str2ent("empty").value
-        ent = env._world_CWH[Channel.ENTITIES.value]
-        fp = env._world_CWH[Channel.FOOTPRINT.value]
-        candidates = ((ent == empty_id) & (fp == 1)).nonzero(as_tuple=False)
-        assert len(candidates) > 0, "No blanked-but-available tile found"
-        tx, ty = candidates[0].tolist()
+        # Default lessons leave all tiles AVAILABLE; pick any empty cell.
+        target = find_tile(env, "empty")
+        assert target is not None, "No empty tile found"
+        tx, ty = target
 
         assert env._world_CWH[Channel.FOOTPRINT.value, tx, ty] == 1
 


### PR DESCRIPTION
## Problem

`_remove_entities` was setting `FOOTPRINT=UNAVAILABLE` for every empty cell in the completed layout. Combined with the multi-label tile BCE loss, this gave the model the answer:

- AVAILABLE cells = exactly the cells the agent needs to fill
- UNAVAILABLE cells = everywhere else (the cells that stay empty in the optimal layout)

Tile selection collapsed to "pick any AVAILABLE-and-empty cell," which is what the BCE loss already rewards. That's why the SFT smoke test consistently hit ~98% val tile accuracy regardless of lesson kind — the input encoded the solution.

## Fix

`_remove_entities` no longer touches FOOTPRINT. `new_world()` initialises it to all-AVAILABLE and lessons leave it that way by default. Specific future lessons can opt-in to bounded build regions (e.g. hazard-concrete imports), but the default must not encode the solution.

`test_lesson_marks_buildable_region` (which asserted the leak existed) is inverted into `test_default_lesson_footprint_is_all_available` (regression guard).

Also: ruff was scanning `.claude/worktrees/*` (other agents' WIP) and erroring on those. Added `extend-exclude = [".claude"]` to `pyproject.toml`.

## Expected smoke-test impact

Val tile accuracy should drop noticeably (it was being inflated by the leak). The post-fix number is the honest one.

## Test plan
- [x] Full pytest suite passes (2538 passed, 148 skipped)
- [x] ruff clean
- [x] cargo fmt + tests + clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)