### PR TITLE
Add binary EOT head to AgentCNN + train it during SFT

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -802,6 +802,20 @@ class AgentCNN(nn.Module):
             layer_init(nn.Linear(flat_dim, 1), std=1.0)
         )
 
+        # Binary end-of-turn head. Predicts whether the factory is complete
+        # (1) or still has placements left (0). At rollout time the caller
+        # samples this and stops the episode when it crosses a threshold —
+        # gives the policy an explicit way to say "I'm done" without
+        # overloading the placement action. Named `eot_head` (not
+        # `done_head`) to avoid colliding with PPO's existing `done` /
+        # `dones_SE` / `next_done` episode-termination flags below. Bias
+        # init at -2 so an untrained model defaults to "not finished"
+        # (sigmoid(-2) ≈ 0.12).
+        self.eot_head = nn.Sequential(
+            nn.Flatten(),
+            layer_init(nn.Linear(flat_dim, 1), std=1.0, bias_const=-2.0),
+        )
+
         # Tile selection: 1x1 conv producing one logit per spatial position
         self.tile_logits = layer_init(nn.Conv2d(chan3, 1, kernel_size=1), std=tile_head_std)
 
@@ -831,6 +845,22 @@ class AgentCNN(nn.Module):
         value_B = self.critic_head(encoded).squeeze(-1)
         self.time_for_get_value = time.time() - t0
         return value_B
+
+    def eot_prob(self, x_BCWH):
+        """End-of-turn probability per observation, in [0, 1].
+
+        Kept off the `get_action_and_value` return tuple so the ~20 PPO /
+        test callsites unpacking that 4-tuple don't have to change. Use
+        this from inference rollouts to decide whether the agent thinks
+        the factory is finished.
+        """
+        encoded = self.encoder(x_BCWH)
+        return torch.sigmoid(self.eot_head(encoded).squeeze(-1))
+
+    def eot_should_stop(self, x_BCWH, threshold: float = 0.5):
+        """Boolean stop signal per observation. Threshold defaults to 0.5;
+        lower it if the model rambles, raise it if it stops short."""
+        return self.eot_prob(x_BCWH) > threshold
 
     def get_action_and_value(self, x_BCWH, action=None):
         t0 = time.time()

--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -296,17 +296,35 @@ def _get_agent(size: int) -> AgentCNN:
         agent = AgentCNN(envs, chan1=chan1, chan2=chan2, chan3=chan3)
     finally:
         envs.close()
-    # critic_head's flat dim depends on W*H, so its saved weights are
-    # the wrong shape whenever the UI grid size != the training size.
-    # Drop those entries before loading; we never call the critic during
-    # inference. strict=False would *not* save us here — it ignores
-    # missing/unexpected keys but still raises on shape mismatches.
+    # critic_head and eot_head are both Linear(flat_dim, 1) where
+    # flat_dim = chan3 * W * H, so their saved weights are the wrong
+    # shape whenever the UI grid size != the training size. strict=False
+    # would *not* save us here — it ignores missing/unexpected keys but
+    # still raises on shape mismatches, so we filter explicitly.
+    #
+    # critic_head: always dropped (the critic isn't called during
+    # inference, so loading it is wasted work even on a size match).
+    #
+    # eot_head: dropped on size mismatch (random init is fine because
+    # the UI doesn't act on the eot signal), kept on size match so the
+    # UI's eot panel shows the real trained prediction. Pre-#103
+    # checkpoints have no eot_head keys at all → load_state_dict
+    # (strict=False) leaves the freshly-initialised head in place.
+    expected_flat = chan3 * size * size
+    saved_eot_w = _CHECKPOINT_STATE.get("eot_head.1.weight")
+    keep_eot = saved_eot_w is not None and saved_eot_w.shape[1] == expected_flat
+    drop_prefixes: tuple[str, ...] = ("critic_head.",)
+    if not keep_eot:
+        drop_prefixes = drop_prefixes + ("eot_head.",)
     filtered = {
         k: v for k, v in _CHECKPOINT_STATE.items()
-        if not k.startswith("critic_head.")
+        if not k.startswith(drop_prefixes)
     }
     missing, unexpected = agent.load_state_dict(filtered, strict=False)
-    ignorable = {"critic_head.1.weight", "critic_head.1.bias"}
+    ignorable = {
+        "critic_head.1.weight", "critic_head.1.bias",
+        "eot_head.1.weight", "eot_head.1.bias",
+    }
     real_missing = [k for k in missing if k not in ignorable]
     real_unexpected = [k for k in unexpected if k not in ignorable]
     if real_missing or real_unexpected:
@@ -380,6 +398,10 @@ def _predict(grid: list[list[dict]]) -> dict:
 
     with torch.no_grad():
         encoded_BCWH = agent.encoder(obs_CWH)
+        # End-of-turn probability — sigmoid of the eot head's single
+        # logit. Surfaced in the side panel so the user can see when
+        # the model thinks the factory is finished.
+        eot_prob = float(torch.sigmoid(agent.eot_head(encoded_BCWH).squeeze(-1)).item())
         tile_logits = agent.tile_logits(encoded_BCWH).reshape(1, -1)
         tile_probs = F.softmax(tile_logits, dim=-1)[0]
         tile_top, tile_rest = _tile_top_p(tile_probs, H)
@@ -435,6 +457,7 @@ def _predict(grid: list[list[dict]]) -> dict:
         "misc_top": misc_top,
         "misc_rest": misc_rest,
         "candidates": candidates,
+        "eot_prob": eot_prob,
     }
 
 
@@ -970,7 +993,14 @@ async function computePrediction() {{
       // Each line: "head:   cand1 (p1), cand2 (p2), ..., rest (R)".
       // The <pre> uses white-space:pre + overflow-x:auto so long top-p
       // lines scroll horizontally instead of wrapping.
+      // EOT line: model's "I'm done" probability. The {{stop}} /
+      // {{continue}} marker matches the >0.5 default threshold in
+      // agent.eot_should_stop — a quick read for whether the model
+      // would terminate an inference rollout right now.
+      const eotPct = fmtPct(data.eot_prob);
+      const eotMark = data.eot_prob > 0.5 ? '[stop]' : '[continue]';
       const lines = [
+        '  eot:       ' + eotPct + ' ' + eotMark,
         '  tile:      ' + fmtTopTile(data.tile_top, data.tile_rest),
         '  entity:    ' + fmtTopNamed(data.entity_top, data.entity_rest),
         '  direction: ' + fmtTopNamed(data.direction_top, data.direction_rest),

--- a/sft.py
+++ b/sft.py
@@ -49,10 +49,11 @@ def extract_expert_actions(solved_CWH, task_CWH):
     """Extract (state, action) pairs by diffing solved vs task worlds.
 
     Returns list of (state_CWH, tile_idx, entity_id, direction_id, item_id,
-    misc_id, valid_tile_mask) tuples. The agent's action covers all four
-    placement channels because the env (ppo.py FactorioEnv.step) rejects
-    placements with mismatched channels — e.g. an underground belt without
-    misc=DOWN/UP, or an assembling_machine_1 without an item (= recipe).
+    misc_id, valid_tile_mask, eot) tuples. The agent's action covers all
+    four placement channels because the env (ppo.py FactorioEnv.step)
+    rejects placements with mismatched channels — e.g. an underground belt
+    without misc=DOWN/UP, or an assembling_machine_1 without an item
+    (= recipe).
 
     The valid_tile_mask is a flat binary tensor marking ALL tiles that still
     need entities at this step — not just the one chosen. This allows
@@ -65,6 +66,12 @@ def extract_expert_actions(solved_CWH, task_CWH):
 
     Actions are applied sequentially in random order, so intermediate states
     reflect realistic observations the agent would see.
+
+    `eot` (end-of-turn) is 0 for every placement step (the factory still
+    has entities to place) and 1 for a single terminal pair appended at
+    the end (state is the fully-solved factory). Placement targets on the
+    terminal pair are sentinel zeros — the SFT loop masks placement losses
+    on eot=1 samples.
     """
     C, W, H = solved_CWH.shape
     solved_ent = solved_CWH[Channel.ENTITIES.value]
@@ -122,7 +129,7 @@ def extract_expert_actions(solved_CWH, task_CWH):
         item_id = int(solved_CWH[Channel.ITEMS.value, x, y])
         misc_id = int(solved_CWH[Channel.MISC.value, x, y])
 
-        pairs.append((obs, tile_idx, entity_id, direction_id, item_id, misc_id, valid_mask))
+        pairs.append((obs, tile_idx, entity_id, direction_id, item_id, misc_id, valid_mask, 0))
 
         # Apply action: copy the entity's full footprint from solved, not
         # just the anchor cell, so the observation reflects what placing
@@ -136,6 +143,15 @@ def extract_expert_actions(solved_CWH, task_CWH):
         for tx, ty in tiles_to_apply:
             for ch in range(C):
                 state[ch, tx, ty] = solved_CWH[ch, tx, ty]
+
+    # Terminal pair: every placement has been applied, so `state` now equals
+    # `solved_CWH`. Emit a sample with eot=1 and sentinel zeros for
+    # placement targets; the SFT loop's placement_mask zeroes out the
+    # placement losses for this sample. valid_mask=all-zero matches the
+    # invariant "no remaining tiles to place".
+    terminal_obs = state.clone()
+    terminal_valid_mask = torch.zeros(W * H)
+    pairs.append((terminal_obs, 0, 0, 0, 0, 0, terminal_valid_mask, 1))
 
     return pairs
 
@@ -206,6 +222,7 @@ def generate_dataset(args: SFTArgs):
     all_item = []
     all_misc = []
     all_valid_masks = []
+    all_eot = []
     all_lesson_seeds = []
     all_lesson_kinds = []
     kind_samples = {k.name: 0 for k in kinds}
@@ -242,7 +259,7 @@ def generate_dataset(args: SFTArgs):
 
         kind_lessons[kind.name] += 1
         pairs = extract_expert_actions(solved, task)
-        for obs, tile_idx, entity_id, direction_id, item_id, misc_id, valid_mask in pairs:
+        for obs, tile_idx, entity_id, direction_id, item_id, misc_id, valid_mask, eot in pairs:
             all_obs.append(obs)
             all_tile_idx.append(tile_idx)
             all_entity.append(entity_id)
@@ -250,6 +267,7 @@ def generate_dataset(args: SFTArgs):
             all_item.append(item_id)
             all_misc.append(misc_id)
             all_valid_masks.append(valid_mask)
+            all_eot.append(eot)
             all_lesson_seeds.append(seed)
             all_lesson_kinds.append(kind.value)
             kind_samples[kind.name] += 1
@@ -269,12 +287,14 @@ def generate_dataset(args: SFTArgs):
     item_tensor = torch.tensor(all_item, dtype=torch.long)
     misc_tensor = torch.tensor(all_misc, dtype=torch.long)
     mask_tensor = torch.stack(all_valid_masks)
+    eot_tensor = torch.tensor(all_eot, dtype=torch.float)
     seed_tensor = torch.tensor(all_lesson_seeds, dtype=torch.long)
     kind_tensor = torch.tensor(all_lesson_kinds, dtype=torch.long)
 
     return (
         obs_tensor, tile_tensor, ent_tensor, dir_tensor,
-        item_tensor, misc_tensor, mask_tensor, seed_tensor, kind_tensor,
+        item_tensor, misc_tensor, mask_tensor, eot_tensor,
+        seed_tensor, kind_tensor,
     )
 
 
@@ -288,7 +308,7 @@ def train_sft(args: SFTArgs):
     t0 = time.time()
     (
         obs, tiles, ents, dirs, items_t, miscs_t,
-        valid_masks, lesson_seeds, lesson_kinds,
+        valid_masks, eot_labels, lesson_seeds, lesson_kinds,
     ) = generate_dataset(args)
     print(f"Generated {len(obs)} samples in {time.time() - t0:.1f}s")
 
@@ -318,12 +338,12 @@ def train_sft(args: SFTArgs):
     train_ds = TensorDataset(
         obs[train_idx], tiles[train_idx], ents[train_idx], dirs[train_idx],
         items_t[train_idx], miscs_t[train_idx], valid_masks[train_idx],
-        lesson_kinds[train_idx],
+        eot_labels[train_idx], lesson_kinds[train_idx],
     )
     val_ds = TensorDataset(
         obs[val_idx], tiles[val_idx], ents[val_idx], dirs[val_idx],
         items_t[val_idx], miscs_t[val_idx], valid_masks[val_idx],
-        lesson_kinds[val_idx],
+        eot_labels[val_idx], lesson_kinds[val_idx],
     )
     train_loader = DataLoader(train_ds, batch_size=args.batch_size, shuffle=True)
     val_loader = DataLoader(val_ds, batch_size=args.batch_size)
@@ -352,12 +372,22 @@ def train_sft(args: SFTArgs):
     agent.to(device)
 
     optimizer = optim.Adam(agent.parameters(), lr=args.lr)
-    ce_loss = nn.CrossEntropyLoss()
-    bce_loss = nn.BCEWithLogitsLoss()
-    # Per-sample variants used in the val loop so per-LessonKind losses can
-    # be aggregated without re-running the forward pass.
+    # All losses use reduction="none" so we can (a) mask placement losses
+    # off on terminal (eot=1) samples and (b) aggregate per-LessonKind in
+    # the val loop without re-running the forward pass.
     ce_loss_none = nn.CrossEntropyLoss(reduction="none")
     bce_loss_none = nn.BCEWithLogitsLoss(reduction="none")
+    # pos_weight balances the eot head against the placement-step
+    # imbalance. Each lesson emits ~max_level placement pairs (eot=0) and
+    # exactly 1 terminal pair (eot=1); without pos_weight the head
+    # collapses to always-predict-not-finished.
+    train_eot = eot_labels[train_idx]
+    n_pos = float(train_eot.sum().item())
+    n_neg = float(len(train_eot) - n_pos)
+    pos_weight = torch.tensor([n_neg / max(1.0, n_pos)])
+    bce_eot = nn.BCEWithLogitsLoss(pos_weight=pos_weight.to(device))
+    bce_eot_none = nn.BCEWithLogitsLoss(pos_weight=pos_weight.to(device), reduction="none")
+    print(f"EOT head pos_weight={pos_weight.item():.2f} (n_pos={int(n_pos)}, n_neg={int(n_neg)})")
 
     # Map kind value -> name so per-kind dict keys read as "MOVE_ONE_ITEM"
     # instead of "0" both in print() lines and in wandb panel titles.
@@ -394,6 +424,8 @@ def train_sft(args: SFTArgs):
     val_dir_acc = 0.0
     val_item_acc = 0.0
     val_misc_acc = 0.0
+    val_eot_acc = 0.0
+    val_eot_pos_recall = 0.0
     print(f"Training for {args.epochs} epochs on {device}...")
 
     for epoch in range(1, args.epochs + 1):
@@ -404,15 +436,18 @@ def train_sft(args: SFTArgs):
         train_loss_dir = 0.0
         train_loss_item = 0.0
         train_loss_misc = 0.0
+        train_loss_eot = 0.0
         train_correct = 0
         train_total = 0
+        train_eot_correct = 0
+        train_place_total = 0
 
         # batch_kind is carried through the loader so val can aggregate
         # per-kind metrics; we ignore it in the train pass.
         for batch in train_loader:
             (
                 batch_obs, batch_tile, batch_ent, batch_dir,
-                batch_item, batch_misc, batch_mask, _batch_kind,
+                batch_item, batch_misc, batch_mask, batch_eot, _batch_kind,
             ) = batch
             batch_obs = batch_obs.float().to(device)
             batch_tile = batch_tile.to(device)
@@ -421,14 +456,27 @@ def train_sft(args: SFTArgs):
             batch_item = batch_item.to(device)
             batch_misc = batch_misc.to(device)
             batch_mask = batch_mask.to(device)
+            batch_eot = batch_eot.to(device)
 
             encoded = agent.encoder(batch_obs)
             B = encoded.shape[0]
+            # Placement loss is only meaningful for non-terminal samples;
+            # eot=1 samples carry sentinel placement targets. Normalise by
+            # the placement-sample count so the loss scale is independent
+            # of the per-batch mix of terminal / placement samples.
+            placement_mask = (batch_eot < 0.5).float()
+            n_place = placement_mask.sum().clamp(min=1.0)
+
+            # EOT head — BCE on every sample, balanced by pos_weight.
+            eot_logits = agent.eot_head(encoded).squeeze(-1)
+            loss_eot = bce_eot(eot_logits, batch_eot)
 
             # Tile logits — use BCE with multi-label mask so ALL valid
-            # tiles are rewarded, not just the randomly-chosen one
+            # tiles are rewarded, not just the randomly-chosen one. Reduce
+            # to per-sample, mask off terminal samples, then average.
             tile_logits = agent.tile_logits(encoded).reshape(B, -1)
-            loss_tile = bce_loss(tile_logits, batch_mask)
+            loss_tile_per = bce_loss_none(tile_logits, batch_mask).mean(dim=1)
+            loss_tile = (loss_tile_per * placement_mask).sum() / n_place
 
             # Extract features at target tile for entity/direction/item/misc heads
             x_B = batch_tile // agent.height
@@ -440,12 +488,16 @@ def train_sft(args: SFTArgs):
             dir_logits = agent.dir_head(tile_features)
             item_logits = agent.item_head(tile_features)
             misc_logits = agent.misc_head(tile_features)
-            loss_ent = ce_loss(ent_logits, batch_ent)
-            loss_dir = ce_loss(dir_logits, batch_dir)
-            loss_item = ce_loss(item_logits, batch_item)
-            loss_misc = ce_loss(misc_logits, batch_misc)
+            loss_ent_per = ce_loss_none(ent_logits, batch_ent)
+            loss_dir_per = ce_loss_none(dir_logits, batch_dir)
+            loss_item_per = ce_loss_none(item_logits, batch_item)
+            loss_misc_per = ce_loss_none(misc_logits, batch_misc)
+            loss_ent = (loss_ent_per * placement_mask).sum() / n_place
+            loss_dir = (loss_dir_per * placement_mask).sum() / n_place
+            loss_item = (loss_item_per * placement_mask).sum() / n_place
+            loss_misc = (loss_misc_per * placement_mask).sum() / n_place
 
-            loss = loss_tile + loss_ent + loss_dir + loss_item + loss_misc
+            loss = loss_tile + loss_ent + loss_dir + loss_item + loss_misc + loss_eot
 
             optimizer.zero_grad()
             loss.backward()
@@ -457,7 +509,10 @@ def train_sft(args: SFTArgs):
             train_loss_dir += loss_dir.item() * B
             train_loss_item += loss_item.item() * B
             train_loss_misc += loss_misc.item() * B
-            # Whole-action accuracy: every action component correct.
+            train_loss_eot += loss_eot.item() * B
+            # Whole-action accuracy: every action component correct, on
+            # placement samples only (terminal samples have no canonical
+            # placement target).
             pred_tile = tile_logits.argmax(dim=1)
             tile_hit = batch_mask[batch_idx, pred_tile] > 0
             pred_ent = ent_logits.argmax(dim=1)
@@ -471,8 +526,13 @@ def train_sft(args: SFTArgs):
                 & (pred_item == batch_item)
                 & (pred_misc == batch_misc)
             )
-            train_correct += correct.sum().item()
+            is_place = placement_mask.bool()
+            train_correct += correct[is_place].sum().item()
+            train_place_total += int(is_place.sum().item())
             train_total += B
+            # EOT head accuracy at threshold 0.5.
+            eot_pred = (eot_logits > 0).float()
+            train_eot_correct += int((eot_pred == batch_eot).sum().item())
 
         train_loss /= train_total
         train_loss_tile /= train_total
@@ -480,7 +540,9 @@ def train_sft(args: SFTArgs):
         train_loss_dir /= train_total
         train_loss_item /= train_total
         train_loss_misc /= train_total
-        train_acc = train_correct / train_total
+        train_loss_eot /= train_total
+        train_acc = train_correct / max(1, train_place_total)
+        train_eot_acc = train_eot_correct / train_total
 
         # Validation
         agent.eval()
@@ -490,13 +552,18 @@ def train_sft(args: SFTArgs):
         val_loss_dir = 0.0
         val_loss_item = 0.0
         val_loss_misc = 0.0
+        val_loss_eot = 0.0
         val_correct = 0
         val_tile_correct = 0
         val_ent_correct = 0
         val_dir_correct = 0
         val_item_correct = 0
         val_misc_correct = 0
+        val_eot_correct = 0
+        val_eot_pos_correct = 0
+        val_eot_pos_total = 0
         val_total = 0
+        val_place_total = 0
 
         # Per-LessonKind accumulators. Indexed by kind name to make wandb
         # panel keys read as "val/MOVE_ONE_ITEM/acc" rather than enum ints.
@@ -513,7 +580,7 @@ def train_sft(args: SFTArgs):
             for batch in val_loader:
                 (
                     batch_obs, batch_tile, batch_ent, batch_dir,
-                    batch_item, batch_misc, batch_mask, batch_kind,
+                    batch_item, batch_misc, batch_mask, batch_eot, batch_kind,
                 ) = batch
                 batch_obs = batch_obs.float().to(device)
                 batch_tile = batch_tile.to(device)
@@ -522,17 +589,24 @@ def train_sft(args: SFTArgs):
                 batch_item = batch_item.to(device)
                 batch_misc = batch_misc.to(device)
                 batch_mask = batch_mask.to(device)
+                batch_eot = batch_eot.to(device)
                 batch_kind = batch_kind.to(device)
 
                 encoded = agent.encoder(batch_obs)
                 B = encoded.shape[0]
+                placement_mask = (batch_eot < 0.5).float()
+                is_place = placement_mask.bool()
+
+                eot_logits = agent.eot_head(encoded).squeeze(-1)
+                loss_eot_per = bce_eot_none(eot_logits, batch_eot)
 
                 tile_logits = agent.tile_logits(encoded).reshape(B, -1)
                 # Per-sample losses: needed so we can sum them within each
-                # LessonKind. mean over the tile axis matches the scale of
-                # bce_loss(reduction="mean"), keeping val/loss_tile
-                # comparable to train/loss_tile.
-                loss_tile_per = bce_loss_none(tile_logits, batch_mask).mean(dim=1)
+                # LessonKind and so terminal samples can be masked out of
+                # placement losses. mean over the tile axis matches the
+                # scale of bce_loss(reduction="mean"), keeping
+                # val/loss_tile comparable to train/loss_tile.
+                loss_tile_per = bce_loss_none(tile_logits, batch_mask).mean(dim=1) * placement_mask
 
                 x_B = batch_tile // agent.height
                 y_B = batch_tile % agent.height
@@ -543,14 +617,14 @@ def train_sft(args: SFTArgs):
                 dir_logits = agent.dir_head(tile_features)
                 item_logits = agent.item_head(tile_features)
                 misc_logits = agent.misc_head(tile_features)
-                loss_ent_per = ce_loss_none(ent_logits, batch_ent)
-                loss_dir_per = ce_loss_none(dir_logits, batch_dir)
-                loss_item_per = ce_loss_none(item_logits, batch_item)
-                loss_misc_per = ce_loss_none(misc_logits, batch_misc)
+                loss_ent_per = ce_loss_none(ent_logits, batch_ent) * placement_mask
+                loss_dir_per = ce_loss_none(dir_logits, batch_dir) * placement_mask
+                loss_item_per = ce_loss_none(item_logits, batch_item) * placement_mask
+                loss_misc_per = ce_loss_none(misc_logits, batch_misc) * placement_mask
 
                 loss_per_sample = (
                     loss_tile_per + loss_ent_per + loss_dir_per
-                    + loss_item_per + loss_misc_per
+                    + loss_item_per + loss_misc_per + loss_eot_per
                 )
                 val_loss += loss_per_sample.sum().item()
                 val_loss_tile += loss_tile_per.sum().item()
@@ -558,6 +632,7 @@ def train_sft(args: SFTArgs):
                 val_loss_dir += loss_dir_per.sum().item()
                 val_loss_item += loss_item_per.sum().item()
                 val_loss_misc += loss_misc_per.sum().item()
+                val_loss_eot += loss_eot_per.sum().item()
 
                 pred_tile = tile_logits.argmax(dim=1)
                 tile_hit = batch_mask[batch_idx, pred_tile] > 0
@@ -573,20 +648,35 @@ def train_sft(args: SFTArgs):
                     tile_hit & ent_correct_per & dir_correct_per
                     & item_correct_per & misc_correct_per
                 )
-                val_correct += correct_per.sum().item()
-                val_tile_correct += tile_hit.sum().item()
-                val_ent_correct += ent_correct_per.sum().item()
-                val_dir_correct += dir_correct_per.sum().item()
-                val_item_correct += item_correct_per.sum().item()
-                val_misc_correct += misc_correct_per.sum().item()
+                val_correct += correct_per[is_place].sum().item()
+                val_tile_correct += tile_hit[is_place].sum().item()
+                val_ent_correct += ent_correct_per[is_place].sum().item()
+                val_dir_correct += dir_correct_per[is_place].sum().item()
+                val_item_correct += item_correct_per[is_place].sum().item()
+                val_misc_correct += misc_correct_per[is_place].sum().item()
                 val_total += B
+                val_place_total += int(is_place.sum().item())
 
-                # Per-kind aggregation: one bool-mask per kind appearing in
-                # this batch. unique() keeps this O(num_kinds_in_batch) so
-                # adding new LessonKind enum values has no cost here.
+                # EOT-head accuracy + recall on positives separately.
+                # Recall on positives matters because the positives are
+                # rare; "always predict 0" would give high accuracy but
+                # never trigger episode termination.
+                eot_pred = (eot_logits > 0).float()
+                eot_correct = (eot_pred == batch_eot)
+                val_eot_correct += int(eot_correct.sum().item())
+                is_pos = batch_eot > 0.5
+                val_eot_pos_correct += int(eot_correct[is_pos].sum().item())
+                val_eot_pos_total += int(is_pos.sum().item())
+
+                # Per-kind aggregation: bucket placement metrics by kind on
+                # placement samples only (terminal samples carry no kind-
+                # specific placement signal; their eot loss is folded in
+                # via loss_per_sample). unique() keeps this
+                # O(num_kinds_in_batch) so adding new LessonKind enum
+                # values has no cost here.
                 for k_val in batch_kind.unique().tolist():
                     k_name = kind_names[k_val]
-                    mask_k = (batch_kind == k_val)
+                    mask_k = (batch_kind == k_val) & is_place
                     per_kind_n[k_name] += int(mask_k.sum().item())
                     per_kind_correct[k_name] += int(correct_per[mask_k].sum().item())
                     per_kind_tile_correct[k_name] += int(tile_hit[mask_k].sum().item())
@@ -596,18 +686,29 @@ def train_sft(args: SFTArgs):
                     per_kind_misc_correct[k_name] += int(misc_correct_per[mask_k].sum().item())
                     per_kind_loss_sum[k_name] += loss_per_sample[mask_k].sum().item()
 
+        # Placement losses were already masked off on terminal samples (their
+        # per-sample contribution is zero), so dividing by val_place_total
+        # gives the average over the placement subset. The eot loss spans
+        # every sample, so it's divided by val_total.
+        place_norm = max(1, val_place_total)
         val_loss /= val_total
-        val_loss_tile /= val_total
-        val_loss_ent /= val_total
-        val_loss_dir /= val_total
-        val_loss_item /= val_total
-        val_loss_misc /= val_total
-        val_acc = val_correct / val_total
-        val_tile_acc = val_tile_correct / val_total
-        val_ent_acc = val_ent_correct / val_total
-        val_dir_acc = val_dir_correct / val_total
-        val_item_acc = val_item_correct / val_total
-        val_misc_acc = val_misc_correct / val_total
+        val_loss_tile /= place_norm
+        val_loss_ent /= place_norm
+        val_loss_dir /= place_norm
+        val_loss_item /= place_norm
+        val_loss_misc /= place_norm
+        val_loss_eot /= val_total
+        val_acc = val_correct / place_norm
+        val_tile_acc = val_tile_correct / place_norm
+        val_ent_acc = val_ent_correct / place_norm
+        val_dir_acc = val_dir_correct / place_norm
+        val_item_acc = val_item_correct / place_norm
+        val_misc_acc = val_misc_correct / place_norm
+        val_eot_acc = val_eot_correct / val_total
+        val_eot_pos_recall = (
+            val_eot_pos_correct / val_eot_pos_total
+            if val_eot_pos_total > 0 else 0.0
+        )
 
         # Build per-kind metric dict for both stdout and wandb. Skip kinds
         # absent from the val split (e.g. small datasets where some kinds
@@ -628,10 +729,12 @@ def train_sft(args: SFTArgs):
 
         print(
             f"Epoch {epoch:3d}/{args.epochs} | "
-            f"train_loss={train_loss:.4f} train_acc={train_acc:.3f} | "
+            f"train_loss={train_loss:.4f} train_acc={train_acc:.3f} "
+            f"train_eot_acc={train_eot_acc:.3f} | "
             f"val_loss={val_loss:.4f} val_acc={val_acc:.3f} "
             f"(tile={val_tile_acc:.3f} ent={val_ent_acc:.3f} dir={val_dir_acc:.3f} "
-            f"item={val_item_acc:.3f} misc={val_misc_acc:.3f})"
+            f"item={val_item_acc:.3f} misc={val_misc_acc:.3f} "
+            f"eot={val_eot_acc:.3f} eot+={val_eot_pos_recall:.3f})"
         )
         if per_kind_metrics:
             kind_summary = "  ".join(
@@ -649,19 +752,24 @@ def train_sft(args: SFTArgs):
                 "train/loss_dir": train_loss_dir,
                 "train/loss_item": train_loss_item,
                 "train/loss_misc": train_loss_misc,
+                "train/loss_eot": train_loss_eot,
                 "train/acc": train_acc,
+                "train/eot_acc": train_eot_acc,
                 "val/loss": val_loss,
                 "val/loss_tile": val_loss_tile,
                 "val/loss_ent": val_loss_ent,
                 "val/loss_dir": val_loss_dir,
                 "val/loss_item": val_loss_item,
                 "val/loss_misc": val_loss_misc,
+                "val/loss_eot": val_loss_eot,
                 "val/acc": val_acc,
                 "val/tile_acc": val_tile_acc,
                 "val/ent_acc": val_ent_acc,
                 "val/dir_acc": val_dir_acc,
                 "val/item_acc": val_item_acc,
                 "val/misc_acc": val_misc_acc,
+                "val/eot_acc": val_eot_acc,
+                "val/eot_pos_recall": val_eot_pos_recall,
                 "train/epoch": epoch,
                 **per_kind_metrics,
             })
@@ -683,6 +791,8 @@ def train_sft(args: SFTArgs):
         "val_dir_acc": round(val_dir_acc, 4),
         "val_item_acc": round(val_item_acc, 4),
         "val_misc_acc": round(val_misc_acc, 4),
+        "val_eot_acc": round(val_eot_acc, 4),
+        "val_eot_pos_recall": round(val_eot_pos_recall, 4),
         "val_loss": round(val_loss, 4),
         "num_samples": args.num_samples,
         "epochs": args.epochs,

--- a/tests/test_factory_builder.py
+++ b/tests/test_factory_builder.py
@@ -261,6 +261,45 @@ class TestPredictSchema:
         finally:
             path.unlink(missing_ok=True)
 
+    def test_predict_returns_eot_prob(self):
+        """_predict must surface `eot_prob` in [0, 1] so the UI can show
+        the model's "I'm done" probability."""
+        path = _make_tiny_checkpoint(size=4, chan=8)
+        try:
+            fb._load_checkpoint(str(path))
+            result = fb._predict(_empty_grid(4))
+            assert "eot_prob" in result
+            assert isinstance(result["eot_prob"], float)
+            assert 0.0 <= result["eot_prob"] <= 1.0
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_eot_head_loaded_on_size_match_dropped_on_mismatch(self):
+        """When the UI grid size matches the checkpoint size, the trained
+        eot_head weights must be loaded. When they differ, the head is
+        dropped (random-init) so cross-size loading doesn't crash on the
+        flat_dim shape mismatch."""
+        path = _make_tiny_checkpoint(size=4, chan=8)
+        try:
+            fb._load_checkpoint(str(path))
+            saved_w = fb._CHECKPOINT_STATE["eot_head.1.weight"]
+
+            # Size match → eot_head should match the checkpoint exactly.
+            # _get_agent moves the model to _AGENT_DEVICE (mps/cuda on
+            # local, cpu on CI); pull weights back to cpu for comparison.
+            agent4 = fb._get_agent(4)
+            assert torch.equal(agent4.eot_head[1].weight.cpu(), saved_w.cpu()), (
+                "eot_head must load when UI size == checkpoint size; "
+                "otherwise the UI shows a random-init eot prediction"
+            )
+
+            # Size mismatch → eot_head is the model's init, not the saved
+            # weights (and shapes differ so they can't be equal anyway).
+            agent6 = fb._get_agent(6)
+            assert agent6.eot_head[1].weight.shape != saved_w.shape
+        finally:
+            path.unlink(missing_ok=True)
+
     def test_predict_argmax_in_tile_top(self):
         """The argmax (x, y) must appear in tile_top[0] — the UI relies
         on this invariant when drawing the dark-blue border."""

--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -31,11 +31,14 @@ class TestExtractExpertActions:
         pairs = extract_expert_actions(solved, task)
         assert len(pairs) > 0, "Should have at least one action"
 
-        # Replay actions onto task world. The action carries all four
-        # placement channels (entity, direction, item, misc) — the agent
-        # is responsible for each.
+        # Replay placement actions onto task world. The action carries all
+        # four placement channels (entity, direction, item, misc) — the
+        # agent is responsible for each. Skip terminal pairs (eot=1) which
+        # carry sentinel placement targets, not real placements.
         state = task.clone()
-        for obs, tile_idx, entity_id, direction_id, item_id, misc_id, valid_mask in pairs:
+        for obs, tile_idx, entity_id, direction_id, item_id, misc_id, valid_mask, eot in pairs:
+            if eot == 1:
+                continue
             H = state.shape[2]
             x = tile_idx // H
             y = tile_idx % H
@@ -61,7 +64,8 @@ class TestExtractExpertActions:
         assert len(pairs) == 0
 
     def test_action_count_matches_missing(self):
-        """Number of actions should equal num_missing_entities."""
+        """Number of pairs should equal num_missing_entities placement
+        actions + 1 terminal (eot=1) pair."""
         for seed in [1, 7, 42]:
             solved, _ = generate_lesson(
                 size=5, kind=LessonKind.MOVE_ONE_ITEM, num_missing_entities=0, seed=seed,
@@ -72,9 +76,14 @@ class TestExtractExpertActions:
                 size=5, kind=LessonKind.MOVE_ONE_ITEM, num_missing_entities=2, seed=seed,
             )
             pairs = extract_expert_actions(solved, task)
-            assert len(pairs) == min_ent, (
-                f"seed={seed}: expected {min_ent} actions, got {len(pairs)}"
+            assert len(pairs) == min_ent + 1, (
+                f"seed={seed}: expected {min_ent} placement pairs + 1 "
+                f"terminal pair, got {len(pairs)}"
             )
+            # Exactly one terminal pair, appended last.
+            eot_flags = [p[7] for p in pairs]
+            assert eot_flags[:-1] == [0] * min_ent
+            assert eot_flags[-1] == 1
 
     def test_intermediate_states_are_sequential(self):
         """Each observation should reflect previously applied actions."""
@@ -98,7 +107,9 @@ class TestExtractExpertActions:
         )
 
     def test_entity_ids_are_valid(self):
-        """All extracted entity IDs should be valid (non-empty) entity values."""
+        """All extracted placement entity IDs should be valid (non-empty)
+        entity values. Terminal pairs (eot=1) carry sentinel zeros and are
+        excluded from this check."""
         solved, _ = generate_lesson(
             size=5, kind=LessonKind.MOVE_ONE_ITEM, num_missing_entities=2, seed=42,
         )
@@ -106,7 +117,9 @@ class TestExtractExpertActions:
             size=5, kind=LessonKind.MOVE_ONE_ITEM, num_missing_entities=2, seed=42,
         )
         pairs = extract_expert_actions(solved, task)
-        for _, _, entity_id, direction_id, _, _, _ in pairs:
+        for _, _, entity_id, direction_id, _, _, _, eot in pairs:
+            if eot == 1:
+                continue
             assert entity_id != str2ent("empty").value, "Expert actions shouldn't place empty"
             assert direction_id != Direction.NONE.value, "Expert belt actions need a direction"
 
@@ -130,7 +143,9 @@ class TestExtractExpertActions:
                 )
             except Exception:
                 continue
-            for _, _, ent_id, _, _, misc_id, _ in extract_expert_actions(solved, task):
+            for _, _, ent_id, _, _, misc_id, _, eot in extract_expert_actions(solved, task):
+                if eot == 1:
+                    continue
                 if ent_id == ug_id:
                     assert misc_id != Misc.NONE.value, (
                         f"seed={seed}: UG belt action emitted with misc=NONE"
@@ -172,7 +187,7 @@ class TestGenerateDataset:
     def test_generates_correct_count(self):
         """Dataset should have the requested number of samples."""
         args = SFTArgs(seed=1, size=5, num_samples=100, max_level=2)
-        obs, tiles, ents, dirs, items_t, miscs_t, masks, seeds, kinds = generate_dataset(args)
+        obs, tiles, ents, dirs, items_t, miscs_t, masks, eots, seeds, kinds = generate_dataset(args)
         assert len(obs) == 100
         assert len(tiles) == 100
         assert len(ents) == 100
@@ -180,6 +195,7 @@ class TestGenerateDataset:
         assert len(items_t) == 100
         assert len(miscs_t) == 100
         assert len(masks) == 100
+        assert len(eots) == 100
         assert len(seeds) == 100
         assert len(kinds) == 100
 
@@ -363,7 +379,7 @@ class TestSFTLossConvergence:
     def test_loss_decreases_on_small_dataset(self, registered_env):
         """SFT loss should decrease when training on a small expert dataset."""
         args = SFTArgs(seed=42, size=5, num_samples=200, max_level=2)
-        obs, tiles, ents, dirs, items_t, miscs_t, masks, _, _ = generate_dataset(args)
+        obs, tiles, ents, dirs, items_t, miscs_t, masks, _eots, _, _ = generate_dataset(args)
 
         envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, 5, "test")])
         agent = AgentCNN(envs, chan1=16, chan2=16, chan3=16, flat_dim=64)
@@ -439,6 +455,134 @@ class TestTrainSFTEndToEnd:
         assert "best_val_acc" in s
         assert s["num_samples"] == 100
         assert s["epochs"] == 2
+
+
+class TestEotHead:
+    """Tests for the binary end-of-turn head."""
+
+    def test_eot_label_per_lesson(self):
+        """A lesson with N missing entities emits N placement pairs
+        (eot=0) followed by one terminal pair (eot=1) whose obs equals
+        the fully-solved factory."""
+        solved, _ = generate_lesson(
+            size=5, kind=LessonKind.MOVE_ONE_ITEM, num_missing_entities=0, seed=11,
+        )
+        task, min_ent = generate_lesson(
+            size=5, kind=LessonKind.MOVE_ONE_ITEM, num_missing_entities=3, seed=11,
+        )
+        pairs = extract_expert_actions(solved, task)
+        # eot flag is at index 7 in the tuple
+        eots = [p[7] for p in pairs]
+        assert sum(eots) == 1, f"Expected exactly one terminal pair, got {sum(eots)}"
+        assert eots[-1] == 1, "Terminal pair must come last"
+        # Terminal observation equals solved (entities + directions).
+        terminal_obs = pairs[-1][0]
+        assert torch.equal(
+            terminal_obs[Channel.ENTITIES.value], solved[Channel.ENTITIES.value]
+        )
+        assert torch.equal(
+            terminal_obs[Channel.DIRECTION.value], solved[Channel.DIRECTION.value]
+        )
+
+    def test_eot_tensor_in_dataset(self):
+        """generate_dataset must return a per-pair eot tensor with values
+        in {0.0, 1.0} and at least one positive (terminal) example."""
+        args = SFTArgs(seed=1, size=5, num_samples=200, max_level=4)
+        *_, eots, _seeds, _kinds = generate_dataset(args)
+        assert eots.dtype == torch.float
+        assert set(eots.unique().tolist()).issubset({0.0, 1.0})
+        assert eots.sum().item() >= 1, "Dataset must contain >=1 terminal pair"
+
+    def test_eot_head_exists_and_forwards(self, registered_env):
+        """AgentCNN must expose an eot_head producing a single logit per
+        observation."""
+        envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, 5, "test")])
+        agent = AgentCNN(envs, chan1=16, chan2=16, chan3=16, flat_dim=64)
+        envs.close()
+
+        assert hasattr(agent, "eot_head"), "AgentCNN must have an eot_head"
+        # Forward a fake batch through the encoder + eot_head.
+        B, C, W, H = 4, agent.channels, agent.width, agent.height
+        x = torch.zeros((B, C, W, H), dtype=torch.float32)
+        enc = agent.encoder(x)
+        logits = agent.eot_head(enc).squeeze(-1)
+        assert logits.shape == (B,), f"eot_head output should be (B,), got {logits.shape}"
+
+    def test_eot_prob_and_should_stop_shapes(self, registered_env):
+        """`eot_prob` returns a [0,1] tensor of shape (B,); `eot_should_stop`
+        returns a bool tensor of the same shape. These are the methods
+        inference rollouts call to decide 'I'm done here'."""
+        envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, 5, "test")])
+        agent = AgentCNN(envs, chan1=16, chan2=16, chan3=16, flat_dim=64)
+        envs.close()
+
+        B = 3
+        x = torch.zeros((B, agent.channels, agent.width, agent.height), dtype=torch.float32)
+        probs = agent.eot_prob(x)
+        assert probs.shape == (B,)
+        assert (probs >= 0).all() and (probs <= 1).all()
+
+        stop = agent.eot_should_stop(x, threshold=0.5)
+        assert stop.shape == (B,)
+        assert stop.dtype == torch.bool
+
+        # Threshold = 1.0 → never stop; threshold = 0.0 → always stop.
+        assert not agent.eot_should_stop(x, threshold=1.0).any()
+        assert agent.eot_should_stop(x, threshold=-0.01).all()
+
+    def test_eot_head_learns_terminal_vs_placement(self, registered_env, tmp_path):
+        """End-to-end: after a short SFT run the eot head should
+        distinguish terminal observations (solved factories) from
+        placement-step observations. This is the contract that lets the
+        rollout 'run until the model thinks it's done'."""
+        ckpt = str(tmp_path / "sft_eot.pt")
+        summary = str(tmp_path / "sft_eot_summary.json")
+        args = SFTArgs(
+            seed=3,
+            size=5,
+            num_samples=1000,
+            max_level=3,
+            epochs=20,
+            batch_size=64,
+            lr=3e-3,
+            chan1=16,
+            chan2=16,
+            chan3=16,
+            flat_dim=64,
+            checkpoint_path=ckpt,
+            summary_path=summary,
+        )
+        agent = train_sft(args)
+
+        # Build a fresh held-out set: solved (eot=1) and partial (eot=0)
+        # observations from a seed range that wasn't in training. Move
+        # inputs to the agent's device (which depends on what train_sft
+        # selected — CPU on CI, MPS/CUDA locally).
+        device = next(agent.parameters()).device
+        agent.eval()
+        pos_logits = []
+        neg_logits = []
+        with torch.no_grad():
+            for seed in range(10_000, 10_040):
+                solved, _ = generate_lesson(
+                    size=5, kind=LessonKind.MOVE_ONE_ITEM,
+                    num_missing_entities=0, seed=seed,
+                )
+                task, _ = generate_lesson(
+                    size=5, kind=LessonKind.MOVE_ONE_ITEM,
+                    num_missing_entities=3, seed=seed,
+                )
+                enc_pos = agent.encoder(solved.unsqueeze(0).float().to(device))
+                enc_neg = agent.encoder(task.unsqueeze(0).float().to(device))
+                pos_logits.append(agent.eot_head(enc_pos).item())
+                neg_logits.append(agent.eot_head(enc_neg).item())
+
+        pos_mean = sum(pos_logits) / len(pos_logits)
+        neg_mean = sum(neg_logits) / len(neg_logits)
+        assert pos_mean > neg_mean, (
+            f"EOT head failed to separate terminal/placement: "
+            f"pos_mean={pos_mean:.3f} <= neg_mean={neg_mean:.3f}"
+        )
 
 
 class TestTrainValSeedSplit:


### PR DESCRIPTION
## Summary

- New `eot_head` on `AgentCNN` (binary sigmoid logit off the encoder's flat output) so the policy has an explicit "I'm done here" output. Lets inference rollouts run until the model thinks the factory is complete instead of overloading a placement action with the termination signal.
- SFT data + loop now train it: each lesson emits one terminal pair (`obs = solved factory`, `eot = 1`), placement pairs are `eot = 0`. BCE with `pos_weight = n_neg / n_pos` balances the rare positive class; placement losses are masked off on terminal samples so the placement heads aren't pulled toward "empty" by the eot=1 sentinels.
- Threshold consumption exposed via `agent.eot_prob(obs)` and `agent.eot_should_stop(obs, threshold=0.5)` — kept off the `get_action_and_value` 4-tuple return so the ~20 PPO + test callsites that unpack it don't have to change.

Logging adds `train/loss_eot`, `train/eot_acc`, `val/loss_eot`, `val/eot_acc`, `val/eot_pos_recall` (positive-class recall matters because "always predict 0" would still look accurate given the ~`max_level:1` class imbalance).

Named `eot_head` (not `done_head`) to avoid colliding with PPO's existing `dones_SE` / `next_done` episode-termination flags.

## Test plan

- [x] `pytest tests/` — 2946 passed
- [x] `ruff check .`
- [x] `cargo fmt` / `cargo clippy` / `cargo test --no-default-features`
- [x] PPO smoke test (5000 steps) runs to completion
- [x] New `TestEotHead` covers: terminal-pair emission, dataset tensor present, head forward shape, `eot_prob`/`eot_should_stop` API, end-to-end "after SFT, terminal logits > placement logits on held-out factories"
- [ ] SFT smoke test on CI (this PR carries the `sft-smoketest` label)

🤖 Generated with [Claude Code](https://claude.com/claude-code)