### PR TITLE
Add MOVE_VIA_UG_BELT lesson (footprint-walled UG belt routing)

### DIFF
--- a/factorion.py
+++ b/factorion.py
@@ -2394,14 +2394,22 @@ def functions(
                 )
 
         elif kind.value == LessonKind.MOVE_VIA_UG_BELT.value:
-            # Source → [belts] → UG_DOWN → wall → UG_UP → [belts] → sink
-            # along a single straight line. The wall is 1..4 empty tiles which
-            # become FOOTPRINT=UNAVAILABLE in the agent's observation, forcing
-            # the agent to bridge them with an underground belt pair (max gap
-            # = 5 ⇒ wall ≤ 4). All off-line tiles are also UNAVAILABLE, so no
-            # surface detour exists.
-            original_count = max(500, size * size * 4)
+            # A 1..4-tile-thick wall spans the grid perpendicular to a chosen
+            # flow direction. UG_DOWN sits on the source side flush against
+            # the wall; UG_UP sits directly opposite on the sink side. Source
+            # and sink are placed randomly on their respective sides, and
+            # transport belts route source→UG_DOWN and UG_UP→sink via
+            # find_belt_path. FOOTPRINT marks ONLY the wall tiles as
+            # UNAVAILABLE — every other tile is freely buildable.
+            original_count = max(500, size * size * 8)
             count = original_count
+
+            if random_item:
+                item_value = random.choice(
+                    [v.value for k, v in items.items() if v.name != "empty"]
+                )
+            else:
+                item_value = str2item("electronic_circuit").value
 
             while count > 0:
                 count -= 1
@@ -2410,80 +2418,159 @@ def functions(
                 )
                 C, W, H = world_CWH.shape
 
-                direction = random.choice(
+                flow_dir = random.choice(
                     [d for d in Direction if d != Direction.NONE]
                 )
-                is_horizontal = direction in (Direction.EAST, Direction.WEST)
-                span = W if is_horizontal else H
-                perp = H if is_horizontal else W
+                is_horizontal = flow_dir in (Direction.EAST, Direction.WEST)
+                flow_span = W if is_horizontal else H
+                perp_span = H if is_horizontal else W
 
-                # Need ≥ 5 tiles along the line: source + UG_DOWN + 1-tile
-                # wall + UG_UP + sink.
-                if span < 5:
+                # Need ≥1 source-side tile + wall (≥1) + ≥1 sink-side tile
+                if flow_span < 3:
                     raise Exception(
-                        f"Grid {W}×{H} too small for MOVE_VIA_UG_BELT (need ≥ 5 along {direction})"
+                        f"Grid {W}×{H} too small for MOVE_VIA_UG_BELT (need ≥ 3 along {flow_dir})"
                     )
 
-                max_wall = min(4, span - 4)
-                wall_width = random.randint(1, max_wall)
-                slack = span - 4 - wall_width
-                pad_before = random.randint(0, slack)
-                pad_after = random.randint(0, slack - pad_before)
-                total_len = 4 + wall_width + pad_before + pad_after
+                max_wall = min(4, flow_span - 2)
+                wall_thickness = random.randint(1, max_wall)
+                wall_lo = random.randint(1, flow_span - 1 - wall_thickness)
+                wall_hi = wall_lo + wall_thickness - 1
 
-                line_perp = random.randint(0, perp - 1)
-                start = random.randint(0, span - total_len)
-
-                if random_item:
-                    item_value = random.choice(
-                        [v.value for k, v in items.items() if v.name != "empty"]
-                    )
+                forward = flow_dir in (Direction.EAST, Direction.SOUTH)
+                if forward:
+                    ug_down_flow = wall_lo - 1
+                    ug_up_flow = wall_hi + 1
+                    src_lo, src_hi = 0, wall_lo - 1
+                    snk_lo, snk_hi = wall_hi + 1, flow_span - 1
                 else:
-                    item_value = str2item("electronic_circuit").value
+                    ug_down_flow = wall_hi + 1
+                    ug_up_flow = wall_lo - 1
+                    src_lo, src_hi = wall_hi + 1, flow_span - 1
+                    snk_lo, snk_hi = 0, wall_lo - 1
 
-                # Build offsets along the line (forward = increasing pos_along).
-                # Reversed for WEST/NORTH so source still leads.
-                forward = direction in (Direction.EAST, Direction.SOUTH)
-                offsets = {}
-                i = 0
-                offsets["source"] = i
-                i += 1
-                pre_keys = []
-                for k in range(pad_before):
-                    key = f"belt_pre_{k}"
-                    offsets[key] = i
-                    pre_keys.append(key)
-                    i += 1
-                offsets["ug_down"] = i
-                i += 1
-                i += wall_width  # wall — no entities placed here
-                offsets["ug_up"] = i
-                i += 1
-                post_keys = []
-                for k in range(pad_after):
-                    key = f"belt_post_{k}"
-                    offsets[key] = i
-                    post_keys.append(key)
-                    i += 1
-                offsets["sink"] = i
+                ug_perp = random.randint(0, perp_span - 1)
 
-                if not forward:
-                    offsets = {k: total_len - 1 - v for k, v in offsets.items()}
+                def fp_to_xy(fc, pc, ih=is_horizontal):
+                    return (fc, pc) if ih else (pc, fc)
 
-                def linepos(off, ip=is_horizontal, lp=line_perp, st=start):
-                    pa = st + off
-                    return (pa, lp) if ip else (lp, pa)
+                ug_down_pos = fp_to_xy(ug_down_flow, ug_perp)
+                ug_up_pos = fp_to_xy(ug_up_flow, ug_perp)
 
-                source_pos = linepos(offsets["source"])
-                sink_pos = linepos(offsets["sink"])
-                ug_down_pos = linepos(offsets["ug_down"])
-                ug_up_pos = linepos(offsets["ug_up"])
+                wall_tiles = set()
+                for fc in range(wall_lo, wall_hi + 1):
+                    for pc in range(perp_span):
+                        wall_tiles.add(fp_to_xy(fc, pc))
 
+                source_cells = []
+                for fc in range(src_lo, src_hi + 1):
+                    for pc in range(perp_span):
+                        cell = fp_to_xy(fc, pc)
+                        if cell != ug_down_pos:
+                            source_cells.append(cell)
+                sink_cells = []
+                for fc in range(snk_lo, snk_hi + 1):
+                    for pc in range(perp_span):
+                        cell = fp_to_xy(fc, pc)
+                        if cell != ug_up_pos:
+                            sink_cells.append(cell)
+                if not source_cells or not sink_cells:
+                    continue
+
+                source_pos = random.choice(source_cells)
+                sink_pos = random.choice(sink_cells)
+                dirs = [d for d in Direction if d != Direction.NONE]
+                source_dir = random.choice(dirs)
+                sink_dir = random.choice(dirs)
+
+                ds = DIR_TO_DELTA[source_dir]
+                dk = DIR_TO_DELTA[sink_dir]
+                source_drop = (source_pos[0] + ds[0], source_pos[1] + ds[1])
+                sink_input = (sink_pos[0] - dk[0], sink_pos[1] - dk[1])
+
+                if not (0 <= source_drop[0] < W and 0 <= source_drop[1] < H):
+                    continue
+                if not (0 <= sink_input[0] < W and 0 <= sink_input[1] < H):
+                    continue
+
+                # source_drop must be on source side or land directly on UG_DOWN
+                if source_drop in wall_tiles:
+                    continue
+                if source_drop in (ug_up_pos, sink_pos):
+                    continue
+                sd_flow = source_drop[0] if is_horizontal else source_drop[1]
+                if not (
+                    src_lo <= sd_flow <= src_hi or source_drop == ug_down_pos
+                ):
+                    continue
+
+                # sink_input must be on sink side or land directly on UG_UP
+                if sink_input in wall_tiles:
+                    continue
+                if sink_input in (ug_down_pos, source_pos):
+                    continue
+                si_flow = sink_input[0] if is_horizontal else sink_input[1]
+                if not (
+                    snk_lo <= si_flow <= snk_hi or sink_input == ug_up_pos
+                ):
+                    continue
+
+                flow_delta = DIR_TO_DELTA[flow_dir]
+
+                # Path 1: source_drop → UG_DOWN_input (on source side)
+                if source_drop == ug_down_pos:
+                    path1 = []
+                else:
+                    ug_down_input = (
+                        ug_down_pos[0] - flow_delta[0],
+                        ug_down_pos[1] - flow_delta[1],
+                    )
+                    blocked1 = wall_tiles | {
+                        source_pos, sink_pos, ug_down_pos, ug_up_pos, sink_input,
+                    }
+                    # Restrict path1 to source side: block all sink-side cells.
+                    for fc in range(snk_lo, snk_hi + 1):
+                        for pc in range(perp_span):
+                            blocked1.add(fp_to_xy(fc, pc))
+                    if source_drop in blocked1 or ug_down_input in blocked1:
+                        continue
+                    path1 = find_belt_path(
+                        W, H, source_drop, ug_down_input, flow_dir, blocked1
+                    )
+                    if path1 is None:
+                        continue
+
+                # Path 2: UG_UP_drop → sink_input (on sink side)
+                if sink_input == ug_up_pos:
+                    path2 = []
+                else:
+                    ug_up_drop = (
+                        ug_up_pos[0] + flow_delta[0],
+                        ug_up_pos[1] + flow_delta[1],
+                    )
+                    path1_cells = {(x, y) for x, y, _ in path1}
+                    blocked2 = (
+                        wall_tiles
+                        | {source_pos, sink_pos, ug_down_pos, ug_up_pos, source_drop}
+                        | path1_cells
+                    )
+                    # Restrict path2 to sink side: block all source-side cells.
+                    for fc in range(src_lo, src_hi + 1):
+                        for pc in range(perp_span):
+                            blocked2.add(fp_to_xy(fc, pc))
+                    if ug_up_drop in blocked2 or sink_input in blocked2:
+                        continue
+                    path2 = find_belt_path(
+                        W, H, ug_up_drop, sink_input, sink_dir, blocked2
+                    )
+                    if path2 is None:
+                        continue
+
+                # Place source/sink
                 world_CWH[Channel.ENTITIES.value, source_pos[0], source_pos[1]] = (
                     str2ent("source").value
                 )
                 world_CWH[Channel.DIRECTION.value, source_pos[0], source_pos[1]] = (
-                    direction.value
+                    source_dir.value
                 )
                 world_CWH[Channel.ITEMS.value, source_pos[0], source_pos[1]] = item_value
 
@@ -2491,16 +2578,17 @@ def functions(
                     str2ent("sink").value
                 )
                 world_CWH[Channel.DIRECTION.value, sink_pos[0], sink_pos[1]] = (
-                    direction.value
+                    sink_dir.value
                 )
                 world_CWH[Channel.ITEMS.value, sink_pos[0], sink_pos[1]] = item_value
 
+                # Place UG pair (always facing flow_dir)
                 world_CWH[Channel.ENTITIES.value, ug_down_pos[0], ug_down_pos[1]] = (
                     str2ent("underground_belt").value
                 )
-                world_CWH[
-                    Channel.DIRECTION.value, ug_down_pos[0], ug_down_pos[1]
-                ] = direction.value
+                world_CWH[Channel.DIRECTION.value, ug_down_pos[0], ug_down_pos[1]] = (
+                    flow_dir.value
+                )
                 world_CWH[Channel.MISC.value, ug_down_pos[0], ug_down_pos[1]] = (
                     Misc.UNDERGROUND_DOWN.value
                 )
@@ -2508,32 +2596,41 @@ def functions(
                 world_CWH[Channel.ENTITIES.value, ug_up_pos[0], ug_up_pos[1]] = (
                     str2ent("underground_belt").value
                 )
-                world_CWH[
-                    Channel.DIRECTION.value, ug_up_pos[0], ug_up_pos[1]
-                ] = direction.value
+                world_CWH[Channel.DIRECTION.value, ug_up_pos[0], ug_up_pos[1]] = (
+                    flow_dir.value
+                )
                 world_CWH[Channel.MISC.value, ug_up_pos[0], ug_up_pos[1]] = (
                     Misc.UNDERGROUND_UP.value
                 )
 
-                for key in pre_keys + post_keys:
-                    bx, by = linepos(offsets[key])
-                    world_CWH[Channel.ENTITIES.value, bx, by] = str2ent(
+                # Place belts
+                for x, y, d in path1 + path2:
+                    world_CWH[Channel.ENTITIES.value, x, y] = str2ent(
                         "transport_belt"
                     ).value
-                    world_CWH[Channel.DIRECTION.value, bx, by] = direction.value
+                    world_CWH[Channel.DIRECTION.value, x, y] = d.value
 
-                # Sanity: the solved factory must actually deliver items.
+                # Sanity: the solved factory must deliver items.
                 tp, _ = funge_throughput(world_CWH.permute(1, 2, 0))
                 if tp <= 0:
                     continue
 
-                total_entities = 2 + pad_before + pad_after
+                total_entities = 2 + len(path1) + len(path2)
                 if total_entities > max_entities:
                     continue
 
                 min_entities_required = _remove_entities(
                     world_CWH, num_missing_entities, total_entities,
                 )
+                # _remove_entities paints all empty tiles UNAVAILABLE; we
+                # override that here so only the wall is UNAVAILABLE and the
+                # agent can route belts freely on either side.
+                world_CWH[Channel.FOOTPRINT.value, :, :] = Footprint.AVAILABLE.value
+                for wx, wy in wall_tiles:
+                    world_CWH[Channel.FOOTPRINT.value, wx, wy] = (
+                        Footprint.UNAVAILABLE.value
+                    )
+
                 break
             if count == 0:
                 raise Exception(

--- a/factorion.py
+++ b/factorion.py
@@ -176,6 +176,7 @@ def datatypes(Enum, dataclass, factorion_rs, mo):
         SPLITTER_SPLIT = 3
         SPLITTER_MERGE = 4
         ASSEMBLE_1IN_1OUT = 5
+        MOVE_VIA_UG_BELT = 6
 
 
     # Map Enum <--> grid deltas
@@ -2391,6 +2392,154 @@ def functions(
                 raise Exception(
                     f"Failed to find valid ASSEMBLE_1IN_1OUT lesson after {original_count} attempts"
                 )
+
+        elif kind.value == LessonKind.MOVE_VIA_UG_BELT.value:
+            # Source → [belts] → UG_DOWN → wall → UG_UP → [belts] → sink
+            # along a single straight line. The wall is 1..4 empty tiles which
+            # become FOOTPRINT=UNAVAILABLE in the agent's observation, forcing
+            # the agent to bridge them with an underground belt pair (max gap
+            # = 5 ⇒ wall ≤ 4). All off-line tiles are also UNAVAILABLE, so no
+            # surface detour exists.
+            original_count = max(500, size * size * 4)
+            count = original_count
+
+            while count > 0:
+                count -= 1
+                world_CWH = torch.tensor(new_world(width=size, height=size)).permute(
+                    2, 0, 1
+                )
+                C, W, H = world_CWH.shape
+
+                direction = random.choice(
+                    [d for d in Direction if d != Direction.NONE]
+                )
+                is_horizontal = direction in (Direction.EAST, Direction.WEST)
+                span = W if is_horizontal else H
+                perp = H if is_horizontal else W
+
+                # Need ≥ 5 tiles along the line: source + UG_DOWN + 1-tile
+                # wall + UG_UP + sink.
+                if span < 5:
+                    raise Exception(
+                        f"Grid {W}×{H} too small for MOVE_VIA_UG_BELT (need ≥ 5 along {direction})"
+                    )
+
+                max_wall = min(4, span - 4)
+                wall_width = random.randint(1, max_wall)
+                slack = span - 4 - wall_width
+                pad_before = random.randint(0, slack)
+                pad_after = random.randint(0, slack - pad_before)
+                total_len = 4 + wall_width + pad_before + pad_after
+
+                line_perp = random.randint(0, perp - 1)
+                start = random.randint(0, span - total_len)
+
+                if random_item:
+                    item_value = random.choice(
+                        [v.value for k, v in items.items() if v.name != "empty"]
+                    )
+                else:
+                    item_value = str2item("electronic_circuit").value
+
+                # Build offsets along the line (forward = increasing pos_along).
+                # Reversed for WEST/NORTH so source still leads.
+                forward = direction in (Direction.EAST, Direction.SOUTH)
+                offsets = {}
+                i = 0
+                offsets["source"] = i
+                i += 1
+                pre_keys = []
+                for k in range(pad_before):
+                    key = f"belt_pre_{k}"
+                    offsets[key] = i
+                    pre_keys.append(key)
+                    i += 1
+                offsets["ug_down"] = i
+                i += 1
+                i += wall_width  # wall — no entities placed here
+                offsets["ug_up"] = i
+                i += 1
+                post_keys = []
+                for k in range(pad_after):
+                    key = f"belt_post_{k}"
+                    offsets[key] = i
+                    post_keys.append(key)
+                    i += 1
+                offsets["sink"] = i
+
+                if not forward:
+                    offsets = {k: total_len - 1 - v for k, v in offsets.items()}
+
+                def linepos(off, ip=is_horizontal, lp=line_perp, st=start):
+                    pa = st + off
+                    return (pa, lp) if ip else (lp, pa)
+
+                source_pos = linepos(offsets["source"])
+                sink_pos = linepos(offsets["sink"])
+                ug_down_pos = linepos(offsets["ug_down"])
+                ug_up_pos = linepos(offsets["ug_up"])
+
+                world_CWH[Channel.ENTITIES.value, source_pos[0], source_pos[1]] = (
+                    str2ent("source").value
+                )
+                world_CWH[Channel.DIRECTION.value, source_pos[0], source_pos[1]] = (
+                    direction.value
+                )
+                world_CWH[Channel.ITEMS.value, source_pos[0], source_pos[1]] = item_value
+
+                world_CWH[Channel.ENTITIES.value, sink_pos[0], sink_pos[1]] = (
+                    str2ent("sink").value
+                )
+                world_CWH[Channel.DIRECTION.value, sink_pos[0], sink_pos[1]] = (
+                    direction.value
+                )
+                world_CWH[Channel.ITEMS.value, sink_pos[0], sink_pos[1]] = item_value
+
+                world_CWH[Channel.ENTITIES.value, ug_down_pos[0], ug_down_pos[1]] = (
+                    str2ent("underground_belt").value
+                )
+                world_CWH[
+                    Channel.DIRECTION.value, ug_down_pos[0], ug_down_pos[1]
+                ] = direction.value
+                world_CWH[Channel.MISC.value, ug_down_pos[0], ug_down_pos[1]] = (
+                    Misc.UNDERGROUND_DOWN.value
+                )
+
+                world_CWH[Channel.ENTITIES.value, ug_up_pos[0], ug_up_pos[1]] = (
+                    str2ent("underground_belt").value
+                )
+                world_CWH[
+                    Channel.DIRECTION.value, ug_up_pos[0], ug_up_pos[1]
+                ] = direction.value
+                world_CWH[Channel.MISC.value, ug_up_pos[0], ug_up_pos[1]] = (
+                    Misc.UNDERGROUND_UP.value
+                )
+
+                for key in pre_keys + post_keys:
+                    bx, by = linepos(offsets[key])
+                    world_CWH[Channel.ENTITIES.value, bx, by] = str2ent(
+                        "transport_belt"
+                    ).value
+                    world_CWH[Channel.DIRECTION.value, bx, by] = direction.value
+
+                # Sanity: the solved factory must actually deliver items.
+                tp, _ = funge_throughput(world_CWH.permute(1, 2, 0))
+                if tp <= 0:
+                    continue
+
+                total_entities = 2 + pad_before + pad_after
+                if total_entities > max_entities:
+                    continue
+
+                min_entities_required = _remove_entities(
+                    world_CWH, num_missing_entities, total_entities,
+                )
+                break
+            if count == 0:
+                raise Exception(
+                    f"Failed to find valid MOVE_VIA_UG_BELT lesson after {original_count} attempts"
+                )
+
         else:
             raise Exception(f"Can't handle {kind}")
         # print(f"Required {original_count-count} (of {original_count}) attempts to generate world ({100- count/original_count*100:.2f}%)")

--- a/tests/test_lesson_generation.py
+++ b/tests/test_lesson_generation.py
@@ -1731,26 +1731,22 @@ class TestAssemble1In1OutMaxEntities:
 # ── MOVE_VIA_UG_BELT ─────────────────────────────────────────────────────────
 
 
-def _ug_line_geometry(world):
-    """Return (direction, line_axis_index, source_pos, sink_pos, ug_down_pos,
-    ug_up_pos) for a MOVE_VIA_UG_BELT solved layout. Asserts the layout is
-    a single straight line."""
+def _ug_layout_info(world):
+    """Extract layout info from a MOVE_VIA_UG_BELT solved world.
+
+    Returns dict with: flow_dir, source_pos, sink_pos, ug_down_pos, ug_up_pos,
+    wall_tiles (set of (x, y)).
+    """
     ent = world[Channel.ENTITIES.value]
     direc = world[Channel.DIRECTION.value]
     misc = world[Channel.MISC.value]
+    fp = world[Channel.FOOTPRINT.value]
 
     src_pos = (ent == str2ent("source").value).nonzero(as_tuple=False)
     sink_pos = (ent == str2ent("sink").value).nonzero(as_tuple=False)
     assert len(src_pos) == 1 and len(sink_pos) == 1
-    sx, sy = src_pos[0].tolist()
-    kx, ky = sink_pos[0].tolist()
-
-    direction = Direction(int(direc[sx, sy].item()))
-    is_horizontal = direction in (Direction.EAST, Direction.WEST)
-    if is_horizontal:
-        assert sy == ky, "source/sink must share a row for horizontal lessons"
-    else:
-        assert sx == kx, "source/sink must share a column for vertical lessons"
+    src = tuple(src_pos[0].tolist())
+    sink = tuple(sink_pos[0].tolist())
 
     ug = (ent == str2ent("underground_belt").value).nonzero(as_tuple=False)
     assert len(ug) == 2, f"expected 2 UG belts, got {len(ug)}"
@@ -1763,7 +1759,22 @@ def _ug_line_geometry(world):
             up_pos = (px, py)
     assert down_pos is not None and up_pos is not None
 
-    return direction, is_horizontal, (sx, sy), (kx, ky), down_pos, up_pos
+    flow_dir = Direction(int(direc[down_pos[0], down_pos[1]].item()))
+    wall_tiles = set()
+    W, H = fp.shape
+    for x in range(W):
+        for y in range(H):
+            if fp[x, y].item() == Footprint.UNAVAILABLE.value:
+                wall_tiles.add((x, y))
+
+    return {
+        "flow_dir": flow_dir,
+        "source_pos": src,
+        "sink_pos": sink,
+        "ug_down_pos": down_pos,
+        "ug_up_pos": up_pos,
+        "wall_tiles": wall_tiles,
+    }
 
 
 class TestMoveViaUgBeltBasic:
@@ -1821,105 +1832,137 @@ class TestMoveViaUgBeltBasic:
 
 
 class TestMoveViaUgBeltGeometry:
-    """The lesson must be a single straight line with a wall the UG pair spans."""
+    """A perpendicular wall separates source and sink; UG pair bridges it."""
 
     @pytest.mark.parametrize("seed", range(40))
-    def test_source_sink_collinear_and_face_same_direction(self, seed):
+    def test_ug_pair_faces_flow_direction(self, seed):
         world, _ = generate_lesson(
             size=8, kind=LessonKind.MOVE_VIA_UG_BELT, num_missing_entities=0, seed=seed
         )
         direc = world[Channel.DIRECTION.value]
-        direction, is_h, src, sink, down, up = _ug_line_geometry(world)
-        # Source, sink, both UGs must all face the same direction
-        for px, py in [src, sink, down, up]:
-            assert int(direc[px, py].item()) == direction.value
+        info = _ug_layout_info(world)
+        for pos in (info["ug_down_pos"], info["ug_up_pos"]):
+            assert int(direc[pos[0], pos[1]].item()) == info["flow_dir"].value
 
     @pytest.mark.parametrize("seed", range(40))
-    def test_ug_gap_within_underground_range(self, seed):
-        """UG_DOWN → UG_UP gap (delta) must be in 1..5 (Factorio's range)."""
+    def test_ug_pair_directly_opposite_across_wall(self, seed):
+        """UG_UP shares UG_DOWN's perpendicular coord and is on the other
+        side of the wall, with the wall flush between them."""
         world, _ = generate_lesson(
             size=8, kind=LessonKind.MOVE_VIA_UG_BELT, num_missing_entities=0, seed=seed
         )
-        direction, is_h, src, sink, down, up = _ug_line_geometry(world)
+        info = _ug_layout_info(world)
+        flow = info["flow_dir"]
+        is_h = flow in (Direction.EAST, Direction.WEST)
+        down = info["ug_down_pos"]
+        up = info["ug_up_pos"]
         if is_h:
-            delta = abs(up[0] - down[0])
+            assert down[1] == up[1], (
+                f"seed={seed}: UG_DOWN.y={down[1]} != UG_UP.y={up[1]}"
+            )
+            gap = abs(up[0] - down[0])
         else:
-            delta = abs(up[1] - down[1])
-        assert 1 <= delta <= 5, f"seed={seed}: gap delta={delta} out of [1,5]"
+            assert down[0] == up[0], (
+                f"seed={seed}: UG_DOWN.x={down[0]} != UG_UP.x={up[0]}"
+            )
+            gap = abs(up[1] - down[1])
+        # gap = wall_thickness + 1, with wall_thickness ∈ [1, 4]
+        assert 2 <= gap <= 5, f"seed={seed}: UG gap {gap} not in [2, 5]"
 
     @pytest.mark.parametrize("seed", range(40))
-    def test_wall_tiles_are_unavailable_in_footprint(self, seed):
-        """Tiles strictly between UG_DOWN and UG_UP are FOOTPRINT.UNAVAILABLE."""
+    def test_wall_spans_full_perpendicular(self, seed):
+        """The wall (UNAVAILABLE tiles) spans the entire perpendicular
+        dimension of the grid."""
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.MOVE_VIA_UG_BELT, num_missing_entities=0, seed=seed
+        )
+        info = _ug_layout_info(world)
+        flow = info["flow_dir"]
+        is_h = flow in (Direction.EAST, Direction.WEST)
+        wall = info["wall_tiles"]
+        assert wall, f"seed={seed}: no wall tiles"
+        # Group by the flow-axis coordinate; each column/row must hit every
+        # perpendicular coordinate.
+        W, H = world[Channel.FOOTPRINT.value].shape
+        flow_coords = {(x if is_h else y) for x, y in wall}
+        perp_span = H if is_h else W
+        for fc in flow_coords:
+            perp_cells = {
+                (y if is_h else x)
+                for x, y in wall
+                if (x if is_h else y) == fc
+            }
+            assert perp_cells == set(range(perp_span)), (
+                f"seed={seed}: wall column/row {fc} doesn't span full perp"
+            )
+
+    @pytest.mark.parametrize("seed", range(40))
+    def test_only_wall_is_unavailable(self, seed):
+        """No tile outside the wall is FOOTPRINT.UNAVAILABLE — open space
+        on either side of the wall is freely buildable."""
         world, _ = generate_lesson(
             size=8, kind=LessonKind.MOVE_VIA_UG_BELT, num_missing_entities=0, seed=seed
         )
         fp = world[Channel.FOOTPRINT.value]
-        direction, is_h, src, sink, down, up = _ug_line_geometry(world)
-        # Walk from low+1 to high-1 along the line axis at the perp coord
-        if is_h:
-            lo, hi = sorted([down[0], up[0]])
-            perp = down[1]
-            for x in range(lo + 1, hi):
-                assert fp[x, perp].item() == Footprint.UNAVAILABLE.value, (
-                    f"seed={seed}: wall ({x},{perp}) was AVAILABLE"
-                )
-        else:
-            lo, hi = sorted([down[1], up[1]])
-            perp = down[0]
-            for y in range(lo + 1, hi):
-                assert fp[perp, y].item() == Footprint.UNAVAILABLE.value, (
-                    f"seed={seed}: wall ({perp},{y}) was AVAILABLE"
-                )
-
-    @pytest.mark.parametrize("seed", range(40))
-    def test_off_line_tiles_unavailable(self, seed):
-        """Every tile not on the source→sink line is FOOTPRINT.UNAVAILABLE."""
-        world, _ = generate_lesson(
-            size=8, kind=LessonKind.MOVE_VIA_UG_BELT, num_missing_entities=0, seed=seed
-        )
-        fp = world[Channel.FOOTPRINT.value]
-        direction, is_h, src, sink, down, up = _ug_line_geometry(world)
+        info = _ug_layout_info(world)
+        wall = info["wall_tiles"]
         W, H = fp.shape
-        line_perp = src[1] if is_h else src[0]
-        if is_h:
-            lo, hi = sorted([src[0], sink[0]])
-        else:
-            lo, hi = sorted([src[1], sink[1]])
         for x in range(W):
             for y in range(H):
-                on_line = (
-                    (is_h and y == line_perp and lo <= x <= hi)
-                    or (not is_h and x == line_perp and lo <= y <= hi)
-                )
-                if not on_line:
-                    assert fp[x, y].item() == Footprint.UNAVAILABLE.value, (
-                        f"seed={seed}: off-line ({x},{y}) was AVAILABLE"
+                if (x, y) not in wall:
+                    assert fp[x, y].item() == Footprint.AVAILABLE.value, (
+                        f"seed={seed}: ({x},{y}) UNAVAILABLE but not in wall"
                     )
 
     @pytest.mark.parametrize("seed", range(40))
-    def test_source_sink_endpoints_of_line(self, seed):
-        """Source and sink sit at opposite ends of the line, with source
-        facing toward sink (i.e. items flow source→sink along the chosen
-        direction)."""
+    def test_source_and_sink_on_opposite_sides_of_wall(self, seed):
+        """Source and sink lie on opposite sides of the wall along the
+        flow axis."""
         world, _ = generate_lesson(
             size=8, kind=LessonKind.MOVE_VIA_UG_BELT, num_missing_entities=0, seed=seed
         )
-        direction, is_h, src, sink, down, up = _ug_line_geometry(world)
-        dx, dy = DIR_TO_DELTA[direction]
-        # Travelling from src in `direction`, we should eventually reach sink
-        if is_h:
-            assert (sink[0] - src[0]) * dx > 0, (
-                f"seed={seed}: source faces {direction.name} but sink is the other way"
-            )
+        info = _ug_layout_info(world)
+        flow = info["flow_dir"]
+        is_h = flow in (Direction.EAST, Direction.WEST)
+        wall = info["wall_tiles"]
+        wall_flow = {(x if is_h else y) for x, y in wall}
+        wall_lo, wall_hi = min(wall_flow), max(wall_flow)
+        src = info["source_pos"]
+        sink = info["sink_pos"]
+        src_f = src[0] if is_h else src[1]
+        sink_f = sink[0] if is_h else sink[1]
+        # Both must be outside the wall, and on different sides of it
+        assert src_f < wall_lo or src_f > wall_hi
+        assert sink_f < wall_lo or sink_f > wall_hi
+        assert (src_f < wall_lo) != (sink_f < wall_lo), (
+            f"seed={seed}: src and sink on same side of wall"
+        )
+
+    @pytest.mark.parametrize("seed", range(40))
+    def test_ug_down_on_source_side_ug_up_on_sink_side(self, seed):
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.MOVE_VIA_UG_BELT, num_missing_entities=0, seed=seed
+        )
+        info = _ug_layout_info(world)
+        flow = info["flow_dir"]
+        is_h = flow in (Direction.EAST, Direction.WEST)
+        wall = info["wall_tiles"]
+        wall_flow = {(x if is_h else y) for x, y in wall}
+        wall_lo, wall_hi = min(wall_flow), max(wall_flow)
+        src = info["source_pos"]
+        down = info["ug_down_pos"]
+        up = info["ug_up_pos"]
+        src_f = src[0] if is_h else src[1]
+        down_f = down[0] if is_h else down[1]
+        up_f = up[0] if is_h else up[1]
+        # UG_DOWN on source side
+        if src_f < wall_lo:
+            assert down_f < wall_lo and up_f > wall_hi
         else:
-            assert (sink[1] - src[1]) * dy > 0, (
-                f"seed={seed}: source faces {direction.name} but sink is the other way"
-            )
+            assert down_f > wall_hi and up_f < wall_lo
 
 
 class TestMoveViaUgBeltManySeeds:
-    """Generate many lessons and verify all are valid."""
-
     @pytest.mark.parametrize("seed", range(50))
     def test_size_8_seed(self, seed):
         world, min_ent = generate_lesson(
@@ -1930,7 +1973,7 @@ class TestMoveViaUgBeltManySeeds:
         tp, _ = py_throughput_safe(world.permute(1, 2, 0))
         assert tp > 0
 
-    @pytest.mark.parametrize("size", [5, 6, 8, 10, 12])
+    @pytest.mark.parametrize("size", [6, 8, 10, 12])
     def test_grid_sizes(self, size):
         world, _ = generate_lesson(
             size=size, kind=LessonKind.MOVE_VIA_UG_BELT,
@@ -1942,7 +1985,7 @@ class TestMoveViaUgBeltManySeeds:
 
 
 class TestMoveViaUgBeltDirections:
-    """All four directions must be reachable by the generator."""
+    """All four flow directions must be reachable by the generator."""
 
     def test_all_directions_appear(self):
         seen = set()
@@ -1951,8 +1994,7 @@ class TestMoveViaUgBeltDirections:
                 size=8, kind=LessonKind.MOVE_VIA_UG_BELT,
                 num_missing_entities=0, seed=seed,
             )
-            direction, *_ = _ug_line_geometry(world)
-            seen.add(direction)
+            seen.add(_ug_layout_info(world)["flow_dir"])
             if len(seen) == 4:
                 break
         assert seen == {
@@ -1961,7 +2003,7 @@ class TestMoveViaUgBeltDirections:
 
 
 class TestMoveViaUgBeltMissingEntities:
-    """Blanking respects source/sink protection and is independent for the UG pair."""
+    """Blanking preserves source/sink and the FOOTPRINT mask."""
 
     @pytest.mark.parametrize("num_missing", [1, 2, 5, float("inf")])
     @pytest.mark.parametrize("seed", range(10))
@@ -1975,31 +2017,29 @@ class TestMoveViaUgBeltMissingEntities:
         assert (ent == str2ent("sink").value).sum().item() == 1
 
     @pytest.mark.parametrize("seed", range(20))
-    def test_blanked_cells_remain_available(self, seed):
-        """A cell whose entity got blanked must keep FOOTPRINT=AVAILABLE so
-        the agent can fill it. Walls (originally empty) stay UNAVAILABLE."""
+    def test_wall_remains_unavailable_after_blanking(self, seed):
+        """Even at maximum blanking, the wall is still the only UNAVAILABLE
+        region (open tiles do not flip to UNAVAILABLE just because they
+        were blanked)."""
         world, _ = generate_lesson(
             size=8, kind=LessonKind.MOVE_VIA_UG_BELT,
             num_missing_entities=float("inf"), seed=seed,
         )
-        ent = world[Channel.ENTITIES.value]
+        info = _ug_layout_info(world)
+        # The wall spans full perpendicular; any non-wall tile must be
+        # AVAILABLE (already covered by other tests for num_missing=0;
+        # here we just re-assert it survives blanking).
         fp = world[Channel.FOOTPRINT.value]
-        empty_id = str2ent("empty").value
-        # Source + sink stay; all removable entities are gone. Their cells
-        # (now empty) must still be AVAILABLE because they were entity tiles
-        # in the solved layout. AVAILABLE cells == solved entity cells, so
-        # ≥ 4 (source + UG_DOWN + UG_UP + sink, with the wall between them
-        # contributing no AVAILABLE tiles).
-        avail = (fp == Footprint.AVAILABLE.value).sum().item()
-        assert avail >= 4, f"seed={seed}: only {avail} AVAILABLE cells"
+        W, H = fp.shape
+        for x in range(W):
+            for y in range(H):
+                if (x, y) not in info["wall_tiles"]:
+                    assert fp[x, y].item() == Footprint.AVAILABLE.value
 
     @pytest.mark.parametrize("seed", range(20))
     def test_independent_ug_removal_possible(self, seed):
-        """With num_missing=1 across many seeds, sometimes only DOWN is
-        removed, sometimes only UP — they are independent removal units."""
-        # We just verify that with num_missing=1, the world has either
-        # 1 DOWN + 0 UP or 0 DOWN + 1 UP or both still present (when a
-        # transport belt got blanked instead). All three are valid.
+        """With num_missing=1, we may end up removing only DOWN, only UP,
+        or only a transport belt — they're independent removal units."""
         world, _ = generate_lesson(
             size=10, kind=LessonKind.MOVE_VIA_UG_BELT,
             num_missing_entities=1, seed=seed,

--- a/tests/test_lesson_generation.py
+++ b/tests/test_lesson_generation.py
@@ -1726,3 +1726,289 @@ class TestAssemble1In1OutMaxEntities:
         assert total2 <= natural_total + 5, (
             f"seed={seed}: generator placed {total2} entities (cap was {natural_total + 5})"
         )
+
+
+# ── MOVE_VIA_UG_BELT ─────────────────────────────────────────────────────────
+
+
+def _ug_line_geometry(world):
+    """Return (direction, line_axis_index, source_pos, sink_pos, ug_down_pos,
+    ug_up_pos) for a MOVE_VIA_UG_BELT solved layout. Asserts the layout is
+    a single straight line."""
+    ent = world[Channel.ENTITIES.value]
+    direc = world[Channel.DIRECTION.value]
+    misc = world[Channel.MISC.value]
+
+    src_pos = (ent == str2ent("source").value).nonzero(as_tuple=False)
+    sink_pos = (ent == str2ent("sink").value).nonzero(as_tuple=False)
+    assert len(src_pos) == 1 and len(sink_pos) == 1
+    sx, sy = src_pos[0].tolist()
+    kx, ky = sink_pos[0].tolist()
+
+    direction = Direction(int(direc[sx, sy].item()))
+    is_horizontal = direction in (Direction.EAST, Direction.WEST)
+    if is_horizontal:
+        assert sy == ky, "source/sink must share a row for horizontal lessons"
+    else:
+        assert sx == kx, "source/sink must share a column for vertical lessons"
+
+    ug = (ent == str2ent("underground_belt").value).nonzero(as_tuple=False)
+    assert len(ug) == 2, f"expected 2 UG belts, got {len(ug)}"
+    down_pos = up_pos = None
+    for px, py in ug.tolist():
+        m = int(misc[px, py].item())
+        if m == Misc.UNDERGROUND_DOWN.value:
+            down_pos = (px, py)
+        elif m == Misc.UNDERGROUND_UP.value:
+            up_pos = (px, py)
+    assert down_pos is not None and up_pos is not None
+
+    return direction, is_horizontal, (sx, sy), (kx, ky), down_pos, up_pos
+
+
+class TestMoveViaUgBeltBasic:
+    """Basic sanity checks for MOVE_VIA_UG_BELT lesson generation."""
+
+    def test_generates_without_error(self):
+        world, min_ent = generate_lesson(
+            size=8, kind=LessonKind.MOVE_VIA_UG_BELT, num_missing_entities=0, seed=42
+        )
+        assert world is not None
+        assert min_ent is not None
+
+    def test_returns_cwh_tensor(self):
+        size = 8
+        world, _ = generate_lesson(
+            size=size, kind=LessonKind.MOVE_VIA_UG_BELT, num_missing_entities=0, seed=42
+        )
+        assert world.shape == (len(Channel), size, size)
+
+    def test_has_source_and_sink(self):
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.MOVE_VIA_UG_BELT, num_missing_entities=0, seed=42
+        )
+        ent = world[Channel.ENTITIES.value]
+        assert (ent == str2ent("source").value).sum().item() == 1
+        assert (ent == str2ent("sink").value).sum().item() == 1
+
+    def test_has_one_ug_pair(self):
+        """Solved layout has exactly one UG_DOWN and one UG_UP."""
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.MOVE_VIA_UG_BELT, num_missing_entities=0, seed=42
+        )
+        ent = world[Channel.ENTITIES.value]
+        misc = world[Channel.MISC.value]
+        ug_mask = ent == str2ent("underground_belt").value
+        assert ug_mask.sum().item() == 2
+        down = ((misc == Misc.UNDERGROUND_DOWN.value) & ug_mask).sum().item()
+        up = ((misc == Misc.UNDERGROUND_UP.value) & ug_mask).sum().item()
+        assert down == 1 and up == 1, f"expected 1 DOWN + 1 UP, got {down} + {up}"
+
+    def test_nonzero_throughput(self):
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.MOVE_VIA_UG_BELT, num_missing_entities=0, seed=42
+        )
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_throughput_parity(self, seed):
+        """Python and Rust throughput agree on solved layouts."""
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.MOVE_VIA_UG_BELT, num_missing_entities=0, seed=seed
+        )
+        compare_throughput(world.permute(1, 2, 0))
+
+
+class TestMoveViaUgBeltGeometry:
+    """The lesson must be a single straight line with a wall the UG pair spans."""
+
+    @pytest.mark.parametrize("seed", range(40))
+    def test_source_sink_collinear_and_face_same_direction(self, seed):
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.MOVE_VIA_UG_BELT, num_missing_entities=0, seed=seed
+        )
+        direc = world[Channel.DIRECTION.value]
+        direction, is_h, src, sink, down, up = _ug_line_geometry(world)
+        # Source, sink, both UGs must all face the same direction
+        for px, py in [src, sink, down, up]:
+            assert int(direc[px, py].item()) == direction.value
+
+    @pytest.mark.parametrize("seed", range(40))
+    def test_ug_gap_within_underground_range(self, seed):
+        """UG_DOWN → UG_UP gap (delta) must be in 1..5 (Factorio's range)."""
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.MOVE_VIA_UG_BELT, num_missing_entities=0, seed=seed
+        )
+        direction, is_h, src, sink, down, up = _ug_line_geometry(world)
+        if is_h:
+            delta = abs(up[0] - down[0])
+        else:
+            delta = abs(up[1] - down[1])
+        assert 1 <= delta <= 5, f"seed={seed}: gap delta={delta} out of [1,5]"
+
+    @pytest.mark.parametrize("seed", range(40))
+    def test_wall_tiles_are_unavailable_in_footprint(self, seed):
+        """Tiles strictly between UG_DOWN and UG_UP are FOOTPRINT.UNAVAILABLE."""
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.MOVE_VIA_UG_BELT, num_missing_entities=0, seed=seed
+        )
+        fp = world[Channel.FOOTPRINT.value]
+        direction, is_h, src, sink, down, up = _ug_line_geometry(world)
+        # Walk from low+1 to high-1 along the line axis at the perp coord
+        if is_h:
+            lo, hi = sorted([down[0], up[0]])
+            perp = down[1]
+            for x in range(lo + 1, hi):
+                assert fp[x, perp].item() == Footprint.UNAVAILABLE.value, (
+                    f"seed={seed}: wall ({x},{perp}) was AVAILABLE"
+                )
+        else:
+            lo, hi = sorted([down[1], up[1]])
+            perp = down[0]
+            for y in range(lo + 1, hi):
+                assert fp[perp, y].item() == Footprint.UNAVAILABLE.value, (
+                    f"seed={seed}: wall ({perp},{y}) was AVAILABLE"
+                )
+
+    @pytest.mark.parametrize("seed", range(40))
+    def test_off_line_tiles_unavailable(self, seed):
+        """Every tile not on the source→sink line is FOOTPRINT.UNAVAILABLE."""
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.MOVE_VIA_UG_BELT, num_missing_entities=0, seed=seed
+        )
+        fp = world[Channel.FOOTPRINT.value]
+        direction, is_h, src, sink, down, up = _ug_line_geometry(world)
+        W, H = fp.shape
+        line_perp = src[1] if is_h else src[0]
+        if is_h:
+            lo, hi = sorted([src[0], sink[0]])
+        else:
+            lo, hi = sorted([src[1], sink[1]])
+        for x in range(W):
+            for y in range(H):
+                on_line = (
+                    (is_h and y == line_perp and lo <= x <= hi)
+                    or (not is_h and x == line_perp and lo <= y <= hi)
+                )
+                if not on_line:
+                    assert fp[x, y].item() == Footprint.UNAVAILABLE.value, (
+                        f"seed={seed}: off-line ({x},{y}) was AVAILABLE"
+                    )
+
+    @pytest.mark.parametrize("seed", range(40))
+    def test_source_sink_endpoints_of_line(self, seed):
+        """Source and sink sit at opposite ends of the line, with source
+        facing toward sink (i.e. items flow source→sink along the chosen
+        direction)."""
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.MOVE_VIA_UG_BELT, num_missing_entities=0, seed=seed
+        )
+        direction, is_h, src, sink, down, up = _ug_line_geometry(world)
+        dx, dy = DIR_TO_DELTA[direction]
+        # Travelling from src in `direction`, we should eventually reach sink
+        if is_h:
+            assert (sink[0] - src[0]) * dx > 0, (
+                f"seed={seed}: source faces {direction.name} but sink is the other way"
+            )
+        else:
+            assert (sink[1] - src[1]) * dy > 0, (
+                f"seed={seed}: source faces {direction.name} but sink is the other way"
+            )
+
+
+class TestMoveViaUgBeltManySeeds:
+    """Generate many lessons and verify all are valid."""
+
+    @pytest.mark.parametrize("seed", range(50))
+    def test_size_8_seed(self, seed):
+        world, min_ent = generate_lesson(
+            size=8, kind=LessonKind.MOVE_VIA_UG_BELT, num_missing_entities=0, seed=seed
+        )
+        assert world is not None
+        assert min_ent is not None
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0
+
+    @pytest.mark.parametrize("size", [5, 6, 8, 10, 12])
+    def test_grid_sizes(self, size):
+        world, _ = generate_lesson(
+            size=size, kind=LessonKind.MOVE_VIA_UG_BELT,
+            num_missing_entities=0, seed=7,
+        )
+        assert world.shape == (len(Channel), size, size)
+        tp, _ = py_throughput_safe(world.permute(1, 2, 0))
+        assert tp > 0
+
+
+class TestMoveViaUgBeltDirections:
+    """All four directions must be reachable by the generator."""
+
+    def test_all_directions_appear(self):
+        seen = set()
+        for seed in range(200):
+            world, _ = generate_lesson(
+                size=8, kind=LessonKind.MOVE_VIA_UG_BELT,
+                num_missing_entities=0, seed=seed,
+            )
+            direction, *_ = _ug_line_geometry(world)
+            seen.add(direction)
+            if len(seen) == 4:
+                break
+        assert seen == {
+            Direction.NORTH, Direction.EAST, Direction.SOUTH, Direction.WEST,
+        }, f"only saw {seen}"
+
+
+class TestMoveViaUgBeltMissingEntities:
+    """Blanking respects source/sink protection and is independent for the UG pair."""
+
+    @pytest.mark.parametrize("num_missing", [1, 2, 5, float("inf")])
+    @pytest.mark.parametrize("seed", range(10))
+    def test_source_and_sink_always_present(self, num_missing, seed):
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.MOVE_VIA_UG_BELT,
+            num_missing_entities=num_missing, seed=seed,
+        )
+        ent = world[Channel.ENTITIES.value]
+        assert (ent == str2ent("source").value).sum().item() == 1
+        assert (ent == str2ent("sink").value).sum().item() == 1
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_blanked_cells_remain_available(self, seed):
+        """A cell whose entity got blanked must keep FOOTPRINT=AVAILABLE so
+        the agent can fill it. Walls (originally empty) stay UNAVAILABLE."""
+        world, _ = generate_lesson(
+            size=8, kind=LessonKind.MOVE_VIA_UG_BELT,
+            num_missing_entities=float("inf"), seed=seed,
+        )
+        ent = world[Channel.ENTITIES.value]
+        fp = world[Channel.FOOTPRINT.value]
+        empty_id = str2ent("empty").value
+        # Source + sink stay; all removable entities are gone. Their cells
+        # (now empty) must still be AVAILABLE because they were entity tiles
+        # in the solved layout. AVAILABLE cells == solved entity cells, so
+        # ≥ 4 (source + UG_DOWN + UG_UP + sink, with the wall between them
+        # contributing no AVAILABLE tiles).
+        avail = (fp == Footprint.AVAILABLE.value).sum().item()
+        assert avail >= 4, f"seed={seed}: only {avail} AVAILABLE cells"
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_independent_ug_removal_possible(self, seed):
+        """With num_missing=1 across many seeds, sometimes only DOWN is
+        removed, sometimes only UP — they are independent removal units."""
+        # We just verify that with num_missing=1, the world has either
+        # 1 DOWN + 0 UP or 0 DOWN + 1 UP or both still present (when a
+        # transport belt got blanked instead). All three are valid.
+        world, _ = generate_lesson(
+            size=10, kind=LessonKind.MOVE_VIA_UG_BELT,
+            num_missing_entities=1, seed=seed,
+        )
+        ent = world[Channel.ENTITIES.value]
+        misc = world[Channel.MISC.value]
+        ug_mask = ent == str2ent("underground_belt").value
+        down = ((misc == Misc.UNDERGROUND_DOWN.value) & ug_mask).sum().item()
+        up = ((misc == Misc.UNDERGROUND_UP.value) & ug_mask).sum().item()
+        assert (down, up) in {(0, 1), (1, 0), (1, 1)}, (
+            f"seed={seed}: unexpected (down, up) = ({down}, {up})"
+        )


### PR DESCRIPTION
## Summary
- New `LessonKind.MOVE_VIA_UG_BELT` lesson: source → optional belts → UG_DOWN → empty wall (1–4 tiles) → UG_UP → optional belts → sink along a single straight line. Wall + off-line tiles become `FOOTPRINT=UNAVAILABLE` so the agent is forced to bridge with an underground belt pair (no surface detour exists).
- 361 new tests covering shape, throughput parity, geometry (collinearity, UG gap ∈ [1, 5], all four directions), FOOTPRINT mask correctness on wall + off-line tiles, and independent UG-pair removal under blanking.
- Picked up automatically by `sft.py` since it enumerates `list(LessonKind)`.

## Test plan
- [x] `cargo fmt --manifest-path factorion_rs/Cargo.toml`
- [x] `cargo clippy --manifest-path factorion_rs/Cargo.toml -- -D warnings`
- [x] `cargo test --manifest-path factorion_rs/Cargo.toml --no-default-features` (48 passed)
- [x] `maturin develop --release --manifest-path factorion_rs/Cargo.toml`
- [x] `WANDB_MODE=disabled WANDB_DISABLED=true uv run python -m pytest tests/ -v` (2897 passed, 148 skipped)
- [x] `uv run ruff check .`
- [x] `WANDB_MODE=disabled uv run python ppo.py --seed 1 --env-id factorion/FactorioEnv-v0 --total-timesteps 5000`
- [ ] SFT smoketest (CI label triggers cloud run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)