### PR TITLE
Bump SFT smoketest: 300k samples, 11x11 grid, 4h watchdog

### DIFF
--- a/scripts/ci/sft_smoke_test.sh
+++ b/scripts/ci/sft_smoke_test.sh
@@ -20,7 +20,7 @@
 
 set -euo pipefail
 
-NUM_SAMPLES="${NUM_SAMPLES:-100000}"
+NUM_SAMPLES="${NUM_SAMPLES:-300000}"
 EPOCHS="${EPOCHS:-30}"
 WANDB_PROJECT="${WANDB_PROJECT:-factorion}"
 PR_NUMBER="${PR_NUMBER:-unknown}"
@@ -38,11 +38,11 @@ echo "  PR:              ${PR_NUMBER}"
 echo "  Commit:          ${COMMIT_SHA}"
 echo "============================================"
 
-# ── Safety net: self-terminate after 2 hours if cleanup fails ─────
+# ── Safety net: self-terminate after 4 hours if cleanup fails ─────
 if [ -n "${RUNPOD_POD_ID:-}" ] && [ -n "${RUNPOD_API_KEY:-}" ]; then
-    echo ">>> Starting self-terminate watchdog (2h timeout)..."
+    echo ">>> Starting self-terminate watchdog (4h timeout)..."
     nohup bash -c "
-      sleep 7200
+      sleep 14400
       curl -s 'https://api.runpod.io/graphql?api_key=${RUNPOD_API_KEY}' \
         -H 'Content-Type: application/json' \
         -d '{\"query\": \"mutation { podTerminate(input: {podId: \\\"${RUNPOD_POD_ID}\\\"}) }\"}'
@@ -77,7 +77,7 @@ echo ">>> Starting SFT smoke test (${NUM_SAMPLES} samples, ${EPOCHS} epochs)..."
 
 python sft.py \
     --seed 1 \
-    --size 8 \
+    --size 11 \
     --num-samples "$NUM_SAMPLES" \
     --epochs "$EPOCHS" \
     --track \


### PR DESCRIPTION
## Summary
- Bumps default `NUM_SAMPLES` 100k → 300k for the SFT smoketest (3x training data).
- Bumps grid size 8 → 11 to match the larger factories we want the SFT prior to cover.
- Extends the self-terminate watchdog 2h → 4h so the longer run doesn't get killed mid-training.

## Test plan
- [ ] Trigger the SFT smoketest on this PR (label `sft-smoketest`) and confirm it finishes within the new 4h watchdog window.
- [ ] Check W&B run: `val/acc` and per-kind val_acc should at least match — ideally improve over — the 100k/8x8 baseline.
- [ ] Confirm the SFT checkpoint artifact is uploaded with the expected (size=11) shape.

Note: SFT checkpoints are shape-specific — an 11x11 checkpoint won't be loadable into an 8x8 PPO run via `--start_from`. Anything downstream that still assumes 8x8 needs bumping in lockstep.

Related: #101 (LR warmup + cosine decay — separate experiment to try next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)