### PR TITLE
Interactive model predictions + W&B checkpoint upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ summary.json
 sft_summary.json
 sft_checkpoint.pt
 claude-resume.sh
+*.pt

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ importlib-metadata==8.5.0
 importlib-resources==6.4.5
 itsdangerous==2.2.0
 jedi==0.19.2
-jinja2==3.1.4
+jinja2==3.1.5
 kiwisolver==1.4.7
 markdown==3.7
 markdown-it-py==3.0.0

--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -342,7 +342,7 @@ def _tile_top_p(probs: torch.Tensor, H: int, top_p: float = 0.95) -> tuple[list[
     return top, max(0.0, 1.0 - cum)
 
 
-CANDIDATE_TILE_THRESHOLD = 0.05
+CANDIDATE_TILE_THRESHOLD = 0.01
 """Minimum p(tile) for a tile to appear as a ghost candidate in the UI.
 Tiles with `p(tile) < CANDIDATE_TILE_THRESHOLD` are dropped — they're
 too unlikely to be worth visualising, and the long tail is dominated by

--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -23,13 +23,16 @@ import traceback
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
+from typing import Optional
 
 import matplotlib
 
 matplotlib.use("Agg")
+import gymnasium as gym  # noqa: E402
 import matplotlib.pyplot as plt  # noqa: E402
 import numpy as np  # noqa: E402
 import torch  # noqa: E402
+import torch.nn.functional as F  # noqa: E402
 import tyro  # noqa: E402
 
 os.environ.setdefault("WANDB_MODE", "disabled")
@@ -44,11 +47,13 @@ from factorion import (  # noqa: E402
     Footprint,
     Misc,
     ent_str2b64img,
+    entities,
     items,
     new_world,
     plot_flow_network,
     world2graph,
 )
+from ppo import AgentCNN, FactorioEnv, make_env  # noqa: E402
 
 
 # Order shown in the palette and dropdowns.
@@ -101,6 +106,17 @@ class Args:
     """port for the local HTTP server"""
     size: int = 8
     """default grid size"""
+    checkpoint: Optional[str] = None
+    """path to a trained SFT/PPO checkpoint (.pt). If set, the UI shows
+    the model's predicted next placement and exposes an Apply button."""
+    wandb_run: Optional[str] = None
+    """W&B run id (or full path 'entity/project/run_id'). The run's most
+    recent model-type artifact is downloaded to /tmp/factorion-checkpoints
+    and loaded. Mutually exclusive with --checkpoint."""
+    wandb_project: str = "factorion"
+    """W&B project to look in when --wandb-run is a bare id."""
+    wandb_entity: Optional[str] = None
+    """W&B entity (team or user). None = your default entity."""
 
 
 def build_world(grid: list[list[dict]]) -> torch.Tensor:
@@ -172,6 +188,141 @@ def render_graph_png(grid: list[list[dict]]) -> dict:
     return {"png": png_b64, "info": info, "edges": edges}
 
 
+# ── Model inference ──────────────────────────────────────────────────────────
+# AgentCNN init reads sizes from a gym env, so we keep one cached per grid
+# size — the user can resize the UI grid live and we rebuild lazily on
+# first request for that size. The state dict is loaded with strict=False
+# because the critic head's flat dim depends on W*H and we only use the
+# action heads for inference.
+
+_AGENT_DEVICE = torch.device(
+    "cuda" if torch.cuda.is_available()
+    else "mps" if torch.backends.mps.is_available()
+    else "cpu"
+)
+_AGENT_CACHE: dict[int, AgentCNN] = {}
+_CHECKPOINT_STATE: Optional[dict] = None
+_CHECKPOINT_PATH: Optional[str] = None
+
+# Reverse lookup: head index -> readable name. The entity head excludes the
+# last two catalog entries (source/sink) but its index space starts at 0 and
+# aligns with the first N-2 Item values, so entities[idx].name works as-is.
+_ENT_NAMES = {ent.value: ent.name for ent in entities.values()}
+_ITEM_NAMES = {it.value: it.name for it in items.values()}
+_DIR_NAMES = {d.value: d.name for d in Direction}
+_MISC_NAMES = {m.value: m.name for m in Misc}
+
+
+def _load_checkpoint(path: str) -> None:
+    """Load the checkpoint once and stash it. Lazy per-size agents are
+    built from this on demand."""
+    global _CHECKPOINT_STATE, _CHECKPOINT_PATH
+    state = torch.load(path, map_location="cpu", weights_only=True)
+    _CHECKPOINT_STATE = state
+    _CHECKPOINT_PATH = path
+    # Sanity print so the user can confirm the shape matches what they
+    # trained — they may have run sft.py with non-default chan widths.
+    chan1 = state["encoder.0.weight"].shape[0]
+    chan2 = state["encoder.2.weight"].shape[0]
+    chan3 = state["encoder.4.weight"].shape[0]
+    print(
+        f"Loaded checkpoint {path} "
+        f"(chan1={chan1}, chan2={chan2}, chan3={chan3}, device={_AGENT_DEVICE})"
+    )
+
+
+def _get_agent(size: int) -> AgentCNN:
+    if _CHECKPOINT_STATE is None:
+        raise RuntimeError("no checkpoint loaded — pass --checkpoint at launch")
+    if size in _AGENT_CACHE:
+        return _AGENT_CACHE[size]
+
+    chan1 = _CHECKPOINT_STATE["encoder.0.weight"].shape[0]
+    chan2 = _CHECKPOINT_STATE["encoder.2.weight"].shape[0]
+    chan3 = _CHECKPOINT_STATE["encoder.4.weight"].shape[0]
+
+    env_id = "factorion/FactorioEnv-v0-fb"
+    if env_id not in gym.registry:
+        gym.register(id=env_id, entry_point=FactorioEnv)
+    envs = gym.vector.SyncVectorEnv([make_env(env_id, 0, False, size, "fb")])
+    try:
+        agent = AgentCNN(envs, chan1=chan1, chan2=chan2, chan3=chan3)
+    finally:
+        envs.close()
+    # critic_head's flat dim depends on W*H, so its saved weights are
+    # the wrong shape whenever the UI grid size != the training size.
+    # Drop those entries before loading; we never call the critic during
+    # inference. strict=False would *not* save us here — it ignores
+    # missing/unexpected keys but still raises on shape mismatches.
+    filtered = {
+        k: v for k, v in _CHECKPOINT_STATE.items()
+        if not k.startswith("critic_head.")
+    }
+    missing, unexpected = agent.load_state_dict(filtered, strict=False)
+    ignorable = {"critic_head.1.weight", "critic_head.1.bias"}
+    real_missing = [k for k in missing if k not in ignorable]
+    real_unexpected = [k for k in unexpected if k not in ignorable]
+    if real_missing or real_unexpected:
+        print(
+            f"[warn] state_dict mismatch at size={size}: "
+            f"missing={real_missing} unexpected={real_unexpected}"
+        )
+    agent.to(_AGENT_DEVICE).eval()
+    _AGENT_CACHE[size] = agent
+    return agent
+
+
+def _predict_greedy(grid: list[list[dict]]) -> dict:
+    """Greedy argmax inference. Returns the predicted placement with
+    readable names plus per-head top-1 probabilities so the UI can show
+    how confident the model is."""
+    world_WHC = build_world(grid)
+    size = world_WHC.shape[0]
+    agent = _get_agent(size)
+
+    obs_CWH = world_WHC.permute(2, 0, 1).float().unsqueeze(0).to(_AGENT_DEVICE)
+    C, W, H = obs_CWH.shape[1], obs_CWH.shape[2], obs_CWH.shape[3]
+
+    with torch.no_grad():
+        encoded_BCWH = agent.encoder(obs_CWH)
+        tile_logits = agent.tile_logits(encoded_BCWH).reshape(1, -1)
+        tile_probs = F.softmax(tile_logits, dim=-1)
+        tile_idx = int(tile_logits.argmax(dim=-1).item())
+        tile_prob = float(tile_probs[0, tile_idx].item())
+        x = tile_idx // H
+        y = tile_idx % H
+
+        feats = encoded_BCWH[0, :, x, y].unsqueeze(0)
+        ent_logits = agent.ent_head(feats)
+        dir_logits = agent.dir_head(feats)
+        item_logits = agent.item_head(feats)
+        misc_logits = agent.misc_head(feats)
+
+        ent_idx = int(ent_logits.argmax(dim=-1).item())
+        dir_idx = int(dir_logits.argmax(dim=-1).item())
+        item_idx = int(item_logits.argmax(dim=-1).item())
+        misc_idx = int(misc_logits.argmax(dim=-1).item())
+
+        ent_prob = float(F.softmax(ent_logits, dim=-1)[0, ent_idx].item())
+        dir_prob = float(F.softmax(dir_logits, dim=-1)[0, dir_idx].item())
+        item_prob = float(F.softmax(item_logits, dim=-1)[0, item_idx].item())
+        misc_prob = float(F.softmax(misc_logits, dim=-1)[0, misc_idx].item())
+
+    return {
+        "x": x,
+        "y": y,
+        "tile_prob": tile_prob,
+        "entity": _ENT_NAMES.get(ent_idx, str(ent_idx)),
+        "entity_prob": ent_prob,
+        "direction": _DIR_NAMES.get(dir_idx, str(dir_idx)),
+        "direction_prob": dir_prob,
+        "item": _ITEM_NAMES.get(item_idx, str(item_idx)),
+        "item_prob": item_prob,
+        "misc": _MISC_NAMES.get(misc_idx, str(misc_idx)),
+        "misc_prob": misc_prob,
+    }
+
+
 # Cache palette icons so the page payload stays small per cell.
 def _icon_b64(name: str) -> str:
     try:
@@ -184,7 +335,7 @@ PALETTE_ICONS = {n: _icon_b64(n) for n in PLACEABLE_ENTITIES + ["empty"]}
 ITEM_ICONS = {n: _icon_b64(n) for n in NON_PLACEABLE_ITEMS}
 
 
-def render_index(default_size: int) -> str:
+def render_index(default_size: int, model_enabled: bool) -> str:
     def _hotbar_slot(idx: int, name: str | None) -> str:
         key_label = str((idx + 1) % 10)
         if name is None:
@@ -220,6 +371,24 @@ def render_index(default_size: int) -> str:
     misc_options = "".join(
         f'<option value="{m}">{m}</option>' for m in MISC_VALUES
     )
+
+    if model_enabled:
+        model_panel_html = (
+            '<div class="model-panel">'
+            '<h3 style="margin-top:0.8em;">'
+            '<span class="swatch"></span>Model prediction'
+            '</h3>'
+            '<div id="model-info" class="help">'
+            '(prediction will appear after the next change)</div>'
+            '<pre id="model-action">{}</pre>'
+            '<div class="model-buttons">'
+            '<button id="model-apply">Apply prediction</button>'
+            '<button id="model-refresh">Refresh</button>'
+            '</div>'
+            '</div>'
+        )
+    else:
+        model_panel_html = ""
 
     return f"""<!doctype html>
 <html><head><meta charset="utf-8"><title>Factory builder</title>
@@ -271,6 +440,9 @@ def render_index(default_size: int) -> str:
     position: relative; background: #fff;
   }}
   table.grid td.selected {{ outline: 2px solid #28c850; outline-offset: -2px; }}
+  table.grid td.predicted {{
+    box-shadow: inset 0 0 0 3px #ff9500;
+  }}
   table.grid td.unavailable {{
     background:
       repeating-linear-gradient(45deg,
@@ -300,6 +472,20 @@ def render_index(default_size: int) -> str:
   pre.edges {{
     font-size: 0.75em; max-height: 240px; overflow: auto;
     background: #222; color: #cfc; padding: 0.5em; border-radius: 4px;
+  }}
+  .model-panel {{ margin-top: 0.8em; }}
+  .model-panel pre {{
+    font-size: 0.78em; background: #f4f4f4; padding: 0.5em;
+    border-radius: 4px; margin: 0.3em 0; white-space: pre-wrap;
+  }}
+  .model-panel .model-buttons {{
+    display: flex; gap: 0.4em; flex-wrap: wrap; margin-top: 0.3em;
+  }}
+  .model-panel .swatch {{
+    display: inline-block; width: 0.8em; height: 0.8em; border: 1px solid #b07000;
+    background: rgba(255,149,0,0.0);
+    box-shadow: inset 0 0 0 2px #ff9500;
+    vertical-align: middle; margin-right: 0.25em;
   }}
 </style></head><body>
 
@@ -357,6 +543,8 @@ def render_index(default_size: int) -> str:
       </select>
     </label>
     <button id="clear-cell" style="margin-top:0.6em;">clear cell</button>
+
+    {model_panel_html}
   </div>
 
 </div>
@@ -368,11 +556,13 @@ const HOTBAR = {json.dumps(HOTBAR)};
 const DIR_ARROW = {{ NONE: '', NORTH: '↑', EAST: '→', SOUTH: '↓', WEST: '←' }};
 const MISC_GLYPH = {{ NONE: '', UNDERGROUND_DOWN: '⭳', UNDERGROUND_UP: '⭱' }};
 const DIR_CYCLE = ['NORTH', 'EAST', 'SOUTH', 'WEST'];
+const MODEL_ENABLED = {json.dumps(model_enabled)};
 
 let SIZE = {default_size};
 let grid = [];           // grid[y][x] = cell dict
 let selected = null;     // {{x, y}} or null
 let activeHotbar = null; // 0..9 or null
+let prediction = null;   // last /predict response (or null)
 
 function emptyCell() {{
   return {{
@@ -407,6 +597,7 @@ function renderGrid() {{
       const c = grid[y][x];
       if (c.footprint === 'UNAVAILABLE') td.classList.add('unavailable');
       if (selected && selected.x === x && selected.y === y) td.classList.add('selected');
+      if (prediction && prediction.x === x && prediction.y === y) td.classList.add('predicted');
 
       const inner = document.createElement('div');
       inner.className = 'cell-inner';
@@ -546,7 +737,68 @@ function clearSelected() {{
 let _computeTimer = null;
 function scheduleCompute() {{
   clearTimeout(_computeTimer);
-  _computeTimer = setTimeout(computeGraph, 200);
+  _computeTimer = setTimeout(() => {{
+    computeGraph();
+    if (MODEL_ENABLED) computePrediction();
+  }}, 200);
+}}
+
+async function computePrediction() {{
+  if (!MODEL_ENABLED) return;
+  const info = document.getElementById('model-info');
+  const out = document.getElementById('model-action');
+  if (info) info.textContent = 'predicting…';
+  try {{
+    const resp = await fetch('/predict', {{
+      method: 'POST',
+      headers: {{ 'Content-Type': 'application/json' }},
+      body: JSON.stringify({{ grid }}),
+    }});
+    const data = await resp.json();
+    if (data.error) {{
+      if (info) info.textContent = 'error: ' + data.error;
+      if (out) out.textContent = '';
+      prediction = null;
+      renderGrid();
+      return;
+    }}
+    prediction = data;
+    if (info) {{
+      info.innerHTML =
+        'predicted next placement at (' + data.x + ', ' + data.y +
+        ') · tile p=' + data.tile_prob.toFixed(3);
+    }}
+    if (out) {{
+      const lines = [
+        '  xy:        (' + data.x + ', ' + data.y +
+          ')    p=' + data.tile_prob.toFixed(3),
+        '  entity:    ' + data.entity.padEnd(22) +
+          'p=' + data.entity_prob.toFixed(3),
+        '  direction: ' + data.direction.padEnd(22) +
+          'p=' + data.direction_prob.toFixed(3),
+        '  item:      ' + data.item.padEnd(22) +
+          'p=' + data.item_prob.toFixed(3),
+        '  misc:      ' + data.misc.padEnd(22) +
+          'p=' + data.misc_prob.toFixed(3),
+      ];
+      out.textContent = lines.join('\\n');
+    }}
+    renderGrid();
+  }} catch (e) {{
+    if (info) info.textContent = 'predict failed: ' + e;
+  }}
+}}
+
+function applyPrediction() {{
+  if (!prediction) return;
+  const {{ x, y, entity, direction, item, misc }} = prediction;
+  grid[y][x] = {{
+    entity, direction, item, misc, footprint: grid[y][x].footprint,
+  }};
+  selected = {{ x, y }};
+  prediction = null;
+  renderGrid(); syncEditor();
+  scheduleCompute();
 }}
 
 async function computeGraph() {{
@@ -580,7 +832,14 @@ async function computeGraph() {{
   }}
 }}
 
-document.getElementById('compute').addEventListener('click', computeGraph);
+document.getElementById('compute').addEventListener('click', () => {{
+  computeGraph();
+  if (MODEL_ENABLED) computePrediction();
+}});
+if (MODEL_ENABLED) {{
+  document.getElementById('model-apply').addEventListener('click', applyPrediction);
+  document.getElementById('model-refresh').addEventListener('click', computePrediction);
+}}
 document.getElementById('resize').addEventListener('click', () => {{
   const n = parseInt(document.getElementById('size').value, 10);
   if (!Number.isFinite(n) || n < 2 || n > 20) return;
@@ -636,7 +895,10 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_GET(self):  # noqa: N802
         if self.path == "/" or self.path.startswith("/?"):
-            body = render_index(self.server.default_size).encode()
+            body = render_index(
+                self.server.default_size,
+                model_enabled=_CHECKPOINT_STATE is not None,
+            ).encode()
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.send_header("Content-Length", str(len(body)))
@@ -646,14 +908,17 @@ class Handler(BaseHTTPRequestHandler):
         self.send_error(404)
 
     def do_POST(self):  # noqa: N802
-        if self.path != "/graph":
+        if self.path not in ("/graph", "/predict"):
             self.send_error(404)
             return
         length = int(self.headers.get("Content-Length", "0"))
         raw = self.rfile.read(length).decode("utf-8")
         try:
             payload = json.loads(raw)
-            result = render_graph_png(payload["grid"])
+            if self.path == "/graph":
+                result = render_graph_png(payload["grid"])
+            else:
+                result = _predict_greedy(payload["grid"])
         except Exception as e:
             traceback.print_exc()
             result = {"error": f"{type(e).__name__}: {e}"}
@@ -665,7 +930,66 @@ class Handler(BaseHTTPRequestHandler):
         self.wfile.write(body)
 
 
+def _resolve_wandb_checkpoint(
+    run_spec: str, project: str, entity: Optional[str]
+) -> str:
+    """Resolve a W&B run id to a local checkpoint path. Downloads the
+    run's first model-type artifact to /tmp/factorion-checkpoints.
+
+    `run_spec` is either a bare id ("abc123") or a full path
+    ("user/factorion/abc123"). Sets WANDB_MODE back to online for the
+    duration of the call — the module's earlier setdefault to disabled
+    is for the local HTTP server, not for fetching."""
+    import wandb
+
+    prev_mode = os.environ.pop("WANDB_MODE", None)
+    prev_disabled = os.environ.pop("WANDB_DISABLED", None)
+    try:
+        api = wandb.Api()
+        if run_spec.count("/") == 2:
+            run = api.run(run_spec)
+        else:
+            ent = entity or api.default_entity
+            run = api.run(f"{ent}/{project}/{run_spec}")
+        dest = Path("/tmp/factorion-checkpoints") / run.id
+        dest.mkdir(parents=True, exist_ok=True)
+
+        model_arts = [a for a in run.logged_artifacts() if a.type == "model"]
+        if not model_arts:
+            raise RuntimeError(
+                f"run {run.id} has no artifacts of type=model — "
+                f"was it trained with --track and the artifact-upload code?"
+            )
+        # Newest first. Each `download()` returns the local dir holding
+        # the artifact's files.
+        art = max(model_arts, key=lambda a: a.created_at)
+        local_dir = Path(art.download(root=str(dest / art.name.replace(":", "_"))))
+        pt_files = sorted(local_dir.glob("*.pt"))
+        if not pt_files:
+            raise RuntimeError(f"artifact {art.name} contains no .pt file")
+        path = str(pt_files[0])
+        print(f"Resolved {run_spec} -> {art.name} -> {path}")
+        return path
+    finally:
+        if prev_mode is not None:
+            os.environ["WANDB_MODE"] = prev_mode
+        if prev_disabled is not None:
+            os.environ["WANDB_DISABLED"] = prev_disabled
+
+
 def main(args: Args) -> None:
+    if args.checkpoint and args.wandb_run:
+        raise SystemExit("pass either --checkpoint or --wandb-run, not both")
+    ckpt_path: Optional[str] = args.checkpoint
+    if args.wandb_run:
+        ckpt_path = _resolve_wandb_checkpoint(
+            args.wandb_run, args.wandb_project, args.wandb_entity,
+        )
+    if ckpt_path:
+        _load_checkpoint(ckpt_path)
+    else:
+        print("(no checkpoint — model prediction panel disabled)")
+
     httpd = HTTPServer(("127.0.0.1", args.port), Handler)
     httpd.default_size = args.size
     print(f"Serving factory builder on http://127.0.0.1:{args.port}")

--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -464,6 +464,20 @@ def render_index(default_size: int, model_enabled: bool) -> str:
     font-weight: bold; color: white; text-shadow: 0 0 2px black; font-size: 18px;
   }}
   .cell-inner .xy {{ position: absolute; top: 0; left: 1px; font-size: 8px; opacity: 0.5; }}
+  /* "ghost" overlay = the model's predicted placement, drawn on top of
+     whatever is actually in the cell. Faded + blue-tinted so it can't be
+     mistaken for a real placement. hue-rotate flips the icon's warm
+     palette toward blue; opacity + the tile's orange inset border
+     together signal "this is suggested, not committed". */
+  .cell-inner img.ent.ghost,
+  .cell-inner img.itm.ghost {{
+    opacity: 0.55;
+    filter: hue-rotate(180deg) saturate(2.2) brightness(1.1);
+  }}
+  .cell-inner .arrow.ghost {{ color: #1976d2; opacity: 0.7; }}
+  .cell-inner .misc.ghost {{
+    color: #1976d2; text-shadow: 0 0 2px white; opacity: 0.75;
+  }}
   .editor label {{ display: block; font-size: 0.8em; margin-top: 0.4em; }}
   .editor select, .editor button {{ width: 100%; padding: 0.2em; }}
   .out-img {{ max-width: 100%; border: 1px solid #ddd; border-radius: 4px; }}
@@ -610,6 +624,21 @@ function renderGrid() {{
       if (arrow) html += `<div class="arrow">${{arrow}}</div>`;
       const m = MISC_GLYPH[c.misc] || '';
       if (m) html += `<div class="misc">${{m}}</div>`;
+      // Ghost overlay: predicted (entity, direction, item, misc) drawn
+      // on top of the actual cell content with a blue tint + opacity.
+      // We render every non-empty head independently so the ghost is
+      // informative even when, say, the model wants to change direction
+      // on an existing entity.
+      if (prediction && prediction.x === x && prediction.y === y) {{
+        if (prediction.entity && prediction.entity !== 'empty')
+          html += `<img class="ent ghost" src="${{iconFor(prediction.entity)}}">`;
+        if (prediction.item && prediction.item !== 'empty')
+          html += `<img class="itm ghost" src="${{iconFor(prediction.item)}}">`;
+        const garrow = DIR_ARROW[prediction.direction] || '';
+        if (garrow) html += `<div class="arrow ghost">${{garrow}}</div>`;
+        const gmisc = MISC_GLYPH[prediction.misc] || '';
+        if (gmisc) html += `<div class="misc ghost">${{gmisc}}</div>`;
+      }}
       inner.innerHTML = html;
       td.appendChild(inner);
 

--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -214,14 +214,15 @@ _MISC_NAMES = {m.value: m.name for m in Misc}
 
 
 def _load_checkpoint(path: str) -> None:
-    """Load the checkpoint once and stash it. Lazy per-size agents are
-    built from this on demand."""
+    """Load the checkpoint and stash it. Clears the per-size agent
+    cache so subsequent /predict calls rebuild against the new
+    weights — important when this is invoked at runtime by the UI to
+    swap models, not just once at startup."""
     global _CHECKPOINT_STATE, _CHECKPOINT_PATH
     state = torch.load(path, map_location="cpu", weights_only=True)
     _CHECKPOINT_STATE = state
     _CHECKPOINT_PATH = path
-    # Sanity print so the user can confirm the shape matches what they
-    # trained — they may have run sft.py with non-default chan widths.
+    _AGENT_CACHE.clear()
     chan1 = state["encoder.0.weight"].shape[0]
     chan2 = state["encoder.2.weight"].shape[0]
     chan3 = state["encoder.4.weight"].shape[0]
@@ -229,6 +230,43 @@ def _load_checkpoint(path: str) -> None:
         f"Loaded checkpoint {path} "
         f"(chan1={chan1}, chan2={chan2}, chan3={chan3}, device={_AGENT_DEVICE})"
     )
+
+
+def _model_info() -> dict:
+    """Snapshot of the currently-loaded model for the UI's status line.
+    Returns `loaded: False` when nothing is loaded yet, so the UI can
+    render "(none loaded)" without special-casing on the JS side."""
+    if _CHECKPOINT_STATE is None:
+        return {"loaded": False}
+    s = _CHECKPOINT_STATE
+    return {
+        "loaded": True,
+        "path": _CHECKPOINT_PATH,
+        "chan1": s["encoder.0.weight"].shape[0],
+        "chan2": s["encoder.2.weight"].shape[0],
+        "chan3": s["encoder.4.weight"].shape[0],
+        "device": str(_AGENT_DEVICE),
+    }
+
+
+def _swap_model(kind: str, value: str, project: str, entity: Optional[str]) -> dict:
+    """Resolve `value` to a local .pt path based on `kind`, load it,
+    and return the new model info. Called by the /load_model POST
+    endpoint so the user can switch models without restarting the
+    server."""
+    value = (value or "").strip()
+    if not value:
+        raise ValueError("value cannot be empty")
+    if kind == "local":
+        if not Path(value).exists():
+            raise FileNotFoundError(f"checkpoint not found: {value}")
+        path = value
+    elif kind == "wandb":
+        path = _resolve_wandb_checkpoint(value, project, entity)
+    else:
+        raise ValueError(f"unknown kind: {kind!r} (expected 'local' or 'wandb')")
+    _load_checkpoint(path)
+    return _model_info()
 
 
 def _get_agent(size: int) -> AgentCNN:
@@ -403,7 +441,7 @@ PALETTE_ICONS = {n: _icon_b64(n) for n in PLACEABLE_ENTITIES + ["empty"]}
 ITEM_ICONS = {n: _icon_b64(n) for n in NON_PLACEABLE_ITEMS}
 
 
-def render_index(default_size: int, model_enabled: bool) -> str:
+def render_index(default_size: int) -> str:
     def _hotbar_slot(idx: int, name: str | None) -> str:
         key_label = str((idx + 1) % 10)
         if name is None:
@@ -440,23 +478,38 @@ def render_index(default_size: int, model_enabled: bool) -> str:
         f'<option value="{m}">{m}</option>' for m in MISC_VALUES
     )
 
-    if model_enabled:
-        model_panel_html = (
-            '<div class="model-panel">'
-            '<h3 style="margin-top:0.8em;">'
-            '<span class="swatch"></span>Model prediction'
-            '</h3>'
-            '<div id="model-info" class="help">'
-            '(prediction will appear after the next change)</div>'
-            '<pre id="model-action">{}</pre>'
-            '<div class="model-buttons">'
-            '<button id="model-apply">Apply prediction</button>'
-            '<button id="model-refresh">Refresh</button>'
-            '</div>'
-            '</div>'
-        )
-    else:
-        model_panel_html = ""
+    # Always rendered now — the section exposes a load form so the user
+    # can switch models at runtime. When no model is loaded the
+    # prediction subsection just shows "(no model loaded)".
+    model_panel_html = (
+        '<div class="model-panel">'
+        '<h3 style="margin-top:0.8em;">'
+        '<span class="swatch"></span>Model'
+        '</h3>'
+        '<div class="model-current help" id="model-current">checking…</div>'
+        '<label>source'
+        '  <select id="model-kind">'
+        '    <option value="local">local path</option>'
+        '    <option value="wandb">wandb run id</option>'
+        '  </select>'
+        '</label>'
+        '<label>value'
+        '  <input id="model-value" type="text" placeholder="sft_local.pt or run_id">'
+        '</label>'
+        '<div class="model-buttons">'
+        '<button id="model-load">Load model</button>'
+        '</div>'
+        '<div id="model-load-status" class="help"></div>'
+        '<h3 style="margin-top:0.8em;">Prediction</h3>'
+        '<div id="model-info" class="help">'
+        '(prediction will appear after the next change)</div>'
+        '<pre id="model-action"></pre>'
+        '<div class="model-buttons">'
+        '<button id="model-apply">Apply prediction</button>'
+        '<button id="model-refresh">Refresh</button>'
+        '</div>'
+        '</div>'
+    )
 
     return f"""<!doctype html>
 <html><head><meta charset="utf-8"><title>Factory builder</title>
@@ -633,7 +686,10 @@ const HOTBAR = {json.dumps(HOTBAR)};
 const DIR_ARROW = {{ NONE: '', NORTH: '↑', EAST: '→', SOUTH: '↓', WEST: '←' }};
 const MISC_GLYPH = {{ NONE: '', UNDERGROUND_DOWN: '⭳', UNDERGROUND_UP: '⭱' }};
 const DIR_CYCLE = ['NORTH', 'EAST', 'SOUTH', 'WEST'];
-const MODEL_ENABLED = {json.dumps(model_enabled)};
+// `modelLoaded` is set by refreshModelInfo() at startup and after each
+// successful /load_model call. Prediction calls are gated on it so we
+// don't pester the server with /predict when no checkpoint is loaded.
+let modelLoaded = false;
 
 let SIZE = {default_size};
 let grid = [];           // grid[y][x] = cell dict
@@ -843,7 +899,7 @@ function scheduleCompute() {{
   clearTimeout(_computeTimer);
   _computeTimer = setTimeout(() => {{
     computeGraph();
-    if (MODEL_ENABLED) computePrediction();
+    computePrediction();
   }}, 200);
 }}
 
@@ -870,7 +926,15 @@ function fmtTopTile(top, rest) {{
 }}
 
 async function computePrediction() {{
-  if (!MODEL_ENABLED) return;
+  if (!modelLoaded) {{
+    prediction = null;
+    const info = document.getElementById('model-info');
+    if (info) info.textContent = '(no model loaded)';
+    const out = document.getElementById('model-action');
+    if (out) out.textContent = '';
+    renderGrid();
+    return;
+  }}
   const info = document.getElementById('model-info');
   const out = document.getElementById('model-action');
   if (info) info.textContent = 'predicting…';
@@ -957,11 +1021,61 @@ async function computeGraph() {{
 
 document.getElementById('compute').addEventListener('click', () => {{
   computeGraph();
-  if (MODEL_ENABLED) computePrediction();
+  computePrediction();
 }});
-if (MODEL_ENABLED) {{
-  document.getElementById('model-apply').addEventListener('click', applyPrediction);
-  document.getElementById('model-refresh').addEventListener('click', computePrediction);
+document.getElementById('model-apply').addEventListener('click', applyPrediction);
+document.getElementById('model-refresh').addEventListener('click', computePrediction);
+document.getElementById('model-load').addEventListener('click', loadModel);
+
+async function refreshModelInfo() {{
+  const cur = document.getElementById('model-current');
+  try {{
+    const resp = await fetch('/model_info');
+    const data = await resp.json();
+    if (data.loaded) {{
+      modelLoaded = true;
+      cur.textContent = 'loaded: ' + data.path +
+        '  (c1=' + data.chan1 + ' c2=' + data.chan2 + ' c3=' + data.chan3 +
+        ' ' + data.device + ')';
+    }} else {{
+      modelLoaded = false;
+      cur.textContent = '(none loaded — paste a path or wandb run id below)';
+    }}
+  }} catch (e) {{
+    cur.textContent = 'model_info failed: ' + e;
+  }}
+}}
+
+async function loadModel() {{
+  const kind = document.getElementById('model-kind').value;
+  const value = document.getElementById('model-value').value;
+  const status = document.getElementById('model-load-status');
+  const btn = document.getElementById('model-load');
+  // wandb downloads can take seconds — disable + show a status so the
+  // user doesn't double-click and queue a second download.
+  btn.disabled = true;
+  status.textContent = 'loading…';
+  try {{
+    const resp = await fetch('/load_model', {{
+      method: 'POST',
+      headers: {{ 'Content-Type': 'application/json' }},
+      body: JSON.stringify({{ kind, value }}),
+    }});
+    const data = await resp.json();
+    if (data.error) {{
+      status.textContent = 'error: ' + data.error;
+      return;
+    }}
+    status.textContent = 'loaded ✓';
+    await refreshModelInfo();
+    // Recompute prediction with the new weights so the UI updates
+    // immediately instead of waiting for the next grid edit.
+    computePrediction();
+  }} catch (e) {{
+    status.textContent = 'load failed: ' + e;
+  }} finally {{
+    btn.disabled = false;
+  }}
 }}
 document.getElementById('resize').addEventListener('click', () => {{
   const n = parseInt(document.getElementById('size').value, 10);
@@ -1006,6 +1120,7 @@ grid = newGrid(SIZE);
 renderGrid();
 bindHotbar();
 bindEditor();
+refreshModelInfo();
 </script>
 </body></html>"""
 
@@ -1016,22 +1131,30 @@ class Handler(BaseHTTPRequestHandler):
     def log_message(self, format, *args):  # noqa: A002
         sys.stderr.write("[%s] %s\n" % (self.address_string(), format % args))
 
+    def _send_json(self, payload: dict, status: int = 200) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
     def do_GET(self):  # noqa: N802
         if self.path == "/" or self.path.startswith("/?"):
-            body = render_index(
-                self.server.default_size,
-                model_enabled=_CHECKPOINT_STATE is not None,
-            ).encode()
+            body = render_index(self.server.default_size).encode()
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)
             return
+        if self.path == "/model_info":
+            self._send_json(_model_info())
+            return
         self.send_error(404)
 
     def do_POST(self):  # noqa: N802
-        if self.path not in ("/graph", "/predict"):
+        if self.path not in ("/graph", "/predict", "/load_model"):
             self.send_error(404)
             return
         length = int(self.headers.get("Content-Length", "0"))
@@ -1040,17 +1163,19 @@ class Handler(BaseHTTPRequestHandler):
             payload = json.loads(raw)
             if self.path == "/graph":
                 result = render_graph_png(payload["grid"])
-            else:
+            elif self.path == "/predict":
                 result = _predict(payload["grid"])
+            else:
+                result = _swap_model(
+                    kind=payload.get("kind", ""),
+                    value=payload.get("value", ""),
+                    project=self.server.wandb_project,
+                    entity=self.server.wandb_entity,
+                )
         except Exception as e:
             traceback.print_exc()
             result = {"error": f"{type(e).__name__}: {e}"}
-        body = json.dumps(result).encode()
-        self.send_response(200)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
+        self._send_json(result)
 
 
 def _resolve_wandb_checkpoint(
@@ -1115,6 +1240,10 @@ def main(args: Args) -> None:
 
     httpd = HTTPServer(("127.0.0.1", args.port), Handler)
     httpd.default_size = args.size
+    # Stashed on the server so the /load_model endpoint can use the same
+    # defaults as the CLI when resolving wandb run ids.
+    httpd.wandb_project = args.wandb_project
+    httpd.wandb_entity = args.wandb_entity
     print(f"Serving factory builder on http://127.0.0.1:{args.port}")
     print("Press Ctrl-C to stop.")
     try:

--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -304,15 +304,31 @@ def _tile_top_p(probs: torch.Tensor, H: int, top_p: float = 0.95) -> tuple[list[
     return top, max(0.0, 1.0 - cum)
 
 
+CANDIDATE_TILE_THRESHOLD = 0.05
+"""Minimum p(tile) for a tile to appear as a ghost candidate in the UI.
+Tiles with `p(tile) < CANDIDATE_TILE_THRESHOLD` are dropped — they're
+too unlikely to be worth visualising, and the long tail is dominated by
+the rest mass anyway."""
+
+
 def _predict(grid: list[list[dict]]) -> dict:
-    """Run the model on `grid` and return the argmax placement plus
-    per-head top-p=0.95 distributions, so the UI can show what
-    alternatives the model was considering, not just the top pick."""
+    """Run the model on `grid` and return:
+      * the argmax placement (drives the Apply button + tile border),
+      * per-head top-p=0.95 distributions conditioned on the argmax
+        tile (drives the side panel),
+      * a candidates list — every tile with p(tile) > threshold, paired
+        with its conditional argmax (entity / dir / item / misc) so the
+        UI can render ghost overlays across the whole grid.
+
+    The four per-tile heads (ent/dir/item/misc) are linear projections
+    of the encoder feature at the chosen tile, so computing them for
+    every tile is one batched matmul each — cheap."""
     world_WHC = build_world(grid)
     size = world_WHC.shape[0]
     agent = _get_agent(size)
 
     obs_CWH = world_WHC.permute(2, 0, 1).float().unsqueeze(0).to(_AGENT_DEVICE)
+    W = obs_CWH.shape[2]
     H = obs_CWH.shape[3]
 
     with torch.no_grad():
@@ -322,31 +338,45 @@ def _predict(grid: list[list[dict]]) -> dict:
         tile_top, tile_rest = _tile_top_p(tile_probs, H)
 
         # Argmax — used both as the "Apply" target and to condition the
-        # per-tile heads on the same tile the top distribution favours.
+        # side-panel per-head distributions on the same tile the top
+        # distribution favours.
         tile_idx = int(tile_probs.argmax().item())
         x, y = tile_idx // H, tile_idx % H
 
         feats = encoded_BCWH[0, :, x, y].unsqueeze(0)
-        ent_probs = F.softmax(agent.ent_head(feats), dim=-1)[0]
-        dir_probs = F.softmax(agent.dir_head(feats), dim=-1)[0]
-        item_probs = F.softmax(agent.item_head(feats), dim=-1)[0]
-        misc_probs = F.softmax(agent.misc_head(feats), dim=-1)[0]
+        ent_top, ent_rest = _top_p_named(F.softmax(agent.ent_head(feats), dim=-1)[0], _ENT_NAMES)
+        dir_top, dir_rest = _top_p_named(F.softmax(agent.dir_head(feats), dim=-1)[0], _DIR_NAMES)
+        item_top, item_rest = _top_p_named(F.softmax(agent.item_head(feats), dim=-1)[0], _ITEM_NAMES)
+        misc_top, misc_rest = _top_p_named(F.softmax(agent.misc_head(feats), dim=-1)[0], _MISC_NAMES)
 
-        ent_top, ent_rest = _top_p_named(ent_probs, _ENT_NAMES)
-        dir_top, dir_rest = _top_p_named(dir_probs, _DIR_NAMES)
-        item_top, item_rest = _top_p_named(item_probs, _ITEM_NAMES)
-        misc_top, misc_rest = _top_p_named(misc_probs, _MISC_NAMES)
+        # Per-tile argmax for ent/dir/item/misc — one matmul per head
+        # against the whole spatial map, reshaped to (W*H, chan3).
+        feats_all = encoded_BCWH[0].permute(1, 2, 0).reshape(W * H, -1)
+        ent_pick = agent.ent_head(feats_all).argmax(dim=-1)
+        dir_pick = agent.dir_head(feats_all).argmax(dim=-1)
+        item_pick = agent.item_head(feats_all).argmax(dim=-1)
+        misc_pick = agent.misc_head(feats_all).argmax(dim=-1)
+
+        candidates: list[dict] = []
+        mask = (tile_probs > CANDIDATE_TILE_THRESHOLD).nonzero(as_tuple=False).squeeze(-1).tolist()
+        for t in mask:
+            candidates.append({
+                "x": t // H,
+                "y": t % H,
+                "p_tile": float(tile_probs[t].item()),
+                "entity": _ENT_NAMES.get(int(ent_pick[t].item()), str(int(ent_pick[t].item()))),
+                "direction": _DIR_NAMES.get(int(dir_pick[t].item()), str(int(dir_pick[t].item()))),
+                "item": _ITEM_NAMES.get(int(item_pick[t].item()), str(int(item_pick[t].item()))),
+                "misc": _MISC_NAMES.get(int(misc_pick[t].item()), str(int(misc_pick[t].item()))),
+            })
 
     return {
-        # Argmax pick — drives the dark-blue border on the predicted
-        # tile and the Apply Prediction button.
         "x": x,
         "y": y,
         "entity": ent_top[0]["name"],
         "direction": dir_top[0]["name"],
         "item": item_top[0]["name"],
         "misc": misc_top[0]["name"],
-        # Top-p=0.95 distributions for the UI.
         "tile_top": tile_top,
         "tile_rest": tile_rest,
         "entity_top": ent_top,
@@ -357,6 +387,7 @@ def _predict(grid: list[list[dict]]) -> dict:
         "item_rest": item_rest,
         "misc_top": misc_top,
         "misc_rest": misc_rest,
+        "candidates": candidates,
     }
 
 
@@ -501,6 +532,12 @@ def render_index(default_size: int, model_enabled: bool) -> str:
     font-weight: bold; color: white; text-shadow: 0 0 2px black; font-size: 18px;
   }}
   .cell-inner .xy {{ position: absolute; top: 0; left: 1px; font-size: 8px; opacity: 0.5; }}
+  /* "ghost" = a predicted placement drawn on top of an empty cell. One
+     ghost per candidate tile (all tiles with p(tile) > threshold).
+     Opacity is set inline per element so it can encode the model's
+     confidence — solid for high p(tile), faded for marginal ones. The
+     argmax tile additionally gets the dark-blue inset border via
+     td.predicted so the top pick stays unambiguous. */
   .editor label {{ display: block; font-size: 0.8em; margin-top: 0.4em; }}
   .editor select, .editor button {{ width: 100%; padding: 0.2em; }}
   .out-img {{ max-width: 100%; border: 1px solid #ddd; border-radius: 4px; }}
@@ -627,6 +664,12 @@ function iconFor(name) {{
 
 function renderGrid() {{
   const host = document.getElementById('grid-host');
+  // Build (x,y) -> candidate map once per render so the per-cell
+  // ghost lookup is O(1).
+  const candByXY = {{}};
+  if (prediction && prediction.candidates) {{
+    for (const c of prediction.candidates) candByXY[c.x + ',' + c.y] = c;
+  }}
   const tbl = document.createElement('table');
   tbl.className = 'grid';
   for (let y = 0; y < SIZE; y++) {{
@@ -650,6 +693,27 @@ function renderGrid() {{
       if (arrow) html += `<div class="arrow">${{arrow}}</div>`;
       const m = MISC_GLYPH[c.misc] || '';
       if (m) html += `<div class="misc">${{m}}</div>`;
+      // Ghost overlay: render every candidate tile (all tiles where
+      // p(tile) > threshold) on top of empty cells, with opacity
+      // proportional to the tile probability so the user can see what
+      // the model is *considering*, not just the top pick. The argmax
+      // tile additionally gets the dark-blue inset border (above).
+      // Skip non-empty cells to keep the visualisation legible.
+      const cand = candByXY[x + ',' + y];
+      if (cand && c.entity === 'empty') {{
+        // Map p in [0.05, 1.0] to opacity in [0.18, 0.95] so the
+        // weakest visible ghost still has some presence and the
+        // strongest reads as near-solid.
+        const op = (0.18 + 0.77 * cand.p_tile).toFixed(2);
+        if (cand.entity && cand.entity !== 'empty')
+          html += `<img class="ent ghost" style="opacity:${{op}}" src="${{iconFor(cand.entity)}}">`;
+        if (cand.item && cand.item !== 'empty')
+          html += `<img class="itm ghost" style="opacity:${{op}}" src="${{iconFor(cand.item)}}">`;
+        const garrow = DIR_ARROW[cand.direction] || '';
+        if (garrow) html += `<div class="arrow ghost" style="opacity:${{op}}">${{garrow}}</div>`;
+        const gmisc = MISC_GLYPH[cand.misc] || '';
+        if (gmisc) html += `<div class="misc ghost" style="opacity:${{op}}">${{gmisc}}</div>`;
+      }}
       inner.innerHTML = html;
       td.appendChild(inner);
 

--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -203,6 +203,11 @@ _AGENT_DEVICE = torch.device(
 _AGENT_CACHE: dict[int, AgentCNN] = {}
 _CHECKPOINT_STATE: Optional[dict] = None
 _CHECKPOINT_PATH: Optional[str] = None
+# How the current checkpoint was loaded. Surfaced to the UI so it can
+# render meaningful info (e.g. wandb run id + link) instead of the
+# anonymous /tmp download path. Either {"kind": "local", "path": "..."}
+# or {"kind": "wandb", "run_id", "run_url", "run_name", "artifact"}.
+_CHECKPOINT_SOURCE: Optional[dict] = None
 
 # Reverse lookup: head index -> readable name. The entity head excludes the
 # last two catalog entries (source/sink) but its index space starts at 0 and
@@ -214,10 +219,10 @@ _MISC_NAMES = {m.value: m.name for m in Misc}
 
 
 def _load_checkpoint(path: str) -> None:
-    """Load the checkpoint and stash it. Clears the per-size agent
+    """Load the checkpoint .pt and stash it. Clears the per-size agent
     cache so subsequent /predict calls rebuild against the new
-    weights — important when this is invoked at runtime by the UI to
-    swap models, not just once at startup."""
+    weights. Does NOT touch _CHECKPOINT_SOURCE — the caller knows the
+    provenance (local vs wandb) and sets it after this returns."""
     global _CHECKPOINT_STATE, _CHECKPOINT_PATH
     state = torch.load(path, map_location="cpu", weights_only=True)
     _CHECKPOINT_STATE = state
@@ -242,6 +247,7 @@ def _model_info() -> dict:
     return {
         "loaded": True,
         "path": _CHECKPOINT_PATH,
+        "source": _CHECKPOINT_SOURCE,
         "chan1": s["encoder.0.weight"].shape[0],
         "chan2": s["encoder.2.weight"].shape[0],
         "chan3": s["encoder.4.weight"].shape[0],
@@ -254,6 +260,7 @@ def _swap_model(kind: str, value: str, project: str, entity: Optional[str]) -> d
     and return the new model info. Called by the /load_model POST
     endpoint so the user can switch models without restarting the
     server."""
+    global _CHECKPOINT_SOURCE
     value = (value or "").strip()
     if not value:
         raise ValueError("value cannot be empty")
@@ -261,11 +268,13 @@ def _swap_model(kind: str, value: str, project: str, entity: Optional[str]) -> d
         if not Path(value).exists():
             raise FileNotFoundError(f"checkpoint not found: {value}")
         path = value
+        source = {"kind": "local", "path": value}
     elif kind == "wandb":
-        path = _resolve_wandb_checkpoint(value, project, entity)
+        path, source = _resolve_wandb_checkpoint(value, project, entity)
     else:
         raise ValueError(f"unknown kind: {kind!r} (expected 'local' or 'wandb')")
     _load_checkpoint(path)
+    _CHECKPOINT_SOURCE = source
     return _model_info()
 
 
@@ -1027,6 +1036,19 @@ document.getElementById('model-apply').addEventListener('click', applyPrediction
 document.getElementById('model-refresh').addEventListener('click', computePrediction);
 document.getElementById('model-load').addEventListener('click', loadModel);
 
+// Minimal HTML escape so we can safely inject artifact names + run
+// URLs into innerHTML. Strings come from the wandb API, which is
+// reasonably trusted, but escaping is cheap insurance against weird
+// characters in run names.
+function escHtml(s) {{
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}}
+
 async function refreshModelInfo() {{
   const cur = document.getElementById('model-current');
   try {{
@@ -1034,9 +1056,22 @@ async function refreshModelInfo() {{
     const data = await resp.json();
     if (data.loaded) {{
       modelLoaded = true;
-      cur.textContent = 'loaded: ' + data.path +
-        '  (c1=' + data.chan1 + ' c2=' + data.chan2 + ' c3=' + data.chan3 +
-        ' ' + data.device + ')';
+      const shape = 'c1=' + data.chan1 + ' c2=' + data.chan2 +
+        ' c3=' + data.chan3 + ' ' + data.device;
+      const src = data.source || {{}};
+      if (src.kind === 'wandb') {{
+        // Show the artifact name (the *meaningful* identifier the user
+        // sees in the W&B UI) plus a clickable link to the run, instead
+        // of the anonymous /tmp/factorion-checkpoints download path.
+        const linkText = src.run_name ? src.run_name : src.run_id;
+        cur.innerHTML = 'loaded: ' + escHtml(src.artifact) +
+          ' from <a href="' + escHtml(src.run_url) + '" target="_blank">' +
+          escHtml(linkText) + '</a>' +
+          '  (' + escHtml(shape) + ')';
+      }} else {{
+        const path = (src && src.path) || data.path;
+        cur.textContent = 'loaded: ' + path + '  (' + shape + ')';
+      }}
     }} else {{
       modelLoaded = false;
       cur.textContent = '(none loaded — paste a path or wandb run id below)';
@@ -1180,9 +1215,14 @@ class Handler(BaseHTTPRequestHandler):
 
 def _resolve_wandb_checkpoint(
     run_spec: str, project: str, entity: Optional[str]
-) -> str:
-    """Resolve a W&B run id to a local checkpoint path. Downloads the
-    run's first model-type artifact to /tmp/factorion-checkpoints.
+) -> tuple[str, dict]:
+    """Resolve a W&B run id to (local_path, source_metadata). Downloads
+    the run's most recent model-type artifact to /tmp/factorion-checkpoints.
+
+    The metadata dict (run_id, run_url, run_name, artifact name) is
+    propagated up to _CHECKPOINT_SOURCE so the UI can show
+    "loaded: <artifact> (wandb)" with a clickable link to the run
+    instead of the anonymous tmp download path.
 
     `run_spec` is either a bare id ("abc123") or a full path
     ("user/factorion/abc123"). Sets WANDB_MODE back to online for the
@@ -1217,7 +1257,14 @@ def _resolve_wandb_checkpoint(
             raise RuntimeError(f"artifact {art.name} contains no .pt file")
         path = str(pt_files[0])
         print(f"Resolved {run_spec} -> {art.name} -> {path}")
-        return path
+        source = {
+            "kind": "wandb",
+            "run_id": run.id,
+            "run_url": run.url,
+            "run_name": run.name,
+            "artifact": art.name,
+        }
+        return path, source
     finally:
         if prev_mode is not None:
             os.environ["WANDB_MODE"] = prev_mode
@@ -1226,15 +1273,18 @@ def _resolve_wandb_checkpoint(
 
 
 def main(args: Args) -> None:
+    global _CHECKPOINT_SOURCE
     if args.checkpoint and args.wandb_run:
         raise SystemExit("pass either --checkpoint or --wandb-run, not both")
-    ckpt_path: Optional[str] = args.checkpoint
     if args.wandb_run:
-        ckpt_path = _resolve_wandb_checkpoint(
+        ckpt_path, source = _resolve_wandb_checkpoint(
             args.wandb_run, args.wandb_project, args.wandb_entity,
         )
-    if ckpt_path:
         _load_checkpoint(ckpt_path)
+        _CHECKPOINT_SOURCE = source
+    elif args.checkpoint:
+        _load_checkpoint(args.checkpoint)
+        _CHECKPOINT_SOURCE = {"kind": "local", "path": args.checkpoint}
     else:
         print("(no checkpoint — model prediction panel disabled)")
 

--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -272,54 +272,91 @@ def _get_agent(size: int) -> AgentCNN:
     return agent
 
 
-def _predict_greedy(grid: list[list[dict]]) -> dict:
-    """Greedy argmax inference. Returns the predicted placement with
-    readable names plus per-head top-1 probabilities so the UI can show
-    how confident the model is."""
+def _top_p_named(probs: torch.Tensor, names: dict, top_p: float = 0.95) -> tuple[list[dict], float]:
+    """Sort `probs` (1-D) by descending probability, take entries until
+    cumulative mass >= top_p, return them as [{name, p}, ...] plus the
+    remaining "rest" mass. Useful for showing the model's distribution
+    over discrete choices (entities, directions, items, misc)."""
+    probs_1d = probs.flatten()
+    sorted_p, sorted_i = torch.sort(probs_1d, descending=True)
+    top: list[dict] = []
+    cum = 0.0
+    for p, i in zip(sorted_p.tolist(), sorted_i.tolist()):
+        top.append({"name": names.get(i, str(i)), "p": float(p)})
+        cum += float(p)
+        if cum >= top_p:
+            break
+    return top, max(0.0, 1.0 - cum)
+
+
+def _tile_top_p(probs: torch.Tensor, H: int, top_p: float = 0.95) -> tuple[list[dict], float]:
+    """Same as _top_p_named but emits (x, y, p) entries for the tile
+    head, since each entry is a 2-D coordinate rather than a named
+    category."""
+    sorted_p, sorted_i = torch.sort(probs.flatten(), descending=True)
+    top: list[dict] = []
+    cum = 0.0
+    for p, i in zip(sorted_p.tolist(), sorted_i.tolist()):
+        top.append({"x": int(i) // H, "y": int(i) % H, "p": float(p)})
+        cum += float(p)
+        if cum >= top_p:
+            break
+    return top, max(0.0, 1.0 - cum)
+
+
+def _predict(grid: list[list[dict]]) -> dict:
+    """Run the model on `grid` and return the argmax placement plus
+    per-head top-p=0.95 distributions, so the UI can show what
+    alternatives the model was considering, not just the top pick."""
     world_WHC = build_world(grid)
     size = world_WHC.shape[0]
     agent = _get_agent(size)
 
     obs_CWH = world_WHC.permute(2, 0, 1).float().unsqueeze(0).to(_AGENT_DEVICE)
-    C, W, H = obs_CWH.shape[1], obs_CWH.shape[2], obs_CWH.shape[3]
+    H = obs_CWH.shape[3]
 
     with torch.no_grad():
         encoded_BCWH = agent.encoder(obs_CWH)
         tile_logits = agent.tile_logits(encoded_BCWH).reshape(1, -1)
-        tile_probs = F.softmax(tile_logits, dim=-1)
-        tile_idx = int(tile_logits.argmax(dim=-1).item())
-        tile_prob = float(tile_probs[0, tile_idx].item())
-        x = tile_idx // H
-        y = tile_idx % H
+        tile_probs = F.softmax(tile_logits, dim=-1)[0]
+        tile_top, tile_rest = _tile_top_p(tile_probs, H)
+
+        # Argmax — used both as the "Apply" target and to condition the
+        # per-tile heads on the same tile the top distribution favours.
+        tile_idx = int(tile_probs.argmax().item())
+        x, y = tile_idx // H, tile_idx % H
 
         feats = encoded_BCWH[0, :, x, y].unsqueeze(0)
-        ent_logits = agent.ent_head(feats)
-        dir_logits = agent.dir_head(feats)
-        item_logits = agent.item_head(feats)
-        misc_logits = agent.misc_head(feats)
+        ent_probs = F.softmax(agent.ent_head(feats), dim=-1)[0]
+        dir_probs = F.softmax(agent.dir_head(feats), dim=-1)[0]
+        item_probs = F.softmax(agent.item_head(feats), dim=-1)[0]
+        misc_probs = F.softmax(agent.misc_head(feats), dim=-1)[0]
 
-        ent_idx = int(ent_logits.argmax(dim=-1).item())
-        dir_idx = int(dir_logits.argmax(dim=-1).item())
-        item_idx = int(item_logits.argmax(dim=-1).item())
-        misc_idx = int(misc_logits.argmax(dim=-1).item())
-
-        ent_prob = float(F.softmax(ent_logits, dim=-1)[0, ent_idx].item())
-        dir_prob = float(F.softmax(dir_logits, dim=-1)[0, dir_idx].item())
-        item_prob = float(F.softmax(item_logits, dim=-1)[0, item_idx].item())
-        misc_prob = float(F.softmax(misc_logits, dim=-1)[0, misc_idx].item())
+        ent_top, ent_rest = _top_p_named(ent_probs, _ENT_NAMES)
+        dir_top, dir_rest = _top_p_named(dir_probs, _DIR_NAMES)
+        item_top, item_rest = _top_p_named(item_probs, _ITEM_NAMES)
+        misc_top, misc_rest = _top_p_named(misc_probs, _MISC_NAMES)
 
     return {
+        # Argmax pick — drives the dark-blue border on the predicted
+        # tile and the Apply Prediction button.
         "x": x,
         "y": y,
-        "tile_prob": tile_prob,
-        "entity": _ENT_NAMES.get(ent_idx, str(ent_idx)),
-        "entity_prob": ent_prob,
-        "direction": _DIR_NAMES.get(dir_idx, str(dir_idx)),
-        "direction_prob": dir_prob,
-        "item": _ITEM_NAMES.get(item_idx, str(item_idx)),
-        "item_prob": item_prob,
-        "misc": _MISC_NAMES.get(misc_idx, str(misc_idx)),
-        "misc_prob": misc_prob,
+        "entity": ent_top[0]["name"],
+        "direction": dir_top[0]["name"],
+        "item": item_top[0]["name"],
+        "misc": misc_top[0]["name"],
+        # Top-p=0.95 distributions for the UI.
+        "tile_top": tile_top,
+        "tile_rest": tile_rest,
+        "entity_top": ent_top,
+        "entity_rest": ent_rest,
+        "direction_top": dir_top,
+        "direction_rest": dir_rest,
+        "item_top": item_top,
+        "item_rest": item_rest,
+        "misc_top": misc_top,
+        "misc_rest": misc_rest,
     }
 
 
@@ -441,7 +478,7 @@ def render_index(default_size: int, model_enabled: bool) -> str:
   }}
   table.grid td.selected {{ outline: 2px solid #28c850; outline-offset: -2px; }}
   table.grid td.predicted {{
-    box-shadow: inset 0 0 0 3px #ff9500;
+    box-shadow: inset 0 0 0 3px #0d47a1;
   }}
   table.grid td.unavailable {{
     background:
@@ -464,20 +501,6 @@ def render_index(default_size: int, model_enabled: bool) -> str:
     font-weight: bold; color: white; text-shadow: 0 0 2px black; font-size: 18px;
   }}
   .cell-inner .xy {{ position: absolute; top: 0; left: 1px; font-size: 8px; opacity: 0.5; }}
-  /* "ghost" overlay = the model's predicted placement, drawn on top of
-     whatever is actually in the cell. Faded + blue-tinted so it can't be
-     mistaken for a real placement. hue-rotate flips the icon's warm
-     palette toward blue; opacity + the tile's orange inset border
-     together signal "this is suggested, not committed". */
-  .cell-inner img.ent.ghost,
-  .cell-inner img.itm.ghost {{
-    opacity: 0.55;
-    filter: hue-rotate(180deg) saturate(2.2) brightness(1.1);
-  }}
-  .cell-inner .arrow.ghost {{ color: #1976d2; opacity: 0.7; }}
-  .cell-inner .misc.ghost {{
-    color: #1976d2; text-shadow: 0 0 2px white; opacity: 0.75;
-  }}
   .editor label {{ display: block; font-size: 0.8em; margin-top: 0.4em; }}
   .editor select, .editor button {{ width: 100%; padding: 0.2em; }}
   .out-img {{ max-width: 100%; border: 1px solid #ddd; border-radius: 4px; }}
@@ -490,15 +513,18 @@ def render_index(default_size: int, model_enabled: bool) -> str:
   .model-panel {{ margin-top: 0.8em; }}
   .model-panel pre {{
     font-size: 0.78em; background: #f4f4f4; padding: 0.5em;
-    border-radius: 4px; margin: 0.3em 0; white-space: pre-wrap;
+    border-radius: 4px; margin: 0.3em 0;
+    /* `pre` (not pre-wrap) + overflow-x:auto so long top-p lines
+       scroll horizontally instead of wrapping mid-token and breaking
+       the column alignment. */
+    white-space: pre; overflow-x: auto;
   }}
   .model-panel .model-buttons {{
     display: flex; gap: 0.4em; flex-wrap: wrap; margin-top: 0.3em;
   }}
   .model-panel .swatch {{
-    display: inline-block; width: 0.8em; height: 0.8em; border: 1px solid #b07000;
-    background: rgba(255,149,0,0.0);
-    box-shadow: inset 0 0 0 2px #ff9500;
+    display: inline-block; width: 0.8em; height: 0.8em; border: 1px solid #082466;
+    box-shadow: inset 0 0 0 2px #0d47a1;
     vertical-align: middle; margin-right: 0.25em;
   }}
 </style></head><body>
@@ -624,21 +650,6 @@ function renderGrid() {{
       if (arrow) html += `<div class="arrow">${{arrow}}</div>`;
       const m = MISC_GLYPH[c.misc] || '';
       if (m) html += `<div class="misc">${{m}}</div>`;
-      // Ghost overlay: predicted (entity, direction, item, misc) drawn
-      // on top of the actual cell content with a blue tint + opacity.
-      // We render every non-empty head independently so the ghost is
-      // informative even when, say, the model wants to change direction
-      // on an existing entity.
-      if (prediction && prediction.x === x && prediction.y === y) {{
-        if (prediction.entity && prediction.entity !== 'empty')
-          html += `<img class="ent ghost" src="${{iconFor(prediction.entity)}}">`;
-        if (prediction.item && prediction.item !== 'empty')
-          html += `<img class="itm ghost" src="${{iconFor(prediction.item)}}">`;
-        const garrow = DIR_ARROW[prediction.direction] || '';
-        if (garrow) html += `<div class="arrow ghost">${{garrow}}</div>`;
-        const gmisc = MISC_GLYPH[prediction.misc] || '';
-        if (gmisc) html += `<div class="misc ghost">${{gmisc}}</div>`;
-      }}
       inner.innerHTML = html;
       td.appendChild(inner);
 
@@ -772,6 +783,28 @@ function scheduleCompute() {{
   }}, 200);
 }}
 
+// Format a probability as a short percent string. Matches the user's
+// preferred ".3%" style (no leading zero for sub-1% values) so the
+// numbers stay compact even when the top-p tail gets long.
+function fmtPct(p) {{
+  const v = p * 100;
+  if (v >= 10) return v.toFixed(1) + '%';
+  if (v >= 1)  return v.toFixed(1) + '%';
+  return v.toFixed(1).replace(/^0/, '') + '%';
+}}
+
+function fmtTopNamed(top, rest) {{
+  const parts = top.map(t => t.name + ' (' + fmtPct(t.p) + ')');
+  parts.push('rest (' + fmtPct(rest) + ')');
+  return parts.join(', ');
+}}
+
+function fmtTopTile(top, rest) {{
+  const parts = top.map(t => '(' + t.x + ',' + t.y + ') (' + fmtPct(t.p) + ')');
+  parts.push('rest (' + fmtPct(rest) + ')');
+  return parts.join(', ');
+}}
+
 async function computePrediction() {{
   if (!MODEL_ENABLED) return;
   const info = document.getElementById('model-info');
@@ -793,22 +826,19 @@ async function computePrediction() {{
     }}
     prediction = data;
     if (info) {{
-      info.innerHTML =
-        'predicted next placement at (' + data.x + ', ' + data.y +
-        ') · tile p=' + data.tile_prob.toFixed(3);
+      info.textContent =
+        'predicted next placement at (' + data.x + ', ' + data.y + ')';
     }}
     if (out) {{
+      // Each line: "head:   cand1 (p1), cand2 (p2), ..., rest (R)".
+      // The <pre> uses white-space:pre + overflow-x:auto so long top-p
+      // lines scroll horizontally instead of wrapping.
       const lines = [
-        '  xy:        (' + data.x + ', ' + data.y +
-          ')    p=' + data.tile_prob.toFixed(3),
-        '  entity:    ' + data.entity.padEnd(22) +
-          'p=' + data.entity_prob.toFixed(3),
-        '  direction: ' + data.direction.padEnd(22) +
-          'p=' + data.direction_prob.toFixed(3),
-        '  item:      ' + data.item.padEnd(22) +
-          'p=' + data.item_prob.toFixed(3),
-        '  misc:      ' + data.misc.padEnd(22) +
-          'p=' + data.misc_prob.toFixed(3),
+        '  tile:      ' + fmtTopTile(data.tile_top, data.tile_rest),
+        '  entity:    ' + fmtTopNamed(data.entity_top, data.entity_rest),
+        '  direction: ' + fmtTopNamed(data.direction_top, data.direction_rest),
+        '  item:      ' + fmtTopNamed(data.item_top, data.item_rest),
+        '  misc:      ' + fmtTopNamed(data.misc_top, data.misc_rest),
       ];
       out.textContent = lines.join('\\n');
     }}
@@ -947,7 +977,7 @@ class Handler(BaseHTTPRequestHandler):
             if self.path == "/graph":
                 result = render_graph_png(payload["grid"])
             else:
-                result = _predict_greedy(payload["grid"])
+                result = _predict(payload["grid"])
         except Exception as e:
             traceback.print_exc()
             result = {"error": f"{type(e).__name__}: {e}"}

--- a/sft.py
+++ b/sft.py
@@ -182,7 +182,8 @@ def _humanize_count(n: int) -> str:
     `n50k` reads better than `n50000`."""
     if n >= 1_000_000:
         v = n / 1_000_000
-        return f"{v:.1f}m".rstrip("0").rstrip(".") + ("m" if not f"{v:.1f}".endswith("m") else "")
+        s = f"{v:.1f}".rstrip("0").rstrip(".")
+        return f"{s}m"
     if n >= 1_000:
         v = n / 1_000
         s = f"{v:.1f}".rstrip("0").rstrip(".")

--- a/sft.py
+++ b/sft.py
@@ -177,6 +177,51 @@ class SFTArgs:
     """path to write summary JSON (default: sft_summary.json next to sft.py)"""
 
 
+def _humanize_count(n: int) -> str:
+    """50_000 -> '50k', 2_500_000 -> '2.5m'. Used in artifact names so
+    `n50k` reads better than `n50000`."""
+    if n >= 1_000_000:
+        v = n / 1_000_000
+        return f"{v:.1f}m".rstrip("0").rstrip(".") + ("m" if not f"{v:.1f}".endswith("m") else "")
+    if n >= 1_000:
+        v = n / 1_000
+        s = f"{v:.1f}".rstrip("0").rstrip(".")
+        return f"{s}k"
+    return str(n)
+
+
+def _humanize_lr(lr: float) -> str:
+    """1e-3 -> '1e-3', 0.0005 -> '5e-4'. Keeps artifact names short and
+    visually obvious."""
+    if lr == 0:
+        return "0"
+    exp = int(np.floor(np.log10(lr)))
+    mantissa = lr / (10 ** exp)
+    if abs(mantissa - round(mantissa)) < 1e-6:
+        return f"{int(round(mantissa))}e{exp}"
+    return f"{mantissa:.2g}e{exp}"
+
+
+def _artifact_name(args: "SFTArgs") -> str:
+    """Build a descriptive W&B artifact name from the training config.
+
+    Identical-config runs collapse into versions of the same artifact;
+    config-changing runs (different size / sample count / lr / channels)
+    get their own artifact. `best_val_acc` deliberately goes to the alias
+    instead, since baking a varying number into the name would defeat
+    versioning."""
+    chans = (args.chan1, args.chan2, args.chan3)
+    chan_str = f"c{args.chan1}" if len(set(chans)) == 1 else f"c{args.chan1}-{args.chan2}-{args.chan3}"
+    return (
+        f"sft-s{args.size}"
+        f"-n{_humanize_count(args.num_samples)}"
+        f"-e{args.epochs}"
+        f"-bs{args.batch_size}"
+        f"-lr{_humanize_lr(args.lr)}"
+        f"-{chan_str}"
+    )
+
+
 def generate_dataset(args: SFTArgs):
     """Generate SFT dataset from expert demonstrations.
 
@@ -693,6 +738,37 @@ def train_sft(args: SFTArgs):
     print(f"Summary written to {summary_path}")
 
     if args.track and run is not None:
+        # Upload the best checkpoint + summary so a Mac can grab the trained
+        # model with `wandb artifact get` without rummaging through the pod.
+        #
+        # Name encodes hyperparams so runs with identical config collapse
+        # into versions of one artifact, while different configs land in
+        # separate artifacts — easier to navigate than a wall of
+        # `sft-checkpoint-vN`. val_acc varies per run, so it stays as an
+        # alias instead of being baked into the name.
+        artifact = wandb.Artifact(
+            name=_artifact_name(args),
+            type="model",
+            metadata={
+                "best_val_acc": best_val_acc,
+                "size": args.size,
+                "chan1": args.chan1,
+                "chan2": args.chan2,
+                "chan3": args.chan3,
+                "num_samples": args.num_samples,
+                "epochs": args.epochs,
+                "batch_size": args.batch_size,
+                "lr": args.lr,
+                "seed": args.seed,
+            },
+        )
+        artifact.add_file(args.checkpoint_path)
+        artifact.add_file(summary_path)
+        run.log_artifact(
+            artifact,
+            aliases=["latest", f"val{best_val_acc:.3f}"],
+        )
+        print(f"Logged W&B artifact: {artifact.name}")
         run.finish()
 
     return agent

--- a/tests/test_factory_builder.py
+++ b/tests/test_factory_builder.py
@@ -1,0 +1,291 @@
+"""Tests for scripts/factory_builder.py — the interactive UI server.
+
+Covers the model inference path (the parts that aren't covered by
+test_sft.py): per-head top-p extraction, the agent cache that lets the
+UI resize the grid live, checkpoint loading + cache invalidation on
+swap, and the full /predict response schema.
+
+HTTP endpoints aren't exercised here — the underlying functions
+(_predict, _model_info, _swap_model) are tested directly, so wiring
+them to BaseHTTPRequestHandler would only re-test stdlib socket
+behaviour. wandb downloads aren't tested either: they'd require
+mocking the wandb client, which is high-effort for low payoff."""
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import gymnasium as gym
+import pytest
+import torch
+
+os.environ["WANDB_MODE"] = "disabled"
+os.environ["WANDB_DISABLED"] = "true"
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+import factory_builder as fb  # noqa: E402
+from ppo import AgentCNN, FactorioEnv, make_env  # noqa: E402
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+def _make_tiny_checkpoint(size: int = 4, chan: int = 8) -> Path:
+    """Build a small AgentCNN at the given size + channel width, save
+    its state_dict to a temp .pt, and return the path. The model isn't
+    trained — we only care about *shape* compatibility with the inference
+    pipeline, not accuracy."""
+    env_id = "factorion/FactorioEnv-v0-fbtest"
+    if env_id not in gym.registry:
+        gym.register(id=env_id, entry_point=FactorioEnv)
+    envs = gym.vector.SyncVectorEnv([make_env(env_id, 0, False, size, "fbtest")])
+    try:
+        agent = AgentCNN(envs, chan1=chan, chan2=chan, chan3=chan)
+    finally:
+        envs.close()
+    fd, path = tempfile.mkstemp(suffix=".pt")
+    os.close(fd)
+    torch.save(agent.state_dict(), path)
+    return Path(path)
+
+
+@pytest.fixture(autouse=True)
+def _reset_fb_state():
+    """factory_builder keeps the loaded checkpoint and per-size agents
+    as module-level globals. Reset them between tests so one test's
+    "no checkpoint loaded" state doesn't leak into the next."""
+    fb._CHECKPOINT_STATE = None
+    fb._CHECKPOINT_PATH = None
+    fb._AGENT_CACHE.clear()
+    yield
+    fb._CHECKPOINT_STATE = None
+    fb._CHECKPOINT_PATH = None
+    fb._AGENT_CACHE.clear()
+
+
+def _empty_grid(size: int) -> list[list[dict]]:
+    return [
+        [{"entity": "empty", "direction": "NONE", "item": "empty",
+          "misc": "NONE", "footprint": "AVAILABLE"} for _ in range(size)]
+        for _ in range(size)
+    ]
+
+
+# ── Pure helpers ────────────────────────────────────────────────────────────
+
+class TestTopP:
+    def test_top_p_named_includes_until_mass_reached(self):
+        # 50/30/15/5 split — top-p=0.95 should include 50+30+15=95, then
+        # the 4th item (5%) takes us to 100%, so it's the last one in.
+        probs = torch.tensor([0.50, 0.30, 0.15, 0.05])
+        names = {0: "a", 1: "b", 2: "c", 3: "d"}
+        top, rest = fb._top_p_named(probs, names, top_p=0.95)
+        assert [t["name"] for t in top] == ["a", "b", "c"]
+        assert top[0]["p"] == pytest.approx(0.50)
+        assert rest == pytest.approx(0.05)
+
+    def test_top_p_named_emits_argmax_first(self):
+        """Order must be descending so the UI's "top pick" is top[0]."""
+        probs = torch.tensor([0.10, 0.70, 0.20])
+        names = {0: "a", 1: "b", 2: "c"}
+        top, _ = fb._top_p_named(probs, names)
+        assert top[0]["name"] == "b"
+
+    def test_top_p_named_concentrated(self):
+        """If the top mass already exceeds top_p in one item, only that
+        item is returned and rest is whatever's left."""
+        probs = torch.tensor([0.99, 0.005, 0.005])
+        names = {0: "a", 1: "b", 2: "c"}
+        top, rest = fb._top_p_named(probs, names, top_p=0.95)
+        assert len(top) == 1 and top[0]["name"] == "a"
+        assert rest == pytest.approx(0.01, abs=1e-5)
+
+    def test_tile_top_p_emits_xy(self):
+        # H=3, so flat idx 4 -> (x=1, y=1); flat idx 0 -> (x=0, y=0).
+        # Probs designed so 4 is top-1 and 0 is top-2.
+        probs = torch.tensor([0.30, 0.05, 0.0, 0.0, 0.60, 0.05, 0.0, 0.0, 0.0])
+        top, rest = fb._tile_top_p(probs, H=3, top_p=0.85)
+        assert top[0] == {"x": 1, "y": 1, "p": pytest.approx(0.60)}
+        assert top[1] == {"x": 0, "y": 0, "p": pytest.approx(0.30)}
+        assert rest == pytest.approx(0.10, abs=1e-5)
+
+
+class TestBuildWorld:
+    def test_round_trip_entity_value(self):
+        """Placing a transport_belt facing EAST writes the entity and
+        direction values into the right channels."""
+        size = 3
+        grid = _empty_grid(size)
+        grid[1][2] = {"entity": "transport_belt", "direction": "EAST",
+                      "item": "empty", "misc": "NONE", "footprint": "AVAILABLE"}
+        world = fb.build_world(grid)
+        # fb.items is keyed by Item.value, not by name, so look up via
+        # the same name->value map build_world itself constructs.
+        name_to_value = {it.name: it.value for it in fb.items.values()}
+        # build_world returns WHC; entity channel at (x=2, y=1).
+        assert int(world[2, 1, fb.Channel.ENTITIES.value]) == name_to_value["transport_belt"]
+        assert int(world[2, 1, fb.Channel.DIRECTION.value]) == fb.Direction.EAST.value
+
+    def test_non_square_raises(self):
+        grid = [
+            [{"entity": "empty", "direction": "NONE", "item": "empty",
+              "misc": "NONE", "footprint": "AVAILABLE"}] * 4,
+            [{"entity": "empty", "direction": "NONE", "item": "empty",
+              "misc": "NONE", "footprint": "AVAILABLE"}] * 3,
+        ]
+        with pytest.raises(ValueError, match="square"):
+            fb.build_world(grid)
+
+    def test_footprint_unavailable_propagates(self):
+        size = 2
+        grid = _empty_grid(size)
+        grid[0][0]["footprint"] = "UNAVAILABLE"
+        world = fb.build_world(grid)
+        assert int(world[0, 0, fb.Channel.FOOTPRINT.value]) == \
+            fb.Footprint.UNAVAILABLE.value
+
+
+# ── Model loading + cache ───────────────────────────────────────────────────
+
+class TestCheckpointLoading:
+    def test_load_checkpoint_populates_state(self):
+        path = _make_tiny_checkpoint()
+        try:
+            fb._load_checkpoint(str(path))
+            assert fb._CHECKPOINT_STATE is not None
+            assert fb._CHECKPOINT_PATH == str(path)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_swap_clears_agent_cache(self):
+        """The agent cache must be invalidated on reload — otherwise a
+        UI-triggered model swap would silently keep predicting from the
+        old weights."""
+        ckpt_a = _make_tiny_checkpoint(size=4, chan=8)
+        ckpt_b = _make_tiny_checkpoint(size=4, chan=8)
+        try:
+            fb._load_checkpoint(str(ckpt_a))
+            # Prime the cache.
+            agent_a = fb._get_agent(4)
+            assert 4 in fb._AGENT_CACHE
+            # Reload triggers cache invalidation.
+            fb._load_checkpoint(str(ckpt_b))
+            assert 4 not in fb._AGENT_CACHE, (
+                "_load_checkpoint must clear _AGENT_CACHE; otherwise the "
+                "next predict() uses stale weights"
+            )
+            # Building anew yields a fresh object.
+            agent_b = fb._get_agent(4)
+            assert agent_a is not agent_b
+        finally:
+            ckpt_a.unlink(missing_ok=True)
+            ckpt_b.unlink(missing_ok=True)
+
+    def test_get_agent_caches_per_size(self):
+        path = _make_tiny_checkpoint(size=4)
+        try:
+            fb._load_checkpoint(str(path))
+            agent4_first = fb._get_agent(4)
+            agent4_second = fb._get_agent(4)
+            agent6 = fb._get_agent(6)
+            assert agent4_first is agent4_second, "Same size → cached"
+            assert agent6 is not agent4_first, "Different size → fresh agent"
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_predict_without_checkpoint_raises(self):
+        with pytest.raises(RuntimeError, match="no checkpoint"):
+            fb._predict(_empty_grid(4))
+
+
+class TestSwapModel:
+    def test_swap_local_path(self):
+        ckpt_a = _make_tiny_checkpoint(size=4, chan=8)
+        ckpt_b = _make_tiny_checkpoint(size=4, chan=8)
+        try:
+            fb._load_checkpoint(str(ckpt_a))
+            info = fb._swap_model("local", str(ckpt_b), project="x", entity=None)
+            assert info["loaded"] is True
+            assert info["path"] == str(ckpt_b)
+            assert fb._CHECKPOINT_PATH == str(ckpt_b)
+        finally:
+            ckpt_a.unlink(missing_ok=True)
+            ckpt_b.unlink(missing_ok=True)
+
+    def test_swap_local_missing_file(self):
+        with pytest.raises(FileNotFoundError):
+            fb._swap_model(
+                "local", "/tmp/does-not-exist.pt", project="x", entity=None,
+            )
+
+    def test_swap_bad_kind(self):
+        with pytest.raises(ValueError, match="unknown kind"):
+            fb._swap_model("magic", "value", project="x", entity=None)
+
+    def test_swap_empty_value(self):
+        with pytest.raises(ValueError, match="empty"):
+            fb._swap_model("local", "", project="x", entity=None)
+
+
+# ── End-to-end /predict schema ──────────────────────────────────────────────
+
+class TestPredictSchema:
+    def test_predict_returns_full_schema(self):
+        path = _make_tiny_checkpoint(size=4, chan=8)
+        try:
+            fb._load_checkpoint(str(path))
+            result = fb._predict(_empty_grid(4))
+            # Argmax-pick fields drive the dark-blue border + Apply.
+            for key in ("x", "y", "entity", "direction", "item", "misc"):
+                assert key in result, f"missing argmax field: {key}"
+            assert 0 <= result["x"] < 4
+            assert 0 <= result["y"] < 4
+            # Side-panel top-p distributions per head.
+            for head in ("tile", "entity", "direction", "item", "misc"):
+                assert f"{head}_top" in result
+                assert f"{head}_rest" in result
+                top = result[f"{head}_top"]
+                rest = result[f"{head}_rest"]
+                assert isinstance(top, list) and len(top) >= 1
+                # Cumulative mass should account for ~all the probability.
+                cum = sum(t["p"] for t in top) + rest
+                assert cum == pytest.approx(1.0, abs=1e-4)
+            # Ghost overlay candidates list.
+            assert "candidates" in result
+            for cand in result["candidates"]:
+                assert cand["p_tile"] > fb.CANDIDATE_TILE_THRESHOLD
+                for key in ("x", "y", "entity", "direction", "item", "misc"):
+                    assert key in cand
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_predict_argmax_in_tile_top(self):
+        """The argmax (x, y) must appear in tile_top[0] — the UI relies
+        on this invariant when drawing the dark-blue border."""
+        path = _make_tiny_checkpoint(size=4, chan=8)
+        try:
+            fb._load_checkpoint(str(path))
+            result = fb._predict(_empty_grid(4))
+            tile_top0 = result["tile_top"][0]
+            assert (tile_top0["x"], tile_top0["y"]) == (result["x"], result["y"])
+        finally:
+            path.unlink(missing_ok=True)
+
+
+class TestModelInfo:
+    def test_unloaded_state(self):
+        info = fb._model_info()
+        assert info == {"loaded": False}
+
+    def test_loaded_state_exposes_shape(self):
+        path = _make_tiny_checkpoint(size=4, chan=8)
+        try:
+            fb._load_checkpoint(str(path))
+            info = fb._model_info()
+            assert info["loaded"] is True
+            assert info["path"] == str(path)
+            assert info["chan1"] == info["chan2"] == info["chan3"] == 8
+        finally:
+            path.unlink(missing_ok=True)

--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -15,7 +15,15 @@ os.environ["WANDB_DISABLED"] = "true"
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from helpers import Channel, Direction, LessonKind, generate_lesson, str2ent
-from sft import extract_expert_actions, generate_dataset, train_sft, SFTArgs
+from sft import (
+    SFTArgs,
+    _artifact_name,
+    _humanize_count,
+    _humanize_lr,
+    extract_expert_actions,
+    generate_dataset,
+    train_sft,
+)
 from ppo import FactorioEnv, AgentCNN, make_env
 
 
@@ -466,3 +474,57 @@ class TestTrainValSeedSplit:
         )
         assert len(val_seeds) >= 1
         assert len(train_seeds) >= 1
+
+
+class TestArtifactNameHelpers:
+    """The W&B artifact name encodes hyperparams so runs with identical
+    configs collapse into versions of one artifact. These tests pin the
+    format so accidentally renaming a hyperparam doesn't silently
+    fragment the artifact namespace."""
+
+    @pytest.mark.parametrize("n,expected", [
+        (500, "500"),
+        (1_000, "1k"),
+        (50_000, "50k"),
+        (200_000, "200k"),
+        (1_000_000, "1m"),
+        (2_500_000, "2.5m"),
+    ])
+    def test_humanize_count(self, n, expected):
+        assert _humanize_count(n) == expected
+
+    @pytest.mark.parametrize("lr,expected", [
+        (1e-3, "1e-3"),
+        (3e-4, "3e-4"),
+        (1e-4, "1e-4"),
+        (5e-4, "5e-4"),
+    ])
+    def test_humanize_lr_round(self, lr, expected):
+        """Mantissas that are clean integers don't get a decimal point."""
+        assert _humanize_lr(lr) == expected
+
+    def test_humanize_lr_zero(self):
+        assert _humanize_lr(0) == "0"
+
+    def test_artifact_name_default(self):
+        assert _artifact_name(SFTArgs()) == "sft-s8-n50k-e30-bs512-lr1e-3-c48"
+
+    def test_artifact_name_larger_run(self):
+        args = SFTArgs(
+            size=16, num_samples=200_000, epochs=50, batch_size=1024, lr=3e-4,
+        )
+        assert _artifact_name(args) == "sft-s16-n200k-e50-bs1024-lr3e-4-c48"
+
+    def test_artifact_name_asymmetric_channels(self):
+        """When chan1/2/3 differ, the suffix expands rather than collapsing
+        to a single c{N} — so a c32-64-64 run can't accidentally be filed
+        under the same artifact as a c48 run."""
+        args = SFTArgs(chan1=32, chan2=64, chan3=64)
+        assert _artifact_name(args) == "sft-s8-n50k-e30-bs512-lr1e-3-c32-64-64"
+
+    def test_artifact_name_stable_across_runs(self):
+        """Two SFTArgs with the same hyperparams must produce the same
+        artifact name (otherwise we lose version collapsing)."""
+        a = SFTArgs(seed=1)
+        b = SFTArgs(seed=999)  # seed isn't part of the artifact name
+        assert _artifact_name(a) == _artifact_name(b)


### PR DESCRIPTION
## Summary

- **Upload SFT checkpoints to W&B** so a Mac can grab a trained model with `wandb artifact get` without rummaging through the (ephemeral) RunPod filesystem. Artifact names encode the training config (`sft-s8-n50k-e30-bs512-lr1e-3-c48`) so identical configs collapse into versions while config-changing runs become separate artifacts.
- **Show what the model is thinking** in `scripts/factory_builder.py`: every empty tile with `p(tile) > 0.01` renders a ghost overlay of the entity/direction/item/misc the model would place there, opacity scaled to the tile probability. The argmax tile gets a dark-blue inset border. Side panel shows top-p=0.95 distributions per head (`tile`, `entity`, `direction`, `item`, `misc`).
- **Swap models from the UI**: source selector (local path or W&B run id) + Load button. Wandb downloads land in `/tmp/factorion-checkpoints/<run-id>/`. The agent cache is invalidated on swap, so the next prediction uses the new weights.
- **Fix `requirements.txt` resolution**: `jinja2==3.1.4` was incompatible with `runpod==1.8.1`'s transitive `fastapi[all]>=0.94.0`. Bumped to `jinja2==3.1.5` (security patch); now `uv pip install -r requirements.txt` resolves cleanly and fresh worktrees don't silently miss `runpod`.
- **Tests**: 34 new tests covering the artifact-name helpers, top-p extraction, build_world, checkpoint loading + agent-cache invalidation, swap-model error paths, and the full `/predict` response schema. Caught a real bug in `_humanize_count(1_000_000)` returning `"1.0mm"`.

## Test plan

- [x] `uv run ruff check .` clean
- [x] `WANDB_MODE=disabled WANDB_DISABLED=true uv run python -m pytest tests/ -v` — 2975 pass, 149 skip, 0 fail (incl. all 34 new tests)
- [x] `uv pip install -r requirements.txt` resolves without conflict
- [x] Launch `uv run python scripts/factory_builder.py --checkpoint <local.pt>`, observe ghost overlays + dark-blue border on argmax tile
- [x] In-UI swap to a different local checkpoint → prediction updates
- [ ] In-UI swap via W&B run id → downloads + loads (needs a `--track`-trained run on the user's W&B account)
- [ ] Train via `uv run python sft.py --track ...` and confirm a `sft-sN-nNk-...` artifact appears in W&B

🤖 Generated with [Claude Code](https://claude.com/claude-code)