### PR TITLE
Agent emits all four placement channels (item, misc heads)

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -805,18 +805,25 @@ class AgentCNN(nn.Module):
         # Tile selection: 1x1 conv producing one logit per spatial position
         self.tile_logits = layer_init(nn.Conv2d(chan3, 1, kernel_size=1), std=tile_head_std)
 
-        # Per-tile entity/direction heads (conditioned on selected tile features)
+        # Per-tile entity/direction/item/misc heads (conditioned on selected
+        # tile features). The env's step() requires all four to be set
+        # consistently — e.g. an underground_belt placement must carry
+        # misc=UNDERGROUND_DOWN/UP, and an assembling_machine_1 placement
+        # must carry a recipe in `item`.
         self.ent_head = layer_init(nn.Linear(chan3, self.num_entities))
         self.dir_head = layer_init(nn.Linear(chan3, self.num_directions))
+        self.item_head = layer_init(nn.Linear(chan3, self.num_items))
+        self.misc_head = layer_init(nn.Linear(chan3, self.num_misc))
         self.time_for_get_value = None
         self.time_for_get_action_and_value = None
 
-        # Bias the entity/direction heads towards predicting empty space
+        # Bias every head toward its "empty / NONE" slot (value 0) so a
+        # freshly-initialised policy mostly proposes no-ops, matching the
+        # prior used for entity/direction.
         with torch.no_grad():
-            self.ent_head.bias.fill_(0.0)
-            self.ent_head.bias.data[0] = 1.0
-            self.dir_head.bias.fill_(0.0)
-            self.dir_head.bias.data[0] = 1.0
+            for head in (self.ent_head, self.dir_head, self.item_head, self.misc_head):
+                head.bias.fill_(0.0)
+                head.bias.data[0] = 1.0
 
     def get_value(self, x_BCWH):
         t0 = time.time()
@@ -853,38 +860,49 @@ class AgentCNN(nn.Module):
         batch_idx = torch.arange(B, device=encoded_BCWH.device)
         tile_features_BC = encoded_BCWH[batch_idx, :, x_B, y_B]  # (B, chan3)
 
-        # --- Entity and direction heads (conditioned on tile features) ---
+        # --- Entity / direction / item / misc heads (conditioned on tile features) ---
         logits_e_BE = self.ent_head(tile_features_BC)
         logits_d_BD = self.dir_head(tile_features_BC)
+        logits_i_BI = self.item_head(tile_features_BC)
+        logits_m_BM = self.misc_head(tile_features_BC)
         dist_e = Categorical(logits=logits_e_BE)
         dist_d = Categorical(logits=logits_d_BD)
+        dist_i = Categorical(logits=logits_i_BI)
+        dist_m = Categorical(logits=logits_m_BM)
 
         if action is None:
             ent_B = dist_e.sample()
             dir_B = dist_d.sample()
+            item_B = dist_i.sample()
+            misc_B = dist_m.sample()
         else:
             ent_B = action[:, 2]
             dir_B = action[:, 3]
+            item_B = action[:, 4]
+            misc_B = action[:, 5]
 
         # --- Log probs and entropy ---
         logp_B = (
             dist_tile.log_prob(tile_idx_B) +
             dist_e.log_prob(ent_B) +
-            dist_d.log_prob(dir_B)
+            dist_d.log_prob(dir_B) +
+            dist_i.log_prob(item_B) +
+            dist_m.log_prob(misc_B)
         )
         entropy_B = (
             dist_tile.entropy() +
             dist_e.entropy() +
-            dist_d.entropy()
+            dist_d.entropy() +
+            dist_i.entropy() +
+            dist_m.entropy()
         )
 
-        # --- Output action dict (format unchanged) ---
         action_out = {
             "xy": torch.stack([x_B, y_B], dim=1),
             "direction": dir_B,
             "entity": ent_B,
-            "item": torch.zeros_like(ent_B),
-            "misc": torch.zeros_like(ent_B),
+            "item": item_B,
+            "misc": misc_B,
         }
         self.time_for_get_action_and_value = time.time() - t0
         return action_out, logp_B, entropy_B, value_B

--- a/sft.py
+++ b/sft.py
@@ -48,11 +48,16 @@ str2ent = _fns["str2ent"]
 def extract_expert_actions(solved_CWH, task_CWH):
     """Extract (state, action) pairs by diffing solved vs task worlds.
 
-    Returns list of (state_CWH, tile_idx, entity_id, direction_id,
-    valid_tile_mask) tuples. The valid_tile_mask is a flat binary tensor
-    marking ALL tiles that still need entities at this step — not just the
-    one chosen. This allows multi-label tile loss to avoid penalizing the
-    model for predicting a valid-but-different tile.
+    Returns list of (state_CWH, tile_idx, entity_id, direction_id, item_id,
+    misc_id, valid_tile_mask) tuples. The agent's action covers all four
+    placement channels because the env (ppo.py FactorioEnv.step) rejects
+    placements with mismatched channels — e.g. an underground belt without
+    misc=DOWN/UP, or an assembling_machine_1 without an item (= recipe).
+
+    The valid_tile_mask is a flat binary tensor marking ALL tiles that still
+    need entities at this step — not just the one chosen. This allows
+    multi-label tile loss to avoid penalizing the model for predicting a
+    valid-but-different tile.
 
     Multi-tile entities (e.g. splitters) emit a single pair at the anchor
     tile, not one per occupied cell — placing the anchor fills the whole
@@ -114,8 +119,10 @@ def extract_expert_actions(solved_CWH, task_CWH):
         tile_idx = x * H + y
         entity_id = int(solved_CWH[Channel.ENTITIES.value, x, y])
         direction_id = int(solved_CWH[Channel.DIRECTION.value, x, y])
+        item_id = int(solved_CWH[Channel.ITEMS.value, x, y])
+        misc_id = int(solved_CWH[Channel.MISC.value, x, y])
 
-        pairs.append((obs, tile_idx, entity_id, direction_id, valid_mask))
+        pairs.append((obs, tile_idx, entity_id, direction_id, item_id, misc_id, valid_mask))
 
         # Apply action: copy the entity's full footprint from solved, not
         # just the anchor cell, so the observation reflects what placing
@@ -196,6 +203,8 @@ def generate_dataset(args: SFTArgs):
     all_tile_idx = []
     all_entity = []
     all_direction = []
+    all_item = []
+    all_misc = []
     all_valid_masks = []
     all_lesson_seeds = []
     all_lesson_kinds = []
@@ -233,11 +242,13 @@ def generate_dataset(args: SFTArgs):
 
         kind_lessons[kind.name] += 1
         pairs = extract_expert_actions(solved, task)
-        for obs, tile_idx, entity_id, direction_id, valid_mask in pairs:
+        for obs, tile_idx, entity_id, direction_id, item_id, misc_id, valid_mask in pairs:
             all_obs.append(obs)
             all_tile_idx.append(tile_idx)
             all_entity.append(entity_id)
             all_direction.append(direction_id)
+            all_item.append(item_id)
+            all_misc.append(misc_id)
             all_valid_masks.append(valid_mask)
             all_lesson_seeds.append(seed)
             all_lesson_kinds.append(kind.value)
@@ -255,11 +266,16 @@ def generate_dataset(args: SFTArgs):
     tile_tensor = torch.tensor(all_tile_idx, dtype=torch.long)
     ent_tensor = torch.tensor(all_entity, dtype=torch.long)
     dir_tensor = torch.tensor(all_direction, dtype=torch.long)
+    item_tensor = torch.tensor(all_item, dtype=torch.long)
+    misc_tensor = torch.tensor(all_misc, dtype=torch.long)
     mask_tensor = torch.stack(all_valid_masks)
     seed_tensor = torch.tensor(all_lesson_seeds, dtype=torch.long)
     kind_tensor = torch.tensor(all_lesson_kinds, dtype=torch.long)
 
-    return obs_tensor, tile_tensor, ent_tensor, dir_tensor, mask_tensor, seed_tensor, kind_tensor
+    return (
+        obs_tensor, tile_tensor, ent_tensor, dir_tensor,
+        item_tensor, misc_tensor, mask_tensor, seed_tensor, kind_tensor,
+    )
 
 
 def train_sft(args: SFTArgs):
@@ -270,7 +286,10 @@ def train_sft(args: SFTArgs):
 
     print(f"Generating {args.num_samples} expert demonstrations...")
     t0 = time.time()
-    obs, tiles, ents, dirs, valid_masks, lesson_seeds, lesson_kinds = generate_dataset(args)
+    (
+        obs, tiles, ents, dirs, items_t, miscs_t,
+        valid_masks, lesson_seeds, lesson_kinds,
+    ) = generate_dataset(args)
     print(f"Generated {len(obs)} samples in {time.time() - t0:.1f}s")
 
     # Train/val split at the LESSON SEED level. A pair-level random split
@@ -296,8 +315,16 @@ def train_sft(args: SFTArgs):
         f"{n_val_seeds} lessons (no factory overlap)"
     )
 
-    train_ds = TensorDataset(obs[train_idx], tiles[train_idx], ents[train_idx], dirs[train_idx], valid_masks[train_idx], lesson_kinds[train_idx])
-    val_ds = TensorDataset(obs[val_idx], tiles[val_idx], ents[val_idx], dirs[val_idx], valid_masks[val_idx], lesson_kinds[val_idx])
+    train_ds = TensorDataset(
+        obs[train_idx], tiles[train_idx], ents[train_idx], dirs[train_idx],
+        items_t[train_idx], miscs_t[train_idx], valid_masks[train_idx],
+        lesson_kinds[train_idx],
+    )
+    val_ds = TensorDataset(
+        obs[val_idx], tiles[val_idx], ents[val_idx], dirs[val_idx],
+        items_t[val_idx], miscs_t[val_idx], valid_masks[val_idx],
+        lesson_kinds[val_idx],
+    )
     train_loader = DataLoader(train_ds, batch_size=args.batch_size, shuffle=True)
     val_loader = DataLoader(val_ds, batch_size=args.batch_size)
 
@@ -365,6 +392,8 @@ def train_sft(args: SFTArgs):
     val_tile_acc = 0.0
     val_ent_acc = 0.0
     val_dir_acc = 0.0
+    val_item_acc = 0.0
+    val_misc_acc = 0.0
     print(f"Training for {args.epochs} epochs on {device}...")
 
     for epoch in range(1, args.epochs + 1):
@@ -373,16 +402,24 @@ def train_sft(args: SFTArgs):
         train_loss_tile = 0.0
         train_loss_ent = 0.0
         train_loss_dir = 0.0
+        train_loss_item = 0.0
+        train_loss_misc = 0.0
         train_correct = 0
         train_total = 0
 
         # batch_kind is carried through the loader so val can aggregate
         # per-kind metrics; we ignore it in the train pass.
-        for batch_obs, batch_tile, batch_ent, batch_dir, batch_mask, _batch_kind in train_loader:
+        for batch in train_loader:
+            (
+                batch_obs, batch_tile, batch_ent, batch_dir,
+                batch_item, batch_misc, batch_mask, _batch_kind,
+            ) = batch
             batch_obs = batch_obs.float().to(device)
             batch_tile = batch_tile.to(device)
             batch_ent = batch_ent.to(device)
             batch_dir = batch_dir.to(device)
+            batch_item = batch_item.to(device)
+            batch_misc = batch_misc.to(device)
             batch_mask = batch_mask.to(device)
 
             encoded = agent.encoder(batch_obs)
@@ -393,7 +430,7 @@ def train_sft(args: SFTArgs):
             tile_logits = agent.tile_logits(encoded).reshape(B, -1)
             loss_tile = bce_loss(tile_logits, batch_mask)
 
-            # Extract features at target tile for entity/direction heads
+            # Extract features at target tile for entity/direction/item/misc heads
             x_B = batch_tile // agent.height
             y_B = batch_tile % agent.height
             batch_idx = torch.arange(B, device=device)
@@ -401,10 +438,14 @@ def train_sft(args: SFTArgs):
 
             ent_logits = agent.ent_head(tile_features)
             dir_logits = agent.dir_head(tile_features)
+            item_logits = agent.item_head(tile_features)
+            misc_logits = agent.misc_head(tile_features)
             loss_ent = ce_loss(ent_logits, batch_ent)
             loss_dir = ce_loss(dir_logits, batch_dir)
+            loss_item = ce_loss(item_logits, batch_item)
+            loss_misc = ce_loss(misc_logits, batch_misc)
 
-            loss = loss_tile + loss_ent + loss_dir
+            loss = loss_tile + loss_ent + loss_dir + loss_item + loss_misc
 
             optimizer.zero_grad()
             loss.backward()
@@ -414,12 +455,22 @@ def train_sft(args: SFTArgs):
             train_loss_tile += loss_tile.item() * B
             train_loss_ent += loss_ent.item() * B
             train_loss_dir += loss_dir.item() * B
-            # Tile accuracy: did the model predict ANY valid tile?
+            train_loss_item += loss_item.item() * B
+            train_loss_misc += loss_misc.item() * B
+            # Whole-action accuracy: every action component correct.
             pred_tile = tile_logits.argmax(dim=1)
             tile_hit = batch_mask[batch_idx, pred_tile] > 0
             pred_ent = ent_logits.argmax(dim=1)
             pred_dir = dir_logits.argmax(dim=1)
-            correct = (tile_hit & (pred_ent == batch_ent) & (pred_dir == batch_dir))
+            pred_item = item_logits.argmax(dim=1)
+            pred_misc = misc_logits.argmax(dim=1)
+            correct = (
+                tile_hit
+                & (pred_ent == batch_ent)
+                & (pred_dir == batch_dir)
+                & (pred_item == batch_item)
+                & (pred_misc == batch_misc)
+            )
             train_correct += correct.sum().item()
             train_total += B
 
@@ -427,6 +478,8 @@ def train_sft(args: SFTArgs):
         train_loss_tile /= train_total
         train_loss_ent /= train_total
         train_loss_dir /= train_total
+        train_loss_item /= train_total
+        train_loss_misc /= train_total
         train_acc = train_correct / train_total
 
         # Validation
@@ -435,10 +488,14 @@ def train_sft(args: SFTArgs):
         val_loss_tile = 0.0
         val_loss_ent = 0.0
         val_loss_dir = 0.0
+        val_loss_item = 0.0
+        val_loss_misc = 0.0
         val_correct = 0
         val_tile_correct = 0
         val_ent_correct = 0
         val_dir_correct = 0
+        val_item_correct = 0
+        val_misc_correct = 0
         val_total = 0
 
         # Per-LessonKind accumulators. Indexed by kind name to make wandb
@@ -448,14 +505,22 @@ def train_sft(args: SFTArgs):
         per_kind_tile_correct = {k.name: 0 for k in LessonKind}
         per_kind_ent_correct = {k.name: 0 for k in LessonKind}
         per_kind_dir_correct = {k.name: 0 for k in LessonKind}
+        per_kind_item_correct = {k.name: 0 for k in LessonKind}
+        per_kind_misc_correct = {k.name: 0 for k in LessonKind}
         per_kind_loss_sum = {k.name: 0.0 for k in LessonKind}
 
         with torch.no_grad():
-            for batch_obs, batch_tile, batch_ent, batch_dir, batch_mask, batch_kind in val_loader:
+            for batch in val_loader:
+                (
+                    batch_obs, batch_tile, batch_ent, batch_dir,
+                    batch_item, batch_misc, batch_mask, batch_kind,
+                ) = batch
                 batch_obs = batch_obs.float().to(device)
                 batch_tile = batch_tile.to(device)
                 batch_ent = batch_ent.to(device)
                 batch_dir = batch_dir.to(device)
+                batch_item = batch_item.to(device)
+                batch_misc = batch_misc.to(device)
                 batch_mask = batch_mask.to(device)
                 batch_kind = batch_kind.to(device)
 
@@ -476,26 +541,44 @@ def train_sft(args: SFTArgs):
 
                 ent_logits = agent.ent_head(tile_features)
                 dir_logits = agent.dir_head(tile_features)
+                item_logits = agent.item_head(tile_features)
+                misc_logits = agent.misc_head(tile_features)
                 loss_ent_per = ce_loss_none(ent_logits, batch_ent)
                 loss_dir_per = ce_loss_none(dir_logits, batch_dir)
+                loss_item_per = ce_loss_none(item_logits, batch_item)
+                loss_misc_per = ce_loss_none(misc_logits, batch_misc)
 
-                loss_per_sample = loss_tile_per + loss_ent_per + loss_dir_per
+                loss_per_sample = (
+                    loss_tile_per + loss_ent_per + loss_dir_per
+                    + loss_item_per + loss_misc_per
+                )
                 val_loss += loss_per_sample.sum().item()
                 val_loss_tile += loss_tile_per.sum().item()
                 val_loss_ent += loss_ent_per.sum().item()
                 val_loss_dir += loss_dir_per.sum().item()
+                val_loss_item += loss_item_per.sum().item()
+                val_loss_misc += loss_misc_per.sum().item()
 
                 pred_tile = tile_logits.argmax(dim=1)
                 tile_hit = batch_mask[batch_idx, pred_tile] > 0
                 pred_ent = ent_logits.argmax(dim=1)
                 pred_dir = dir_logits.argmax(dim=1)
+                pred_item = item_logits.argmax(dim=1)
+                pred_misc = misc_logits.argmax(dim=1)
                 ent_correct_per = (pred_ent == batch_ent)
                 dir_correct_per = (pred_dir == batch_dir)
-                correct_per = (tile_hit & ent_correct_per & dir_correct_per)
+                item_correct_per = (pred_item == batch_item)
+                misc_correct_per = (pred_misc == batch_misc)
+                correct_per = (
+                    tile_hit & ent_correct_per & dir_correct_per
+                    & item_correct_per & misc_correct_per
+                )
                 val_correct += correct_per.sum().item()
                 val_tile_correct += tile_hit.sum().item()
                 val_ent_correct += ent_correct_per.sum().item()
                 val_dir_correct += dir_correct_per.sum().item()
+                val_item_correct += item_correct_per.sum().item()
+                val_misc_correct += misc_correct_per.sum().item()
                 val_total += B
 
                 # Per-kind aggregation: one bool-mask per kind appearing in
@@ -509,16 +592,22 @@ def train_sft(args: SFTArgs):
                     per_kind_tile_correct[k_name] += int(tile_hit[mask_k].sum().item())
                     per_kind_ent_correct[k_name] += int(ent_correct_per[mask_k].sum().item())
                     per_kind_dir_correct[k_name] += int(dir_correct_per[mask_k].sum().item())
+                    per_kind_item_correct[k_name] += int(item_correct_per[mask_k].sum().item())
+                    per_kind_misc_correct[k_name] += int(misc_correct_per[mask_k].sum().item())
                     per_kind_loss_sum[k_name] += loss_per_sample[mask_k].sum().item()
 
         val_loss /= val_total
         val_loss_tile /= val_total
         val_loss_ent /= val_total
         val_loss_dir /= val_total
+        val_loss_item /= val_total
+        val_loss_misc /= val_total
         val_acc = val_correct / val_total
         val_tile_acc = val_tile_correct / val_total
         val_ent_acc = val_ent_correct / val_total
         val_dir_acc = val_dir_correct / val_total
+        val_item_acc = val_item_correct / val_total
+        val_misc_acc = val_misc_correct / val_total
 
         # Build per-kind metric dict for both stdout and wandb. Skip kinds
         # absent from the val split (e.g. small datasets where some kinds
@@ -534,12 +623,15 @@ def train_sft(args: SFTArgs):
             per_kind_metrics[f"val/{k.name}/tile_acc"] = per_kind_tile_correct[k.name] / n
             per_kind_metrics[f"val/{k.name}/ent_acc"] = per_kind_ent_correct[k.name] / n
             per_kind_metrics[f"val/{k.name}/dir_acc"] = per_kind_dir_correct[k.name] / n
+            per_kind_metrics[f"val/{k.name}/item_acc"] = per_kind_item_correct[k.name] / n
+            per_kind_metrics[f"val/{k.name}/misc_acc"] = per_kind_misc_correct[k.name] / n
 
         print(
             f"Epoch {epoch:3d}/{args.epochs} | "
             f"train_loss={train_loss:.4f} train_acc={train_acc:.3f} | "
             f"val_loss={val_loss:.4f} val_acc={val_acc:.3f} "
-            f"(tile={val_tile_acc:.3f} ent={val_ent_acc:.3f} dir={val_dir_acc:.3f})"
+            f"(tile={val_tile_acc:.3f} ent={val_ent_acc:.3f} dir={val_dir_acc:.3f} "
+            f"item={val_item_acc:.3f} misc={val_misc_acc:.3f})"
         )
         if per_kind_metrics:
             kind_summary = "  ".join(
@@ -555,15 +647,21 @@ def train_sft(args: SFTArgs):
                 "train/loss_tile": train_loss_tile,
                 "train/loss_ent": train_loss_ent,
                 "train/loss_dir": train_loss_dir,
+                "train/loss_item": train_loss_item,
+                "train/loss_misc": train_loss_misc,
                 "train/acc": train_acc,
                 "val/loss": val_loss,
                 "val/loss_tile": val_loss_tile,
                 "val/loss_ent": val_loss_ent,
                 "val/loss_dir": val_loss_dir,
+                "val/loss_item": val_loss_item,
+                "val/loss_misc": val_loss_misc,
                 "val/acc": val_acc,
                 "val/tile_acc": val_tile_acc,
                 "val/ent_acc": val_ent_acc,
                 "val/dir_acc": val_dir_acc,
+                "val/item_acc": val_item_acc,
+                "val/misc_acc": val_misc_acc,
                 "train/epoch": epoch,
                 **per_kind_metrics,
             })
@@ -583,6 +681,8 @@ def train_sft(args: SFTArgs):
         "val_tile_acc": round(val_tile_acc, 4),
         "val_ent_acc": round(val_ent_acc, 4),
         "val_dir_acc": round(val_dir_acc, 4),
+        "val_item_acc": round(val_item_acc, 4),
+        "val_misc_acc": round(val_misc_acc, 4),
         "val_loss": round(val_loss, 4),
         "num_samples": args.num_samples,
         "epochs": args.epochs,

--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -31,17 +31,18 @@ class TestExtractExpertActions:
         pairs = extract_expert_actions(solved, task)
         assert len(pairs) > 0, "Should have at least one action"
 
-        # Replay actions onto task world
+        # Replay actions onto task world. The action carries all four
+        # placement channels (entity, direction, item, misc) — the agent
+        # is responsible for each.
         state = task.clone()
-        for obs, tile_idx, entity_id, direction_id, valid_mask in pairs:
+        for obs, tile_idx, entity_id, direction_id, item_id, misc_id, valid_mask in pairs:
             H = state.shape[2]
             x = tile_idx // H
             y = tile_idx % H
             state[Channel.ENTITIES.value, x, y] = entity_id
             state[Channel.DIRECTION.value, x, y] = direction_id
-            # Copy other channels from solved
-            state[Channel.ITEMS.value, x, y] = solved[Channel.ITEMS.value, x, y]
-            state[Channel.MISC.value, x, y] = solved[Channel.MISC.value, x, y]
+            state[Channel.ITEMS.value, x, y] = item_id
+            state[Channel.MISC.value, x, y] = misc_id
 
         # Entity and direction channels should match solved
         assert torch.equal(
@@ -105,9 +106,45 @@ class TestExtractExpertActions:
             size=5, kind=LessonKind.MOVE_ONE_ITEM, num_missing_entities=2, seed=42,
         )
         pairs = extract_expert_actions(solved, task)
-        for _, _, entity_id, direction_id, _ in pairs:
+        for _, _, entity_id, direction_id, _, _, _ in pairs:
             assert entity_id != str2ent("empty").value, "Expert actions shouldn't place empty"
             assert direction_id != Direction.NONE.value, "Expert belt actions need a direction"
+
+    def test_ug_belt_action_carries_misc(self):
+        """A MOVE_VIA_UG_BELT lesson with the UG pair blanked must produce
+        action pairs whose misc_id is UNDERGROUND_DOWN or UNDERGROUND_UP —
+        not NONE. Without this the env rejects every UG placement at step
+        time (ug_belt_wo_up_or_down)."""
+        from helpers import Misc
+        ug_id = str2ent("underground_belt").value
+        found_down = found_up = False
+        for seed in range(50):
+            try:
+                solved, _ = generate_lesson(
+                    size=8, kind=LessonKind.MOVE_VIA_UG_BELT,
+                    num_missing_entities=0, seed=seed,
+                )
+                task, _ = generate_lesson(
+                    size=8, kind=LessonKind.MOVE_VIA_UG_BELT,
+                    num_missing_entities=2, seed=seed,
+                )
+            except Exception:
+                continue
+            for _, _, ent_id, _, _, misc_id, _ in extract_expert_actions(solved, task):
+                if ent_id == ug_id:
+                    assert misc_id != Misc.NONE.value, (
+                        f"seed={seed}: UG belt action emitted with misc=NONE"
+                    )
+                    if misc_id == Misc.UNDERGROUND_DOWN.value:
+                        found_down = True
+                    if misc_id == Misc.UNDERGROUND_UP.value:
+                        found_up = True
+            if found_down and found_up:
+                break
+        assert found_down and found_up, (
+            f"Expected to see both DOWN and UP actions across seeds; "
+            f"found_down={found_down}, found_up={found_up}"
+        )
 
     def test_source_and_sink_always_present(self):
         """Task observations should always contain source and sink entities."""
@@ -135,11 +172,13 @@ class TestGenerateDataset:
     def test_generates_correct_count(self):
         """Dataset should have the requested number of samples."""
         args = SFTArgs(seed=1, size=5, num_samples=100, max_level=2)
-        obs, tiles, ents, dirs, masks, seeds, kinds = generate_dataset(args)
+        obs, tiles, ents, dirs, items_t, miscs_t, masks, seeds, kinds = generate_dataset(args)
         assert len(obs) == 100
         assert len(tiles) == 100
         assert len(ents) == 100
         assert len(dirs) == 100
+        assert len(items_t) == 100
+        assert len(miscs_t) == 100
         assert len(masks) == 100
         assert len(seeds) == 100
         assert len(kinds) == 100
@@ -164,7 +203,7 @@ class TestGenerateDataset:
         from the same lesson share the same seed (multiple pairs per
         lesson when level > 1)."""
         args = SFTArgs(seed=1, size=5, num_samples=100, max_level=2)
-        _, _, _, _, _, seeds, _ = generate_dataset(args)
+        *_, seeds, _kinds = generate_dataset(args)
         # Multiple unique seeds expected (each lesson has its own seed).
         assert len(set(seeds.tolist())) >= 2
         # And at least one seed appears more than once (level=2 → ~2 pairs).
@@ -324,7 +363,7 @@ class TestSFTLossConvergence:
     def test_loss_decreases_on_small_dataset(self, registered_env):
         """SFT loss should decrease when training on a small expert dataset."""
         args = SFTArgs(seed=42, size=5, num_samples=200, max_level=2)
-        obs, tiles, ents, dirs, masks, _, _ = generate_dataset(args)
+        obs, tiles, ents, dirs, items_t, miscs_t, masks, _, _ = generate_dataset(args)
 
         envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, 5, "test")])
         agent = AgentCNN(envs, chan1=16, chan2=16, chan3=16, flat_dim=64)
@@ -351,7 +390,15 @@ class TestSFTLossConvergence:
 
             ent_logits = agent.ent_head(tile_features)
             dir_logits = agent.dir_head(tile_features)
-            loss = loss_tile + ce_loss(ent_logits, ents) + ce_loss(dir_logits, dirs)
+            item_logits = agent.item_head(tile_features)
+            misc_logits = agent.misc_head(tile_features)
+            loss = (
+                loss_tile
+                + ce_loss(ent_logits, ents)
+                + ce_loss(dir_logits, dirs)
+                + ce_loss(item_logits, items_t)
+                + ce_loss(misc_logits, miscs_t)
+            )
 
             optimizer.zero_grad()
             loss.backward()
@@ -405,7 +452,7 @@ class TestTrainValSeedSplit:
         random.seed(args.seed)
         np.random.seed(args.seed)
         torch.manual_seed(args.seed)
-        _, _, _, _, _, lesson_seeds, _ = generate_dataset(args)
+        *_, lesson_seeds, _kinds = generate_dataset(args)
 
         unique_seeds = torch.unique(lesson_seeds)
         n_seeds = len(unique_seeds)

--- a/tests/test_spatial_agent.py
+++ b/tests/test_spatial_agent.py
@@ -82,12 +82,15 @@ class TestForwardPass:
         value = agent.get_value(obs)
         assert value.shape == (4,)
 
-    def test_item_and_misc_are_zero(self, agent):
-        """Item and misc should always be zero (hardcoded)."""
+    def test_item_and_misc_within_head_bounds(self, agent):
+        """Item and misc are now sampled from learned heads, so they must
+        be valid indices into items/Misc — not the old hardcoded 0."""
         obs = torch.randn(8, NUM_CHANNELS, 5, 5)
         action_out, _, _, _ = agent.get_action_and_value(obs)
-        assert (action_out["item"] == 0).all()
-        assert (action_out["misc"] == 0).all()
+        assert (action_out["item"] >= 0).all()
+        assert (action_out["item"] < agent.num_items).all()
+        assert (action_out["misc"] >= 0).all()
+        assert (action_out["misc"] < agent.num_misc).all()
 
 
 class TestLogProbConsistency:
@@ -130,7 +133,8 @@ class TestEntropy:
 
 class TestGradientFlow:
     def test_gradients_flow_through_all_params(self, agent):
-        """Verify gradients flow to encoder, tile_logits, ent_head, dir_head."""
+        """Verify gradients flow to encoder, tile_logits, and all four
+        per-tile heads (entity, direction, item, misc)."""
         obs = torch.randn(4, NUM_CHANNELS, 5, 5)
         action_out, logp_B, entropy_B, value_B = agent.get_action_and_value(obs)
         loss = -(logp_B.mean()) + value_B.mean()
@@ -140,9 +144,11 @@ class TestGradientFlow:
         assert agent.tile_logits.weight.grad is not None
         assert agent.tile_logits.weight.grad.abs().sum() > 0
 
-        # Check entity/direction heads have gradients
-        assert agent.ent_head.weight.grad is not None
-        assert agent.dir_head.weight.grad is not None
+        # Check entity/direction/item/misc heads have gradients
+        for head_name in ("ent_head", "dir_head", "item_head", "misc_head"):
+            head = getattr(agent, head_name)
+            assert head.weight.grad is not None, f"No grad for {head_name}.weight"
+            assert head.weight.grad.abs().sum() > 0, f"Zero grad for {head_name}.weight"
 
         # Check encoder has gradients
         for name, param in agent.encoder.named_parameters():
@@ -150,7 +156,8 @@ class TestGradientFlow:
                 assert param.grad is not None, f"No gradient for {name}"
 
     def test_gradients_flow_during_update(self, agent):
-        """Simulate the PPO update path (action not None) and check grads."""
+        """Simulate the PPO update path (action not None) and check grads
+        propagate through every head."""
         obs = torch.randn(4, NUM_CHANNELS, 5, 5)
         with torch.no_grad():
             action_out, _, _, _ = agent.get_action_and_value(obs)
@@ -158,9 +165,10 @@ class TestGradientFlow:
         y_B = action_out["xy"][:, 1]
         ent_B = action_out["entity"]
         dir_B = action_out["direction"]
+        item_B = action_out["item"]
+        misc_B = action_out["misc"]
         action_tensor = torch.stack(
-            [x_B, y_B, ent_B, dir_B, torch.zeros_like(ent_B), torch.zeros_like(ent_B)],
-            dim=1,
+            [x_B, y_B, ent_B, dir_B, item_B, misc_B], dim=1,
         )
 
         _, logp_B, entropy_B, value_B = agent.get_action_and_value(
@@ -169,9 +177,9 @@ class TestGradientFlow:
         loss = -(logp_B.mean()) + value_B.mean()
         loss.backward()
 
-        assert agent.tile_logits.weight.grad is not None
-        assert agent.ent_head.weight.grad is not None
-        assert agent.dir_head.weight.grad is not None
+        for head_name in ("tile_logits", "ent_head", "dir_head", "item_head", "misc_head"):
+            head = getattr(agent, head_name)
+            assert head.weight.grad is not None, f"No grad for {head_name}"
 
 
 class TestBatchConsistency:

--- a/tests/test_torch_compile.py
+++ b/tests/test_torch_compile.py
@@ -114,9 +114,9 @@ class TestCompiledGradientFlow:
 
         # Access underlying module's parameters through the compiled wrapper
         underlying = compiled_agent._orig_mod if hasattr(compiled_agent, "_orig_mod") else compiled_agent
-        assert underlying.tile_logits.weight.grad is not None
-        assert underlying.ent_head.weight.grad is not None
-        assert underlying.dir_head.weight.grad is not None
+        for head_name in ("tile_logits", "ent_head", "dir_head", "item_head", "misc_head"):
+            head = getattr(underlying, head_name)
+            assert head.weight.grad is not None, f"No grad for {head_name}"
 
         for name, param in underlying.encoder.named_parameters():
             if param.requires_grad:


### PR DESCRIPTION
## Summary
- AgentCNN gains `item_head` and `misc_head` matching the existing `ent_head`/`dir_head` pattern, biased toward index 0.
- `get_action_and_value` samples / replays all four heads and folds them into log-prob + entropy.
- SFT pipeline (`extract_expert_actions`, `generate_dataset`, `train_sft`) now pulls and supervises the ITEMS + MISC channels at the target tile. Per-epoch eval reports item_acc / misc_acc.

## Why
Previously the policy hardcoded `item=0` and `misc=0`. The env rejects every underground belt without `misc=UNDERGROUND_DOWN/UP` (`ppo.py:415`) and every assembling_machine_1 without an item recipe (`ppo.py:400`), so those entity types were effectively unplaceable. After this PR the policy can express every legal action the env accepts.

## Test plan
- [x] `cargo fmt`, `cargo clippy -- -D warnings`, `cargo test --no-default-features`
- [x] `maturin develop --release`
- [x] `pytest tests/` — 2940 passed, 149 skipped
- [x] `ruff check .`
- [x] PPO smoke test 5000 timesteps — completes; agent now emits non-zero `item` / `misc` actions
- [x] Targeted regression test: MOVE_VIA_UG_BELT lesson with the UG pair blanked emits actions carrying both `UNDERGROUND_DOWN` and `UNDERGROUND_UP` (never `NONE`)
- [ ] SFT smoketest (cloud, label-triggered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
