### PR TITLE
Fix splitter-to-splitter connections

### DIFF
--- a/factorion.py
+++ b/factorion.py
@@ -1442,13 +1442,14 @@ def functions(
                             in_dir = Direction(
                                 world_WHC[in_cell[0], in_cell[1], Channel.DIRECTION.value]
                             )
-                            # Only accept belt-like entities or sources/sinks
-                            # pointing in the same direction as the splitter
+                            # Only accept belt-like entities, sources/sinks,
+                            # or adjacent splitters pointing in the same direction
                             in_is_belt = "belt" in in_ent.name and in_dir == d
                             in_is_source_sink = in_ent.name in (
                                 "stack_inserter", "bulk_inserter"
                             ) and in_dir == d
-                            if in_is_belt or in_is_source_sink:
+                            in_is_splitter = "splitter" in in_ent.name and in_dir == d
+                            if in_is_belt or in_is_source_sink or in_is_splitter:
                                 pending_edges.append((
                                     f"{in_ent.name}\n@{in_cell[0]},{in_cell[1]}",
                                     self_name,
@@ -1471,13 +1472,14 @@ def functions(
                                     out_cell[0], out_cell[1], Channel.DIRECTION.value
                                 ]
                             )
-                            # Only connect to belt-like entities or sinks,
-                            # not facing the opposite direction
+                            # Connect to belt-like entities, sinks, or adjacent
+                            # splitters — but not if they face the opposite direction
                             out_is_belt = "belt" in out_ent.name
                             out_is_sink = out_ent.name in (
                                 "stack_inserter", "bulk_inserter"
                             )
-                            if (out_is_belt or out_is_sink) and out_dir != opposite_dir:
+                            out_is_splitter = "splitter" in out_ent.name
+                            if (out_is_belt or out_is_sink or out_is_splitter) and out_dir != opposite_dir:
                                 pending_edges.append((
                                     self_name,
                                     f"{out_ent.name}\n@{out_cell[0]},{out_cell[1]}",

--- a/factorion_rs/src/entities.rs
+++ b/factorion_rs/src/entities.rs
@@ -531,14 +531,18 @@ impl FactoryEntity for Splitter {
                 if world.in_bounds(in_pos.x, in_pos.y) {
                     if let Some(src_entity) = world.entity_at(ix, iy) {
                         let src_dir = world.direction_at(ix, iy);
-                        // Only accept belt-like entities pointing into the splitter
+                        // Only accept belt-like entities or adjacent splitters pointing into the splitter
                         let src_is_belt =
                             matches!(src_entity, Item::TransportBelt | Item::UndergroundBelt)
                                 && src_dir == dir;
                         // Also accept sources/sinks (they use inserter-style connections)
                         let src_is_source_sink =
                             matches!(src_entity, Item::Source | Item::Sink) && src_dir == dir;
-                        if (src_is_belt || src_is_source_sink) && !tile_set.contains(&in_pos) {
+                        let src_is_splitter =
+                            matches!(src_entity, Item::Splitter) && src_dir == dir;
+                        if (src_is_belt || src_is_source_sink || src_is_splitter)
+                            && !tile_set.contains(&in_pos)
+                        {
                             edges.push((NodeId::new(src_entity, ix, iy), self_id.clone()));
                         }
                     }
@@ -551,12 +555,14 @@ impl FactoryEntity for Splitter {
                 if world.in_bounds(out_pos.x, out_pos.y) {
                     if let Some(dst_entity) = world.entity_at(ox, oy) {
                         let dst_dir = world.direction_at(ox, oy);
-                        // Only connect to belt-like entities or sinks, not opposing
+                        // Connect to belt-like entities, sinks, or adjacent splitters,
+                        // but not if they face the opposite direction
                         let dst_is_belt =
                             matches!(dst_entity, Item::TransportBelt | Item::UndergroundBelt);
                         let dst_is_sink = matches!(dst_entity, Item::Source | Item::Sink);
+                        let dst_is_splitter = matches!(dst_entity, Item::Splitter);
                         let dst_not_opposing = dst_dir != dir.opposite();
-                        if (dst_is_belt || dst_is_sink)
+                        if (dst_is_belt || dst_is_sink || dst_is_splitter)
                             && dst_not_opposing
                             && !tile_set.contains(&out_pos)
                         {
@@ -933,6 +939,36 @@ mod tests {
         assert!(edges.contains(&(self_id.clone(), NodeId::new(Item::TransportBelt, 0, 1))));
         assert!(edges.contains(&(self_id.clone(), NodeId::new(Item::TransportBelt, 1, 1))));
         assert_eq!(edges.len(), 3);
+    }
+
+    #[test]
+    fn test_splitter_to_splitter_connections() {
+        // Two east-facing splitters directly adjacent: splitter1 at (2,0)/(2,1),
+        // splitter2 at (3,0)/(3,1). Verify that splitter1's output connects to splitter2.
+        let mut w = World::empty(6, 2);
+        w.place(1, 0, Item::TransportBelt, Direction::East, None);
+        w.place_splitter(2, 0, Direction::East, None); // tiles (2,0)/(2,1)
+        w.place_splitter(3, 0, Direction::East, None); // tiles (3,0)/(3,1)
+        w.place(4, 0, Item::TransportBelt, Direction::East, None);
+
+        let splitter1_id = NodeId::new(Item::Splitter, 2, 0);
+        let splitter2_id = NodeId::new(Item::Splitter, 3, 0);
+
+        let splitter = Splitter;
+
+        // splitter1 should output to splitter2
+        let edges1 = splitter.connections((2, 0), Direction::East, &w);
+        assert!(
+            edges1.contains(&(splitter1_id.clone(), splitter2_id.clone())),
+            "splitter1 output should connect to splitter2; edges: {edges1:?}"
+        );
+
+        // splitter2 should accept input from splitter1
+        let edges2 = splitter.connections((3, 0), Direction::East, &w);
+        assert!(
+            edges2.contains(&(splitter1_id.clone(), splitter2_id.clone())),
+            "splitter2 input should connect from splitter1; edges: {edges2:?}"
+        );
     }
 
     #[test]

--- a/tests/test_parity.py
+++ b/tests/test_parity.py
@@ -638,25 +638,23 @@ class TestSplitterEdgeCases:
         tp, _ = compare_throughput(world)
         assert tp == 0.0
 
-    def test_adjacent_splitters_no_belt(self):
-        """Two splitters placed directly adjacent (no belt between) → zero throughput.
+    def test_adjacent_splitters_direct(self):
+        """Two splitters placed directly adjacent (no belt between) connect and pass throughput.
 
-        Splitter connections only accept belt-like entities, so direct
-        splitter→splitter produces no edges.
+        Source → Belt → Splitter1 → Splitter2 → Belt → Sink
+        Splitter1 has 1 input, 1 effective output (splitter2). Splitter2 has 1 effective
+        output (belt at (4,0)). Expected throughput = 15.0 i/s.
         """
         world = make_world(8)
         set_entity(world, 0, 0, "source", Direction.EAST, "copper_cable")
         set_entity(world, 1, 0, "transport_belt", Direction.EAST)
         set_splitter(world, 2, 0, Direction.EAST)  # tiles (2,0)/(2,1)
-        # Splitter2 directly adjacent — its input cells are at (2,0)/(2,1)
-        # which are splitter1's tiles. Splitter connections reject non-belt entities.
         set_splitter(world, 3, 0, Direction.EAST)  # tiles (3,0)/(3,1)
         set_entity(world, 4, 0, "transport_belt", Direction.EAST)
         set_entity(world, 5, 0, "sink", Direction.EAST, "copper_cable")
 
         tp, _ = compare_throughput(world)
-        # No connection between the two splitters
-        assert tp == 0.0
+        assert abs(tp - 15.0) < 1e-6, f"Expected 15.0, got {tp}"
 
     @pytest.mark.parametrize("d", DIRS, ids=lambda d: d.name)
     def test_underground_belt_into_splitter(self, d):


### PR DESCRIPTION
Fixes #90

Adds splitter-as-neighbor support to both the Python (`world2graph`) and Rust (`Splitter::connections`) throughput graph builders, so adjacent splitters now connect correctly.

Generated with [Claude Code](https://claude.ai/code)