### PR TITLE
ASSEMBLE_2IN_1OUT lesson generator + tests

### DIFF
--- a/factorion.py
+++ b/factorion.py
@@ -2009,8 +2009,21 @@ def build_factory(
             if any(c in asm_tiles for c in key_cells):
                 continue
 
+            # Compute ALL 12 non-corner perimeter slots and exclude them
+            # from the source/sink candidate set. A Source/Sink placed on
+            # a perimeter slot is treated as an inserter by
+            # AssemblingMachine::connections (Source/Sink are inserter-
+            # like), which would feed/drain the assembler at infinite
+            # rate — bypassing the input/output inserter bottleneck and
+            # breaking the closed-form throughput.
+            all_perim = {
+                (ax + ddx, ay + ddy)
+                for ddx, ddy, _, _ in perim_slots
+                if 0 <= ax + ddx < W and 0 <= ay + ddy < H
+            }
+
             # Pick source + sink positions outside everything reserved
-            reserved = asm_tiles | set(key_cells)
+            reserved = asm_tiles | set(key_cells) | all_perim
             available = [
                 (x, y)
                 for x in range(W)

--- a/factorion.py
+++ b/factorion.py
@@ -151,6 +151,7 @@ class LessonKind(Enum):
     SPLITTER_MERGE = 4
     ASSEMBLE_1IN_1OUT = 5
     MOVE_VIA_UG_BELT = 6
+    ASSEMBLE_2IN_1OUT = 7
 
 
 @dataclass(frozen=True)
@@ -2390,6 +2391,273 @@ def build_factory(
                 world_CWH[Channel.FOOTPRINT.value, wx, wy] = (
                     Footprint.UNAVAILABLE.value
                 )
+
+            break
+        if count == 0:
+            return None
+
+    elif kind.value == LessonKind.ASSEMBLE_2IN_1OUT.value:
+        # 2 sources → belts → 2 input inserters → 3×3 assembler (recipe)
+        #   → output inserter → belts → 1 sink. Recipe is randomly chosen
+        # from all 2-input 1-output recipes in the live recipe table
+        # (filtered dynamically — no hardcoded list, so new recipes added
+        # in factorion_rs are picked up automatically).
+        two_in_one_out = [
+            (name, r)
+            for name, r in recipes.items()
+            if len(r.consumes) == 2 and len(r.produces) == 1
+        ]
+        if not two_in_one_out:
+            raise Exception("No 2-input 1-output recipes available")
+
+        original_count = max(500, size * size * 16)
+        count = original_count
+        asm_ent = str2ent("assembling_machine_1")
+
+        # 12 non-corner perimeter slots — same set as the 1-in-1-out
+        # generator, but here we pick THREE distinct slots: two for
+        # input inserters (one per ingredient) and one for the output.
+        perim_slots = [
+            # North side (ddy = -1)
+            (0, -1, Direction.SOUTH, Direction.NORTH),
+            (1, -1, Direction.SOUTH, Direction.NORTH),
+            (2, -1, Direction.SOUTH, Direction.NORTH),
+            # South side (ddy = 3)
+            (0, 3, Direction.NORTH, Direction.SOUTH),
+            (1, 3, Direction.NORTH, Direction.SOUTH),
+            (2, 3, Direction.NORTH, Direction.SOUTH),
+            # West side (ddx = -1)
+            (-1, 0, Direction.EAST, Direction.WEST),
+            (-1, 1, Direction.EAST, Direction.WEST),
+            (-1, 2, Direction.EAST, Direction.WEST),
+            # East side (ddx = 3)
+            (3, 0, Direction.WEST, Direction.EAST),
+            (3, 1, Direction.WEST, Direction.EAST),
+            (3, 2, Direction.WEST, Direction.EAST),
+        ]
+
+        while count > 0:
+            count -= 1
+            world_CWH = torch.tensor(new_world(width=size, height=size)).permute(
+                2, 0, 1
+            )
+            C, W, H = world_CWH.shape
+
+            if W < 3 or H < 3:
+                raise Exception(
+                    f"Grid {W}×{H} too small for ASSEMBLE_2IN_1OUT (need ≥ 3×3)"
+                )
+
+            # Pick recipe + items
+            recipe_name, recipe = random.choice(two_in_one_out)
+            input_items = list(recipe.consumes.keys())
+            # Randomize which ingredient is "A" vs "B" so the two
+            # sources appear in random order across seeds.
+            random.shuffle(input_items)
+            input_a_name, input_b_name = input_items
+            output_item_name = next(iter(recipe.produces.keys()))
+            recipe_item_value = str2item(recipe_name).value
+            input_a_value = str2item(input_a_name).value
+            input_b_value = str2item(input_b_name).value
+            output_item_value = str2item(output_item_name).value
+
+            # Pick assembler anchor
+            ax = random.randint(0, W - 3)
+            ay = random.randint(0, H - 3)
+            asm_tiles = {
+                (ax + dx, ay + dy) for dx in range(3) for dy in range(3)
+            }
+
+            # Pick three distinct perimeter slots: 2 inputs + 1 output
+            in_a_slot, in_b_slot, out_slot = random.sample(perim_slots, 3)
+
+            in_a_pos = (ax + in_a_slot[0], ay + in_a_slot[1])
+            in_a_dir = in_a_slot[2]
+            in_b_pos = (ax + in_b_slot[0], ay + in_b_slot[1])
+            in_b_dir = in_b_slot[2]
+            out_pos = (ax + out_slot[0], ay + out_slot[1])
+            out_dir = out_slot[3]
+
+            in_a_dd = DIR_TO_DELTA[in_a_dir]
+            in_b_dd = DIR_TO_DELTA[in_b_dir]
+            out_dd = DIR_TO_DELTA[out_dir]
+
+            in_a_pickup = (in_a_pos[0] - in_a_dd[0], in_a_pos[1] - in_a_dd[1])
+            in_b_pickup = (in_b_pos[0] - in_b_dd[0], in_b_pos[1] - in_b_dd[1])
+            out_drop = (out_pos[0] + out_dd[0], out_pos[1] + out_dd[1])
+
+            key_cells = [
+                in_a_pos, in_b_pos, out_pos,
+                in_a_pickup, in_b_pickup, out_drop,
+            ]
+            if any(not (0 <= c[0] < W and 0 <= c[1] < H) for c in key_cells):
+                continue
+            if len(set(key_cells)) != len(key_cells):
+                continue
+            if any(c in asm_tiles for c in key_cells):
+                continue
+
+            # Exclude all 12 perimeter slots — a Source/Sink placed on
+            # one is treated as an inserter by AssemblingMachine::
+            # connections and would feed/drain the assembler at infinite
+            # rate, breaking the closed-form throughput.
+            all_perim = {
+                (ax + ddx, ay + ddy)
+                for ddx, ddy, _, _ in perim_slots
+                if 0 <= ax + ddx < W and 0 <= ay + ddy < H
+            }
+            reserved = asm_tiles | set(key_cells) | all_perim
+            available = [
+                (x, y)
+                for x in range(W)
+                for y in range(H)
+                if (x, y) not in reserved
+            ]
+            if len(available) < 3:
+                continue
+
+            src_a_pos, src_b_pos, sink_pos = random.sample(available, 3)
+            dirs = [d for d in Direction if d != Direction.NONE]
+            src_a_dir = random.choice(dirs)
+            src_b_dir = random.choice(dirs)
+            sink_dir = random.choice(dirs)
+
+            ds_a = DIR_TO_DELTA[src_a_dir]
+            ds_b = DIR_TO_DELTA[src_b_dir]
+            dk = DIR_TO_DELTA[sink_dir]
+            src_a_out = (src_a_pos[0] + ds_a[0], src_a_pos[1] + ds_a[1])
+            src_b_out = (src_b_pos[0] + ds_b[0], src_b_pos[1] + ds_b[1])
+            sink_in = (sink_pos[0] - dk[0], sink_pos[1] - dk[1])
+
+            conn = [src_a_out, src_b_out, sink_in]
+            if any(not (0 <= c[0] < W and 0 <= c[1] < H) for c in conn):
+                continue
+            if len(set(conn)) != len(conn):
+                continue
+            if any(c in reserved for c in conn):
+                continue
+            if any(c in {src_a_pos, src_b_pos, sink_pos} for c in conn):
+                continue
+
+            fixed_cells = (
+                asm_tiles
+                | {in_a_pos, in_b_pos, out_pos}
+                | {src_a_pos, src_b_pos, sink_pos}
+            )
+
+            # Path A: source A → input-A pickup
+            blocked_a = (
+                fixed_cells
+                | {in_b_pickup, out_drop, src_b_out, sink_in}
+            )
+            path_a = find_belt_path(
+                W, H, src_a_out, in_a_pickup, in_a_dir, blocked_a
+            )
+            if path_a is None:
+                continue
+            path_a_cells = {(x, y) for x, y, _ in path_a}
+
+            # Path B: source B → input-B pickup
+            blocked_b = (
+                fixed_cells
+                | {in_a_pickup, out_drop, src_a_out, sink_in}
+                | path_a_cells
+            )
+            path_b = find_belt_path(
+                W, H, src_b_out, in_b_pickup, in_b_dir, blocked_b
+            )
+            if path_b is None:
+                continue
+            path_b_cells = {(x, y) for x, y, _ in path_b}
+
+            # Path C: output drop → sink input
+            blocked_c = (
+                fixed_cells
+                | {in_a_pickup, in_b_pickup, src_a_out, src_b_out}
+                | path_a_cells
+                | path_b_cells
+            )
+            path_c = find_belt_path(
+                W, H, out_drop, sink_in, sink_dir, blocked_c
+            )
+            if path_c is None:
+                continue
+
+            # 1 assembler + 3 inserters + belts (assembler is 1 entity)
+            total_entities = len(path_a) + len(path_b) + len(path_c) + 4
+            if total_entities > max_entities:
+                continue
+
+            # Place sources
+            world_CWH[Channel.ENTITIES.value, src_a_pos[0], src_a_pos[1]] = (
+                str2ent("source").value
+            )
+            world_CWH[Channel.DIRECTION.value, src_a_pos[0], src_a_pos[1]] = (
+                src_a_dir.value
+            )
+            world_CWH[Channel.ITEMS.value, src_a_pos[0], src_a_pos[1]] = (
+                input_a_value
+            )
+
+            world_CWH[Channel.ENTITIES.value, src_b_pos[0], src_b_pos[1]] = (
+                str2ent("source").value
+            )
+            world_CWH[Channel.DIRECTION.value, src_b_pos[0], src_b_pos[1]] = (
+                src_b_dir.value
+            )
+            world_CWH[Channel.ITEMS.value, src_b_pos[0], src_b_pos[1]] = (
+                input_b_value
+            )
+
+            # Place sink
+            world_CWH[Channel.ENTITIES.value, sink_pos[0], sink_pos[1]] = (
+                str2ent("sink").value
+            )
+            world_CWH[Channel.DIRECTION.value, sink_pos[0], sink_pos[1]] = (
+                sink_dir.value
+            )
+            world_CWH[Channel.ITEMS.value, sink_pos[0], sink_pos[1]] = (
+                output_item_value
+            )
+
+            # Place assembler (3×3, all tiles tagged with the recipe item)
+            for tx, ty in asm_tiles:
+                world_CWH[Channel.ENTITIES.value, tx, ty] = asm_ent.value
+                world_CWH[Channel.DIRECTION.value, tx, ty] = (
+                    Direction.NORTH.value
+                )
+                world_CWH[Channel.ITEMS.value, tx, ty] = recipe_item_value
+
+            # Place 2 input inserters + 1 output inserter
+            for ipos, idir in [
+                (in_a_pos, in_a_dir),
+                (in_b_pos, in_b_dir),
+                (out_pos, out_dir),
+            ]:
+                world_CWH[
+                    Channel.ENTITIES.value, ipos[0], ipos[1]
+                ] = str2ent("inserter").value
+                world_CWH[
+                    Channel.DIRECTION.value, ipos[0], ipos[1]
+                ] = idir.value
+
+            # Place belt paths
+            for x, y, d in path_a + path_b + path_c:
+                world_CWH[Channel.ENTITIES.value, x, y] = str2ent(
+                    "transport_belt"
+                ).value
+                world_CWH[Channel.DIRECTION.value, x, y] = d.value
+
+            # Verify throughput > 0
+            tp, _ = funge_throughput(world_CWH.permute(1, 2, 0))
+            if tp <= 0:
+                continue
+
+            # The assembler is a valid blanking target — same rationale
+            # as ASSEMBLE_1IN_1OUT: source/sink items are never blanked
+            # so the recipe is inferable, and forcing the model to
+            # place the assembler is the only way the item head learns
+            # to predict non-zero recipes.
 
             break
         if count == 0:

--- a/tests/test_lesson_generation.py
+++ b/tests/test_lesson_generation.py
@@ -2203,3 +2203,505 @@ class TestMoveViaUgBeltMissingEntities:
         assert (down, up) in {(0, 1), (1, 0), (1, 1)}, (
             f"seed={seed}: unexpected (down, up) = ({down}, {up})"
         )
+
+
+# ── ASSEMBLE_2IN_1OUT tests ─────────────────────────────────────────────────
+#
+# An ASSEMBLE_2IN_1OUT lesson is:
+#   2× (source(input_i) → belt → input inserter) → 3×3 assembler (recipe)
+#                                                  → output inserter → belt → sink(output)
+# Recipe is randomly chosen from all 2-input 1-output recipes — derived
+# dynamically from the live recipe table so the tests stay correct as
+# new recipes land in factorion_rs.
+
+
+def _two_in_one_out_recipes():
+    """{recipe_name: (frozenset(input_names), output_name)}."""
+    out = {}
+    for name, r in recipes.items():
+        if len(r.consumes) == 2 and len(r.produces) == 1:
+            out[name] = (
+                frozenset(r.consumes.keys()),
+                next(iter(r.produces.keys())),
+            )
+    return out
+
+
+TWO_IN_ONE_OUT_RECIPES = _two_in_one_out_recipes()
+
+
+class TestAssemble2In1OutBasic:
+    def test_generates_without_error(self):
+        f = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=42)
+        assert f is not None
+        world, min_ent = blank_entities(f, num_missing_entities=0)
+        assert world is not None
+        assert min_ent is not None
+
+    def test_returns_cwh_tensor(self):
+        size = 10
+        f = build_factory(size=size, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=42)
+        assert f is not None
+        world, _ = blank_entities(f, num_missing_entities=0)
+        assert world.shape[0] == len(Channel)
+        assert world.shape[1] == size
+        assert world.shape[2] == size
+
+    def test_has_two_sources_one_sink(self):
+        f = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=42)
+        assert f is not None
+        world, _ = blank_entities(f, num_missing_entities=0)
+        ent_layer = world[Channel.ENTITIES.value]
+        assert (ent_layer == str2ent("source").value).sum().item() == 2
+        assert (ent_layer == str2ent("sink").value).sum().item() == 1
+
+    def test_has_one_assembler(self):
+        f = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=42)
+        assert f is not None
+        world, _ = blank_entities(f, num_missing_entities=0)
+        ent_layer = world[Channel.ENTITIES.value]
+        asm = (ent_layer == str2ent("assembling_machine_1").value).sum().item()
+        assert asm == 9, f"Expected 9 assembler tiles, got {asm}"
+
+    def test_has_three_inserters(self):
+        """2 input + 1 output."""
+        f = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=42)
+        assert f is not None
+        world, _ = blank_entities(f, num_missing_entities=0)
+        ent_layer = world[Channel.ENTITIES.value]
+        ins = (ent_layer == str2ent("inserter").value).sum().item()
+        assert ins == 3, f"Expected 3 inserters, got {ins}"
+
+    def test_has_belts(self):
+        f = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=42)
+        assert f is not None
+        world, _ = blank_entities(f, num_missing_entities=0)
+        ent_layer = world[Channel.ENTITIES.value]
+        belts = (ent_layer == str2ent("transport_belt").value).sum().item()
+        assert belts >= 3, f"Expected at least 3 belts, got {belts}"
+
+    def test_nonzero_throughput(self):
+        f = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=42)
+        assert f is not None
+        world, _ = blank_entities(f, num_missing_entities=0)
+        tp, _ = rs_throughput(world.permute(1, 2, 0))
+        assert tp > 0, f"Expected positive throughput, got {tp}"
+
+
+class TestAssemble2In1OutManySeeds:
+    @pytest.mark.parametrize("seed", range(50))
+    def test_size_10_seed(self, seed):
+        f = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=seed)
+        assert f is not None
+        world, _ = blank_entities(f, num_missing_entities=0)
+        tp, _ = rs_throughput(world.permute(1, 2, 0))
+        assert tp > 0, f"seed={seed}: throughput is {tp}"
+
+    @pytest.mark.parametrize("seed", range(30))
+    def test_size_8_seed(self, seed):
+        f = build_factory(size=8, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=seed)
+        assert f is not None
+        world, _ = blank_entities(f, num_missing_entities=0)
+        tp, _ = rs_throughput(world.permute(1, 2, 0))
+        assert tp > 0
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_size_12_seed(self, seed):
+        f = build_factory(size=12, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=seed)
+        assert f is not None
+        world, _ = blank_entities(f, num_missing_entities=0)
+        tp, _ = rs_throughput(world.permute(1, 2, 0))
+        assert tp > 0
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_size_15_seed(self, seed):
+        f = build_factory(size=15, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=seed)
+        assert f is not None
+        world, _ = blank_entities(f, num_missing_entities=0)
+        tp, _ = rs_throughput(world.permute(1, 2, 0))
+        assert tp > 0
+
+
+class TestAssemble2In1OutGridSizes:
+    @pytest.mark.parametrize("size", [8, 9, 10, 12, 15])
+    def test_valid_factory_per_size(self, size):
+        f = build_factory(size=size, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=7)
+        assert f is not None
+        world, _ = blank_entities(f, num_missing_entities=0)
+        ent = world[Channel.ENTITIES.value]
+        assert (ent == str2ent("source").value).sum().item() == 2
+        assert (ent == str2ent("sink").value).sum().item() == 1
+        assert (ent == str2ent("assembling_machine_1").value).sum().item() == 9
+        assert (ent == str2ent("inserter").value).sum().item() == 3
+        tp, _ = rs_throughput(world.permute(1, 2, 0))
+        assert tp > 0
+
+
+class TestAssemble2In1OutEntityDirections:
+    @pytest.mark.parametrize("seed", range(20))
+    def test_all_entities_have_directions(self, seed):
+        f = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=seed)
+        assert f is not None
+        world, _ = blank_entities(f, num_missing_entities=0)
+        ent = world[Channel.ENTITIES.value]
+        dirs = world[Channel.DIRECTION.value]
+        for x in range(world.shape[1]):
+            for y in range(world.shape[2]):
+                v = ent[x, y].item()
+                if v != str2ent("empty").value:
+                    assert dirs[x, y].item() != Direction.NONE.value, (
+                        f"seed={seed}: entity {entities[v].name} at ({x},{y}) has NONE dir"
+                    )
+
+
+class TestAssemble2In1OutNoOverlaps:
+    @pytest.mark.parametrize("seed", range(30))
+    def test_no_double_placement(self, seed):
+        f = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=seed)
+        assert f is not None
+        world, _ = blank_entities(f, num_missing_entities=0)
+        ent = world[Channel.ENTITIES.value]
+        occ = []
+        for x in range(world.shape[1]):
+            for y in range(world.shape[2]):
+                if ent[x, y].item() != str2ent("empty").value:
+                    occ.append((x, y))
+        assert len(occ) == len(set(occ))
+
+
+class TestAssemble2In1OutItems:
+    """Both sources carry the recipe's two ingredient items; sink carries
+    the recipe's product. The two sources must NOT carry the same item."""
+
+    @pytest.mark.parametrize("seed", range(30))
+    def test_sources_match_recipe_inputs(self, seed):
+        f = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=seed)
+        assert f is not None
+        world, _ = blank_entities(f, num_missing_entities=0)
+        ent = world[Channel.ENTITIES.value]
+        item = world[Channel.ITEMS.value]
+        src_positions = (ent == str2ent("source").value).nonzero(as_tuple=False)
+        snk_pos = (ent == str2ent("sink").value).nonzero(as_tuple=False)[0]
+
+        src_items = {item[p[0], p[1]].item() for p in src_positions}
+        sink_item = item[snk_pos[0], snk_pos[1]].item()
+
+        assert str2item("empty").value not in src_items
+        assert sink_item != str2item("empty").value
+        assert len(src_items) == 2, (
+            f"seed={seed}: 2 sources carry the same item ({src_items})"
+        )
+        assert sink_item not in src_items
+
+        src_names = frozenset(items[v].name for v in src_items)
+        sink_name = items[sink_item].name
+        assert (src_names, sink_name) in {
+            (inputs, out) for (inputs, out) in TWO_IN_ONE_OUT_RECIPES.values()
+        }, (
+            f"seed={seed}: pair ({src_names}, {sink_name}) does not match any "
+            f"2-in-1-out recipe in the live recipe table"
+        )
+
+    @pytest.mark.parametrize("seed", range(30))
+    def test_assembler_recipe_matches_output(self, seed):
+        f = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=seed)
+        assert f is not None
+        world, _ = blank_entities(f, num_missing_entities=0)
+        ent = world[Channel.ENTITIES.value]
+        item = world[Channel.ITEMS.value]
+        asm_positions = (ent == str2ent("assembling_machine_1").value).nonzero(as_tuple=False)
+        snk_pos = (ent == str2ent("sink").value).nonzero(as_tuple=False)[0]
+        sink_item = item[snk_pos[0], snk_pos[1]].item()
+        for p in asm_positions:
+            assert item[p[0], p[1]].item() == sink_item
+
+
+class TestAssemble2In1OutMissingEntities:
+    @pytest.mark.parametrize("num_missing", [1, 2, 3])
+    def test_removes_correct_count(self, num_missing):
+        f = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=42)
+        assert f is not None
+        world, min_ent = blank_entities(f, num_missing_entities=num_missing)
+        assert min_ent == num_missing
+        ent = world[Channel.ENTITIES.value]
+        assert (ent == str2ent("source").value).sum().item() == 2
+        assert (ent == str2ent("sink").value).sum().item() == 1
+
+    @pytest.mark.parametrize("seed", range(10))
+    def test_missing_inf_returns_positive_count(self, seed):
+        f = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=seed)
+        assert f is not None
+        world, min_ent = blank_entities(f, num_missing_entities=float("inf"))
+        assert world is not None
+        assert min_ent is not None and min_ent > 0
+
+    @pytest.mark.parametrize("seed", range(10))
+    @pytest.mark.parametrize("num_missing", [1, 5, 20, float("inf")])
+    def test_assembler_kept_or_fully_removed(self, seed, num_missing):
+        """The 3×3 assembler is removed atomically — either all 9 tiles
+        remain or all 9 are blanked. Partial removal corrupts the lesson."""
+        f = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=seed)
+        assert f is not None
+        world, _ = blank_entities(f, num_missing_entities=num_missing)
+        ent_layer = world[Channel.ENTITIES.value]
+        asm_count = (ent_layer == str2ent("assembling_machine_1").value).sum().item()
+        assert asm_count in (0, 9), (
+            f"seed={seed}, num_missing={num_missing}: assembler partially "
+            f"removed ({asm_count} tiles, expected 0 or 9)"
+        )
+
+    def test_assembler_can_be_removed(self):
+        """The assembler must occasionally be blanked, mirroring the
+        1-in-1-out behaviour (#108). With the assembler removed, the
+        2-in-1-out lesson degenerates to just 2 sources + 1 sink — the
+        agent must learn to place the assembler with its recipe."""
+        removed_count = 0
+        for seed in range(60):
+            f = build_factory(
+                size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=seed,
+            )
+            assert f is not None
+            world, _ = blank_entities(f, num_missing_entities=20)
+            ent_layer = world[Channel.ENTITIES.value]
+            asm_count = (ent_layer == str2ent("assembling_machine_1").value).sum().item()
+            if asm_count == 0:
+                removed_count += 1
+        assert removed_count >= 5, (
+            f"Assembler was blanked in only {removed_count}/60 lessons; "
+            f"the item head won't see enough recipe targets"
+        )
+
+    def test_fully_blanked_keeps_only_sources_and_sink(self):
+        """With the assembler removed at high num_missing, the only entities
+        remaining should be the 2 sources, the 1 sink, and (sometimes, when
+        the random blanking doesn't catch every belt/inserter) some leftover
+        belt/inserter tiles. The sources and sink are always preserved."""
+        for seed in range(20):
+            f = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=seed)
+            assert f is not None
+            world, _ = blank_entities(f, num_missing_entities=float("inf"))
+            ent_layer = world[Channel.ENTITIES.value]
+            assert (ent_layer == str2ent("source").value).sum().item() == 2
+            assert (ent_layer == str2ent("sink").value).sum().item() == 1
+
+    @pytest.mark.parametrize("seed", range(10))
+    @pytest.mark.parametrize("num_missing", [1, 5, 20, float("inf")])
+    def test_assembler_recipe_preserved_when_kept(self, seed, num_missing):
+        """When the assembler is kept (asm_count == 9), every tile must
+        still carry the recipe. When fully blanked (asm_count == 0), there
+        are no tiles to check."""
+        f = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=seed)
+        assert f is not None
+        world, _ = blank_entities(f, num_missing_entities=num_missing)
+        ent_layer = world[Channel.ENTITIES.value]
+        item_layer = world[Channel.ITEMS.value]
+        asm_positions = (
+            ent_layer == str2ent("assembling_machine_1").value
+        ).nonzero(as_tuple=False)
+        for pos in asm_positions:
+            assert item_layer[pos[0], pos[1]].item() != str2item("empty").value
+
+
+class TestAssemble2In1OutDeterminism:
+    @pytest.mark.parametrize("seed", [0, 1, 7, 42, 100])
+    def test_same_seed_same_world(self, seed):
+        f1 = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=seed)
+        f2 = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=seed)
+        assert f1 is not None and f2 is not None
+        w1, m1 = blank_entities(f1, num_missing_entities=0, seed=seed)
+        w2, m2 = blank_entities(f2, num_missing_entities=0, seed=seed)
+        assert torch.equal(w1, w2)
+        assert m1 == m2
+
+
+class TestAssemble2In1OutThroughputPerRecipe:
+    """Closed-form throughput, computed from the live recipe table so the
+    test stays correct as new recipes land.
+
+    With 2 input inserters and 1 output inserter, each capped at
+    INSERTER_CAP = 0.86 i/s:
+
+      input ratio per ingredient i = INSERTER_CAP / consumes[i]
+      min_ratio                    = min(1.0, min over i of input ratios)
+      output rate                  = produces[product] × min_ratio
+      final throughput             = min(INSERTER_CAP, output rate)
+    """
+
+    INSERTER_CAP = 0.86
+
+    @pytest.mark.parametrize("seed", range(40))
+    def test_throughput_matches_recipe_closed_form(self, seed):
+        f = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=seed)
+        assert f is not None
+        world, _ = blank_entities(f, num_missing_entities=0)
+        ent = world[Channel.ENTITIES.value]
+        item = world[Channel.ITEMS.value]
+        snk = (ent == str2ent("sink").value).nonzero(as_tuple=False)[0]
+        recipe_name = items[item[snk[0], snk[1]].item()].name
+        recipe = recipes[recipe_name]
+        assert len(recipe.consumes) == 2 and len(recipe.produces) == 1
+        min_ratio = min(
+            1.0,
+            *(self.INSERTER_CAP / c for c in recipe.consumes.values()),
+        )
+        prod_count = next(iter(recipe.produces.values()))
+        expected = min(self.INSERTER_CAP, prod_count * min_ratio)
+
+        tp, _ = rs_throughput(world.permute(1, 2, 0))
+        assert abs(tp - expected) < 1e-3, (
+            f"seed={seed}, recipe={recipe_name}: expected ≈ {expected}, got {tp}"
+        )
+
+
+class TestAssemble2In1OutInserterGeometry:
+    """Two inserters' drop tiles must be inside the assembler body
+    (input inserters); one inserter's pickup tile must be inside (output).
+    All on valid 12 non-corner perimeter slots."""
+
+    @pytest.mark.parametrize("seed", range(30))
+    def test_two_input_one_output(self, seed):
+        f = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=seed)
+        assert f is not None
+        world, _ = blank_entities(f, num_missing_entities=0)
+        asm = _asm_tiles(world)
+        input_count = 0
+        output_count = 0
+        for (x, y), d_val in _inserters(world):
+            d = _dir_from_value(d_val)
+            assert d is not None
+            dx, dy = DIR_TO_DELTA[d]
+            drop = (x + dx, y + dy)
+            pickup = (x - dx, y - dy)
+            if drop in asm and pickup not in asm:
+                input_count += 1
+            elif pickup in asm and drop not in asm:
+                output_count += 1
+            else:
+                raise AssertionError(
+                    f"seed={seed}: inserter at ({x},{y}) has invalid geometry"
+                )
+        assert input_count == 2, f"seed={seed}: expected 2 input inserters, got {input_count}"
+        assert output_count == 1, f"seed={seed}: expected 1 output inserter, got {output_count}"
+
+    @pytest.mark.parametrize("seed", range(30))
+    def test_inserters_on_non_corner_perimeter(self, seed):
+        f = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=seed)
+        assert f is not None
+        world, _ = blank_entities(f, num_missing_entities=0)
+        asm = _asm_tiles(world)
+        ax = min(x for x, _ in asm)
+        ay = min(y for _, y in asm)
+        valid = set()
+        for d in range(3):
+            valid.add((ax + d, ay - 1))
+            valid.add((ax + d, ay + 3))
+            valid.add((ax - 1, ay + d))
+            valid.add((ax + 3, ay + d))
+        for (x, y), _ in _inserters(world):
+            assert (x, y) in valid, (
+                f"seed={seed}: inserter at ({x},{y}) not on a valid perimeter slot"
+            )
+
+    @pytest.mark.parametrize("seed", range(50))
+    def test_source_and_sink_not_on_assembler_perimeter(self, seed):
+        """REGRESSION: same bug as TestAssemble1In1OutInserterGeometry —
+        Source/Sink on the assembler's perimeter ring create phantom
+        infinite-rate edges. With 2 sources here the chance of one
+        landing on a perimeter slot is roughly double."""
+        f = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=seed)
+        assert f is not None
+        world, _ = blank_entities(f, num_missing_entities=0)
+        asm = _asm_tiles(world)
+        ax = min(x for x, _ in asm)
+        ay = min(y for _, y in asm)
+        bad_slots = set()
+        for d in range(3):
+            bad_slots.add((ax + d, ay - 1))
+            bad_slots.add((ax + d, ay + 3))
+            bad_slots.add((ax - 1, ay + d))
+            bad_slots.add((ax + 3, ay + d))
+
+        ent = world[Channel.ENTITIES.value]
+        for v in [str2ent("source").value, str2ent("sink").value]:
+            for p in (ent == v).nonzero(as_tuple=False):
+                pos = (p[0].item(), p[1].item())
+                assert pos not in bad_slots, (
+                    f"seed={seed}: {entities[v].name} at {pos} is on a "
+                    f"non-corner perimeter slot of the assembler at "
+                    f"({ax},{ay}) — would create a phantom infinite-rate "
+                    f"edge"
+                )
+
+
+class TestAssemble2In1OutConnectivity:
+    @pytest.mark.parametrize("seed", range(20))
+    def test_both_sources_reach_assembler(self, seed):
+        f = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=seed)
+        assert f is not None
+        world, _ = blank_entities(f, num_missing_entities=0)
+        G = world2graph(world.permute(1, 2, 0))
+        import networkx as nx
+        sources = [n for n in G.nodes if "stack_inserter" in n]
+        sink = [n for n in G.nodes if "bulk_inserter" in n]
+        asm = [n for n in G.nodes if "assembling_machine" in n]
+        assert len(sources) == 2 and len(sink) == 1 and len(asm) == 1
+        for s in sources:
+            assert nx.has_path(G, s, asm[0])
+        assert nx.has_path(G, asm[0], sink[0])
+
+
+class TestAssemble2In1OutEdgeCases:
+    @pytest.mark.parametrize("size", [1, 2])
+    def test_grid_too_small_raises(self, size):
+        with pytest.raises(Exception):
+            build_factory(size=size, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=0)
+
+    @pytest.mark.parametrize("seed", range(5))
+    def test_large_grid_works(self, seed):
+        f = build_factory(size=20, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=seed)
+        assert f is not None
+        world, _ = blank_entities(f, num_missing_entities=0)
+        tp, _ = rs_throughput(world.permute(1, 2, 0))
+        assert tp > 0
+
+
+class TestAssemble2In1OutBeltItems:
+    """Belt tiles should not have items set."""
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_belt_items_channel_is_empty(self, seed):
+        f = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=seed)
+        assert f is not None
+        world, _ = blank_entities(f, num_missing_entities=0)
+        ent = world[Channel.ENTITIES.value]
+        item = world[Channel.ITEMS.value]
+        empty = str2item("empty").value
+        for p in (ent == str2ent("transport_belt").value).nonzero(as_tuple=False):
+            x, y = p[0].item(), p[1].item()
+            assert item[x, y].item() == empty
+
+
+class TestAssemble2In1OutRecipeSelection:
+    """Multiple distinct 2-in-1-out recipes should appear across seeds."""
+
+    def test_multiple_recipes_appear(self):
+        seen = set()
+        for seed in range(200):
+            f = build_factory(size=10, kind=LessonKind.ASSEMBLE_2IN_1OUT, seed=seed)
+            assert f is not None
+            world, _ = blank_entities(f, num_missing_entities=0)
+            ent = world[Channel.ENTITIES.value]
+            item = world[Channel.ITEMS.value]
+            snk = (ent == str2ent("sink").value).nonzero(as_tuple=False)[0]
+            seen.add(item[snk[0], snk[1]].item())
+
+        seen_names = {items[v].name for v in seen}
+        assert seen_names <= set(TWO_IN_ONE_OUT_RECIPES.keys()), (
+            f"Saw items that are not 2-in-1-out recipes: "
+            f"{seen_names - set(TWO_IN_ONE_OUT_RECIPES.keys())}"
+        )
+        expected_distinct = min(len(TWO_IN_ONE_OUT_RECIPES), 5)
+        assert len(seen_names) >= expected_distinct, (
+            f"Expected ≥ {expected_distinct} distinct recipes across 200 "
+            f"seeds, only saw {len(seen_names)}: {seen_names}"
+        )

--- a/tests/test_lesson_generation.py
+++ b/tests/test_lesson_generation.py
@@ -1602,6 +1602,44 @@ class TestAssemble1In1OutInserterGeometry:
                 f"non-corner perimeter slot of the assembler at ({ax},{ay})"
             )
 
+    @pytest.mark.parametrize("seed", range(50))
+    def test_source_and_sink_not_on_assembler_perimeter(self, seed):
+        """REGRESSION: AssemblingMachine::connections in factorion_rs treats
+        Source/Sink as inserter-like. If a Source happens to land on an
+        unused perimeter slot, it creates a phantom infinite-rate edge
+        directly into the assembler, bypassing the input inserter
+        bottleneck. The Sink mirror would drain at infinite rate, masking
+        any output-inserter cap. The generator must never place Source or
+        Sink on any of the 12 non-corner perimeter slots.
+        """
+        f = build_factory(
+            size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT, seed=seed
+        )
+        assert f is not None
+        world = f.world_CWH
+        asm = _asm_tiles(world)
+        ax = min(x for x, _ in asm)
+        ay = min(y for _, y in asm)
+        # Only the 12 non-corner perimeter slots are problematic; corners
+        # are skipped by AssemblingMachine::connections.
+        bad_slots = set()
+        for d in range(3):
+            bad_slots.add((ax + d, ay - 1))   # north
+            bad_slots.add((ax + d, ay + 3))   # south
+            bad_slots.add((ax - 1, ay + d))   # west
+            bad_slots.add((ax + 3, ay + d))   # east
+
+        ent = world[Channel.ENTITIES.value]
+        for v in [str2ent("source").value, str2ent("sink").value]:
+            for p in (ent == v).nonzero(as_tuple=False):
+                pos = (p[0].item(), p[1].item())
+                assert pos not in bad_slots, (
+                    f"seed={seed}: {entities[v].name} at {pos} is on a "
+                    f"non-corner perimeter slot of the assembler at "
+                    f"({ax},{ay}) — would create a phantom infinite-rate "
+                    f"edge, bypassing the inserter bottleneck"
+                )
+
 
 class TestAssemble1In1OutConnectivity:
     """The graph must form a continuous source → … → sink path that passes


### PR DESCRIPTION
## Summary

New `LessonKind::ASSEMBLE_2IN_1OUT` (= 6) variant. Random pick from the
2-input, 1-output recipes (`electronic_circuit`, `transport_belt`).

Layout:

\`\`\`
  source(input_a) → belts → input inserter A ↘
                                                3×3 assembler(recipe)
  source(input_b) → belts → input inserter B ↗      ↓
                                                  output inserter
                                                       ↓
                                              belts → sink(output)
\`\`\`

## What's in the PR

- **6c6521d** Fix Source/Sink phantom-edge bug in `ASSEMBLE_1IN_1OUT`
  generator. `AssemblingMachine::connections` treats Source/Sink as
  inserter-like, so a Source landing on an unused perimeter slot
  parasitically fed the assembler at infinite rate. Throughput for
  copper_cable would still pass (output-inserter-bound regardless), but
  iron_gear_wheel could read 0.86 instead of 0.43. Fix excludes all 12
  non-corner perimeter slots from the source/sink pool. Pinned with
  \`test_source_and_sink_not_on_assembler_perimeter\` (50 seeds) and
  a docstring explaining why removing it is a footgun.
- **63ee683** New `ASSEMBLE_2IN_1OUT` generator + 17 new test classes
  (~588 instances) mirroring 1-in-1-out coverage.
- **d952871** Vis script `--size`-aware card width so size>=10 grids
  don't overflow the HTML cards.

## Test status

- Rust: 48 passed
- Python: **3224 passed, 148 skipped** (was 2536 — +688 new tests)
- Pre-completion checklist: cargo fmt/clippy/test ✅, maturin develop ✅,
  pytest ✅, ruff ✅

## Closed-form throughput verification

Per-recipe throughput is asserted within 1e-3 of the closed form:

| Recipe | Inputs | Output | Bottleneck | Expected |
|---|---|---|---|---|
| `electronic_circuit` | 3 cu_cable + 1 iron_plate | 1 EC | input inserter (CC: 0.86/3) | 0.287 |
| `transport_belt` | 1 IGW + 1 iron_plate | 2 TB | output inserter (cap 0.86) | 0.86 |

## Test plan

- [ ] CI green
- [ ] Code review
- [ ] sft-smoketest label triggers SFT smoke run

🤖 Generated with [Claude Code](https://claude.com/claude-code)