### PR TITLE
Add factorion-mod: Factorio mod + Python server bridge

### DIFF
--- a/factorion-mod/.gitignore
+++ b/factorion-mod/.gitignore
@@ -1,0 +1,21 @@
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+.ruff_cache/
+.pytest_cache/
+
+# Local server state
+server/state/
+server/logs/
+*.log
+
+# Factorio mod build artefacts
+mod/*.zip
+mod/dist/
+
+# Editor / OS
+.DS_Store
+.idea/
+.vscode/
+*.swp

--- a/factorion-mod/README.md
+++ b/factorion-mod/README.md
@@ -1,0 +1,178 @@
+# Factorion Mod
+
+A Factorio mod + local Python server that lets you ask a trained Factorion
+policy to design a factory layout from inside the game and paste it back as
+a blueprint.
+
+## Round trip
+
+A single RCON connection carries both directions. The server polls a
+`poll_request` remote interface every ~250 ms; the mod returns either an
+empty string (nothing pending) or the next queued request JSON.
+
+```
+   ┌──────────────┐  poll: remote.call("factorion","poll_request")   ┌────────┐
+   │              │ ◄─────────────────────────────────────────────── │        │
+   │   Factorio   │                                                  │ Python │
+   │   (mod)      │ ──────────────────────────────────────────────►  │ server │
+   │              │  reply: request JSON  (or "" when empty)         │        │
+   │              │                                                  │        │
+   │              │ ◄─────────────────────────────────────────────── │        │
+   └──────────────┘  push: remote.call("factorion",                  └────────┘
+                          "deliver_blueprint", req_id, bp_b64)
+```
+
+Why is this asymmetric on the wire even though it's one channel? Because
+**Factorio's modding Lua has no file-read API and no socket access** —
+the sandbox is intentional for multiplayer determinism. The only inbound
+channel for an external process is RCON. So:
+
+- The mod *enqueues* outbound requests into a Lua table; the server
+  *pulls* them by RCON-polling `poll_request`.
+- The server *pushes* blueprint responses by RCON-calling
+  `deliver_blueprint`.
+
+One TCP socket, two directions, no script-output files involved.
+
+## Why does Factorio need a special launch?
+
+RCON is configured only by command-line flags (`--rcon-bind`,
+`--rcon-password`) — there is no `config.ini` or env-var equivalent. The
+included `scripts/launch.sh` spawns Factorio with those flags
+pre-baked (random free port + random password) and starts the server
+pointed at the same endpoint, so you never type them yourself.
+
+If you'd rather launch Factorio manually (e.g. through Steam), pass:
+
+```bash
+factorio --rcon-bind 127.0.0.1:27015 --rcon-password factorion
+```
+
+…and start the server with matching `--rcon-port` / `--rcon-password`.
+
+## Layout
+
+```
+factorion-mod/
+├── README.md                 ← this file
+├── mod/                      ← the actual Factorio mod (publishable)
+│   ├── info.json
+│   ├── .luarc.json           ← lua-language-server config (Factorio globals)
+│   ├── control.lua           ← event handlers, RCON interface (poll + deliver)
+│   ├── data.lua              ← prototype loader
+│   ├── settings.lua          ← mod settings (grid size, default item)
+│   ├── locale/en/factorion.cfg
+│   └── prototypes/
+│       ├── selection-tools.lua  ← footprint / source / sink tools
+│       └── custom-inputs.lua    ← hotkey: execute prediction
+├── server/                   ← local inference daemon
+│   ├── server.py             ← RCON poll loop → model → RCON push
+│   ├── blueprint.py          ← tensor → Factorio blueprint JSON
+│   └── README.md
+└── scripts/
+    ├── install_mod.sh        ← symlink mod/ into Factorio's mods dir
+    └── launch.sh             ← spawn Factorio with auto-RCON + start server
+```
+
+## Quick start
+
+1. Build the project's Rust extension and install deps (one-time, from the
+   repo root):
+
+   ```bash
+   uv venv --python 3.11
+   uv pip install -r requirements.txt
+   uv run maturin develop --release --manifest-path factorion_rs/Cargo.toml
+   ```
+
+2. Symlink the mod into Factorio:
+
+   ```bash
+   bash factorion-mod/scripts/install_mod.sh
+   ```
+
+3. Launch Factorio + the model server with one command:
+
+   ```bash
+   bash factorion-mod/scripts/launch.sh runs/<your-run>/agent.pt
+   ```
+
+   This spawns Factorio with RCON pre-configured on a random free port
+   and starts the server pointed at the same endpoint. Load a save with
+   the `factorion` mod enabled — the server connects automatically.
+
+4. In Factorio:
+   - Take the **Factorion footprint tool** from your inventory (granted on
+     first join). Drag-select an 8×8 region.
+   - Take the **Factorion source/sink tool**. Left-click tiles on the
+     footprint border to add a source; right-click to add a sink.
+   - Press **Ctrl+Shift+P** (default) to request a prediction.
+   - A blueprint with the predicted layout appears in your cursor. Paste.
+
+## Status
+
+### What works (verified end-to-end against Factorio 2.0.76, 2026-05-12)
+
+- Mod loads cleanly in Factorio 2.0 (`factorio --start-server-load-scenario base/freeplay`).
+- Server connects via RCON, pings the mod, starts the poll loop.
+- Client injects a request via the `inject_request` remote interface.
+- Server polls, deserialises, runs iterative inference, emits a
+  valid Factorio blueprint b64 string, pushes it back via RCON.
+- Headless mode reports the blueprint via `log()` since there's no
+  player cursor to inject into.
+- `lua-language-server --check` reports clean on the mod.
+
+### What doesn't work / wasn't possible
+
+- **Symmetric file-based transport** — tried; Factorio's modding Lua
+  has no `game.read_file`, no `loadfile`, no socket access. The sandbox
+  is intentional for multiplayer determinism. Inbound side must be RCON.
+- **Avoiding the `--rcon-port` launch flag** — tried; RCON is only
+  configurable via command-line flags. No `config.ini` or env-var
+  alternative exists in Factorio. `scripts/launch.sh` hides the flag
+  by spawning the binary itself, but the flag is still there.
+- **Poking mod `storage` directly from RCON** — tried; `/silent-command`
+  runs in *level (scenario) scope*, not any mod's scope. The `storage`
+  visible to RCON commands is the scenario's, not the mod's. Required
+  adding an `inject_request` remote interface as the only way in.
+- **Cursor injection in headless mode** — tried; no player exists in
+  `--start-server-load-scenario`, so `game.get_player(1)` is nil and
+  `cursor_stack` ops would crash. Worked around with a
+  `deliver_to_player_index=0` sentinel that logs the blueprint instead.
+
+### Not yet tried / known partial
+
+- **Live in-game UI flow** (footprint drag-select, source/sink marker,
+  Ctrl+Shift+P hotkey, cursor injection into a real player) — needs a
+  human in the seat with a non-headless game. The wire is proven; the
+  GUI events are untested.
+- **Source/sink item picker** — hardcoded to `iron-plate` until a per-
+  source GUI is added.
+- **Multi-tile entities (splitters, undergrounds) during iterative
+  inference** — emitted in the final blueprint correctly, but the
+  server's iterative state update treats them as 1×1. The policy may
+  compose them in odd ways until the stepping loop calls into
+  `factorion_rs` for proper validation.
+- **Cross-platform `launch.sh` binary discovery** — macOS path verified
+  (Steam install), Linux/Windows paths are heuristics. Override with
+  `FACTORIO_BIN=/path/to/factorio` if it can't find yours.
+- **Reconnect after `/c game.reload_mods()`** — server has reconnect
+  logic but reloading the mod mid-session hasn't been exercised.
+
+## Lua linting
+
+The mod directory ships a `.luarc.json` so
+[`lua-language-server`](https://github.com/LuaLS/lua-language-server)
+recognises Factorio's runtime globals (`game`, `storage`, `script`,
+`remote`, `helpers`, `defines`, `data`, `settings`, `rcon`, `log`).
+
+CLI check:
+
+```bash
+lua-language-server --check factorion-mod/mod --checklevel=Warning
+```
+
+Exits clean when there are no diagnostics. For deeper API-level type
+checking (e.g. typed `LuaPlayer.cursor_stack`), install
+[FMTK / vscode-factoriomod-debug](https://github.com/justarandomgeek/vscode-factoriomod-debug)
+which ships full Factorio API definitions for LLS.

--- a/factorion-mod/README.md
+++ b/factorion-mod/README.md
@@ -1,8 +1,8 @@
 # Factorion Mod
 
-A Factorio mod + local Python server that lets you ask a trained Factorion
-policy to design a factory layout from inside the game and paste it back as
-a blueprint.
+A Factorio mod + local Python server that lets you ask a trained
+Factorion policy to design a factory layout from inside the game and
+paste it back as a blueprint.
 
 ## Round trip
 
@@ -25,30 +25,42 @@ empty string (nothing pending) or the next queued request JSON.
 Why is this asymmetric on the wire even though it's one channel? Because
 **Factorio's modding Lua has no file-read API and no socket access** —
 the sandbox is intentional for multiplayer determinism. The only inbound
-channel for an external process is RCON. So:
+channel for an external process is RCON.
 
-- The mod *enqueues* outbound requests into a Lua table; the server
-  *pulls* them by RCON-polling `poll_request`.
-- The server *pushes* blueprint responses by RCON-calling
-  `deliver_blueprint`.
+## Source / sink representation
 
-One TCP socket, two directions, no script-output files involved.
+The mod uses **constant-combinators** as source/sink markers. Place one
+in your footprint and configure its first section with three filters:
 
-## Why does Factorio need a special launch?
+| filter | purpose         | values                                                                  |
+| ------ | --------------- | ----------------------------------------------------------------------- |
+| item   | what flows      | `iron-plate`, `electronic-circuit`, … (items tab)                       |
+| role   | source vs sink  | `signal-output` (source) or `signal-input` (sink) (virtual signals)     |
+| arrow  | facing          | `up-arrow` / `right-arrow` / `down-arrow` / `left-arrow` (virtual)      |
 
-RCON is configured only by command-line flags (`--rcon-bind`,
-`--rcon-password`) — there is no `config.ini` or env-var equivalent. The
-included `scripts/launch.sh` spawns Factorio with those flags
-pre-baked (random free port + random password) and starts the server
-pointed at the same endpoint, so you never type them yourself.
+Slot order doesn't matter — the mod parses by signal name. The server
+re-renders these same combinators in the output blueprint so the round
+trip is loss-free; you can paste-over your existing markers and only the
+model's belts/inserters get added as ghosts.
 
-If you'd rather launch Factorio manually (e.g. through Steam), pass:
+There's also a fallback click-tool (drag = sources, Shift+drag = sinks)
+if you'd rather mark by tile without dropping combinators.
 
-```bash
-factorio --rcon-bind 127.0.0.1:27015 --rcon-password factorion
-```
+## RCON setup
 
-…and start the server with matching `--rcon-port` / `--rcon-password`.
+RCON only binds when Factorio is **hosting multiplayer**. Two paths:
+
+- **Headless server** (no GUI): `factorio --start-server <save> --rcon-bind 127.0.0.1:PORT --rcon-password PW`. RCON binds at launch. CLI flags work directly.
+- **GUI multiplayer host** (singleplayer-feeling): `factorio --host <save>` opens the GUI in host mode. For RCON to bind, add to `config.ini` under `[other]`:
+
+  ```ini
+  local-rcon-socket=127.0.0.1:64502
+  local-rcon-password=<some password>
+  ```
+
+  CLI `--rcon-bind` is **ignored** for GUI mode — config.ini is the only path.
+
+`scripts/launch.sh` automates the headless path with auto-generated port+password.
 
 ## Layout
 
@@ -58,26 +70,23 @@ factorion-mod/
 ├── mod/                      ← the actual Factorio mod (publishable)
 │   ├── info.json
 │   ├── .luarc.json           ← lua-language-server config (Factorio globals)
-│   ├── control.lua           ← event handlers, RCON interface (poll + deliver)
-│   ├── data.lua              ← prototype loader
-│   ├── settings.lua          ← mod settings (grid size, default item)
+│   ├── control.lua           ← event handlers, RCON interface, combinator auto-detect
+│   ├── data.lua / settings.lua
 │   ├── locale/en/factorion.cfg
-│   └── prototypes/
-│       ├── selection-tools.lua  ← footprint / source / sink tools
-│       └── custom-inputs.lua    ← hotkey: execute prediction
+│   └── prototypes/           ← footprint + marker selection tools, hotkey definitions
 ├── server/                   ← local inference daemon
-│   ├── server.py             ← RCON poll loop → model → RCON push
-│   ├── blueprint.py          ← tensor → Factorio blueprint JSON
+│   ├── server.py             ← RCON poll loop → model (with eot_head stop) → RCON push
+│   ├── blueprint.py          ← obs tensor → Factorio blueprint b64 (combinator markers)
 │   └── README.md
 └── scripts/
     ├── install_mod.sh        ← symlink mod/ into Factorio's mods dir
-    └── launch.sh             ← spawn Factorio with auto-RCON + start server
+    └── launch.sh             ← spawn Factorio with auto-RCON + start server (headless)
 ```
 
 ## Quick start
 
-1. Build the project's Rust extension and install deps (one-time, from the
-   repo root):
+1. Build the project's Rust extension and install deps (one-time, from
+   the repo root):
 
    ```bash
    uv venv --python 3.11
@@ -91,80 +100,111 @@ factorion-mod/
    bash factorion-mod/scripts/install_mod.sh
    ```
 
-3. Launch Factorio + the model server with one command:
+3. Set `mod settings → Factorion grid size` to match what your checkpoint
+   was trained on (default 8; the included `0g9hfjna` checkpoint is 11).
+
+4. Enable RCON. Either headless (use `scripts/launch.sh`) or GUI host
+   mode (edit `config.ini` per above).
+
+5. Start the server pointed at your checkpoint:
 
    ```bash
-   bash factorion-mod/scripts/launch.sh runs/<your-run>/agent.pt
+   uv run python factorion-mod/server/server.py \
+     --checkpoint path/to/agent.pt \
+     --rcon-port 64502 --rcon-password <pw>
    ```
 
-   This spawns Factorio with RCON pre-configured on a random free port
-   and starts the server pointed at the same endpoint. Load a save with
-   the `factorion` mod enabled — the server connects automatically.
+   A sidecar `agent.hp.json` next to the `.pt` with `{"grid_size": N, "chan1": …}`
+   is read automatically.
 
-4. In Factorio:
-   - Take the **Factorion footprint tool** from your inventory (granted on
-     first join). Drag-select an 8×8 region.
-   - Take the **Factorion source/sink tool**. Left-click tiles on the
-     footprint border to add a source; right-click to add a sink.
-   - Press **Ctrl+Shift+P** (default) to request a prediction.
-   - A blueprint with the predicted layout appears in your cursor. Paste.
+6. In Factorio:
+   - Place one or more **constant-combinators** in the area you want
+     the factory built. Configure each per the table above.
+   - Take the **Factorion footprint tool** (granted on first join; or
+     `Ctrl+T` to re-grant).
+   - Drag-select the rectangular footprint over your combinators. The
+     mod auto-fires a prediction as soon as the area is valid (≥1 source
+     + ≥1 sink detected). If you add combinators later, press `Ctrl+P`.
+   - A blueprint titled `Factorion: N entities (M placed + K markers)`
+     lands in your cursor. Description has a per-step trace with item
+     icons. Paste to materialise.
+
+   Hotkeys (rebindable in Controls → Factorion):
+   - `Ctrl+P` — request prediction
+   - `Ctrl+R` — clear footprint, sources and sinks
+   - `Ctrl+T` — re-grant selection tools
+
+## Debug interfaces (RCON)
+
+Server-callable remote methods exposed by the mod:
+
+- `ping()` — round-trip check
+- `introspect()` — outbox depth, pending requests, players known
+- `dump_state(player_index?)` — full footprint + sources + sinks dump
+- `inject_request(json, deliver_to_player_index)` — synthesise a request
+  without using the hotkey (for headless / scripted tests). Pass
+  `player_index=0` for the headless sentinel where `deliver_blueprint`
+  logs the result instead of cursor-injecting.
 
 ## Status
 
-### What works (verified end-to-end against Factorio 2.0.76, 2026-05-12)
+### Verified end-to-end (Factorio 2.0.76)
 
-- Mod loads cleanly in Factorio 2.0 (`factorio --start-server-load-scenario base/freeplay`).
-- Server connects via RCON, pings the mod, starts the poll loop.
-- Client injects a request via the `inject_request` remote interface.
-- Server polls, deserialises, runs iterative inference, emits a
-  valid Factorio blueprint b64 string, pushes it back via RCON.
-- Headless mode reports the blueprint via `log()` since there's no
-  player cursor to inject into.
-- `lua-language-server --check` reports clean on the mod.
+- Mod loads cleanly, `lua-language-server --check` reports clean.
+- Headless round trip via `--start-server-load-scenario base/freeplay` +
+  `inject_request` (proves the wire).
+- Live GUI round trip via `--host <save>` with config.ini RCON +
+  W&B SFT checkpoint `0g9hfjna`: place combinators → drag footprint →
+  auto-predict → blueprint in cursor → paste materialises markers + model
+  placements with no Factorio import warnings.
+- Constant-combinator markers round-trip through blueprint import/export
+  preserving all three filter signals.
+- Per-step inference trace embedded in the blueprint description with
+  rich-text item icons; description char-budget aware so it doesn't
+  truncate mid-tag.
+- `eot_head` is wired as the iterative stop signal (PPO PR #103 landed
+  via the main-merge).
 
 ### What doesn't work / wasn't possible
 
-- **Symmetric file-based transport** — tried; Factorio's modding Lua
-  has no `game.read_file`, no `loadfile`, no socket access. The sandbox
-  is intentional for multiplayer determinism. Inbound side must be RCON.
-- **Avoiding the `--rcon-port` launch flag** — tried; RCON is only
-  configurable via command-line flags. No `config.ini` or env-var
-  alternative exists in Factorio. `scripts/launch.sh` hides the flag
-  by spawning the binary itself, but the flag is still there.
-- **Poking mod `storage` directly from RCON** — tried; `/silent-command`
-  runs in *level (scenario) scope*, not any mod's scope. The `storage`
-  visible to RCON commands is the scenario's, not the mod's. Required
-  adding an `inject_request` remote interface as the only way in.
-- **Cursor injection in headless mode** — tried; no player exists in
-  `--start-server-load-scenario`, so `game.get_player(1)` is nil and
-  `cursor_stack` ops would crash. Worked around with a
-  `deliver_to_player_index=0` sentinel that logs the blueprint instead.
+- **Symmetric file-based transport** — tried; Factorio's modding Lua has
+  no `game.read_file`, no `loadfile`, no socket access. Inbound side
+  must be RCON.
+- **Avoiding launch flags entirely** — RCON config can't be set
+  in-game. For GUI hosting, `config.ini`'s `local-rcon-socket` /
+  `local-rcon-password` is the only path (no env-vars, no in-game UI).
+- **Poking mod `storage` directly from RCON** — `/silent-command` runs
+  in *level scope*, not mod scope. The mod's `remote.add_interface`
+  methods are the only way in.
+- **`game.reload_script()` picking up `control.lua` edits from disk** —
+  reloads from the **save's embedded mod scripts**, so changes only
+  stick after save → exit → host-saved-game cycle.
+- **Cursor injection in headless mode** — no player exists, so
+  `cursor_stack` ops would crash. Server uses `player_index=0` as the
+  sentinel and the mod logs the blueprint via `log()` instead.
 
-### Not yet tried / known partial
+### Not yet integrated
 
-- **Live in-game UI flow** (footprint drag-select, source/sink marker,
-  Ctrl+Shift+P hotkey, cursor injection into a real player) — needs a
-  human in the seat with a non-headless game. The wire is proven; the
-  GUI events are untested.
-- **Source/sink item picker** — hardcoded to `iron-plate` until a per-
-  source GUI is added.
-- **Multi-tile entities (splitters, undergrounds) during iterative
-  inference** — emitted in the final blueprint correctly, but the
-  server's iterative state update treats them as 1×1. The policy may
-  compose them in odd ways until the stepping loop calls into
-  `factorion_rs` for proper validation.
-- **Cross-platform `launch.sh` binary discovery** — macOS path verified
-  (Steam install), Linux/Windows paths are heuristics. Override with
-  `FACTORIO_BIN=/path/to/factorio` if it can't find yours.
-- **Reconnect after `/c game.reload_mods()`** — server has reconnect
-  logic but reloading the mod mid-session hasn't been exercised.
+- **Stochastic / temperature sampling.** Inference is argmax-only; with
+  weak checkpoints the policy can argmax-loop on the same tile. A
+  `--temperature` flag with `Categorical(logits)` sampling is ~10 LoC.
+- **Tile-mask in the tile head**: prevent the model from re-picking a
+  tile that's already non-empty. Would also break degenerate loops.
+- **Multi-tile entity validation** during iterative inference. The
+  obs-side state update treats splitters / undergrounds as 1×1; final
+  blueprint emission handles them correctly. To enforce validity during
+  the loop, drive `FactorioEnv.step()` directly.
+- **Cross-platform `launch.sh` binary discovery**. macOS Steam install
+  verified; Linux / Windows paths are heuristics. Override with
+  `FACTORIO_BIN=…` if it can't find yours.
 
 ## Lua linting
 
 The mod directory ships a `.luarc.json` so
 [`lua-language-server`](https://github.com/LuaLS/lua-language-server)
 recognises Factorio's runtime globals (`game`, `storage`, `script`,
-`remote`, `helpers`, `defines`, `data`, `settings`, `rcon`, `log`).
+`remote`, `helpers`, `defines`, `data`, `settings`, `rcon`, `log`,
+`table_size`).
 
 CLI check:
 
@@ -172,7 +212,6 @@ CLI check:
 lua-language-server --check factorion-mod/mod --checklevel=Warning
 ```
 
-Exits clean when there are no diagnostics. For deeper API-level type
-checking (e.g. typed `LuaPlayer.cursor_stack`), install
+For full API typing (typed `LuaPlayer.cursor_stack` etc.), install
 [FMTK / vscode-factoriomod-debug](https://github.com/justarandomgeek/vscode-factoriomod-debug)
 which ships full Factorio API definitions for LLS.

--- a/factorion-mod/mod/.luarc.json
+++ b/factorion-mod/mod/.luarc.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
+  "runtime.version": "Lua 5.2",
+  "diagnostics.globals": [
+    "data",
+    "defines",
+    "game",
+    "helpers",
+    "log",
+    "rcon",
+    "remote",
+    "script",
+    "settings",
+    "storage",
+    "table_size"
+  ],
+  "diagnostics.disable": [],
+  "workspace.library": [],
+  "workspace.checkThirdParty": false
+}

--- a/factorion-mod/mod/control.lua
+++ b/factorion-mod/mod/control.lua
@@ -47,6 +47,13 @@ local function ensure_pending_lookup()
   storage.outbox = storage.outbox or {}
 end
 
+-- Forward declarations: these are defined further down but referenced
+-- from event handlers (registered earlier in file order). Declaring them
+-- as locals here lets the handler closures capture the local slot, which
+-- the later assignments fill in.
+local try_request_prediction
+local json_encode
+
 -- ----------------------------------------------------------------------------
 -- player onboarding
 -- ----------------------------------------------------------------------------
@@ -118,10 +125,19 @@ script.on_event(defines.events.on_player_selected_area, function(event)
     state.sources = {}
     state.sinks = {}
     player.print(string.format(
-      "[Factorion] Footprint set: x=%d..%d (%d wide), y=%d..%d (%d tall). " ..
-      "Mark sources/sinks WITHIN these bounds.",
+      "[Factorion] Footprint set: x=%d..%d (%d wide), y=%d..%d (%d tall).",
       bbox.x, bbox.x + bbox.w - 1, bbox.w,
       bbox.y, bbox.y + bbox.h - 1, bbox.h))
+    -- Auto-trigger a prediction if sources/sinks (combinators or click-marks)
+    -- are already valid. If not, the message is informative — the player can
+    -- then drop combinators in and press CTRL+P manually.
+    local ok, msg = try_request_prediction(event.player_index)
+    if ok then
+      player.print("[Factorion] " .. msg)
+    else
+      player.print("[Factorion] " .. msg ..
+        " (After adding them, press CTRL+P to predict.)")
+    end
 
   elseif event.item == "factorion-marker-tool" then
     -- left-click = sources
@@ -371,13 +387,11 @@ local function gather_request(state, player_index)
     end
   end
 
-  if player then
-    player.print(string.format(
-      "[Factorion] %d source(s) from %s, %d sink(s) from %s.",
-      #sources, source_provenance, #sinks, sink_provenance))
-  end
+  local provenance = string.format(
+    "%d source(s) from %s, %d sink(s) from %s",
+    #sources, source_provenance, #sinks, sink_provenance)
 
-  return {
+  local request = {
     request_id    = new_request_id(),
     player_index  = player_index,
     grid_size     = size,
@@ -386,9 +400,37 @@ local function gather_request(state, player_index)
     sinks         = sinks,
     default_item  = default_item,
   }
+  return request, provenance
 end
 
-local function json_encode(t)
+-- Build a request from the player's current state (combinators preferred,
+-- click-marks as fallback) and enqueue it for the server. Returns
+-- (true, message) on success, (false, message) on a precheck failure.
+try_request_prediction = function(player_index)
+  local state = ensure_player_state(player_index)
+  ensure_pending_lookup()
+  if not state.footprint then
+    return false, "No footprint set."
+  end
+  local request, provenance = gather_request(state, player_index)
+  if #request.sources == 0 and #request.sinks == 0 then
+    return false,
+      "No sources or sinks. Place a constant-combinator inside the " ..
+      "footprint (with signal-output/signal-input + an arrow + an item) " ..
+      "or use the marker tool."
+  end
+  local request_json = json_encode(request)
+  table.insert(storage.outbox, request_json)
+  storage.pending_by_request[request.request_id] = player_index
+  state.pending = { request_id = request.request_id, tick = game.tick }
+  log("[Factorion] enqueued request " .. request.request_id ..
+      " (" .. provenance .. ") json=" .. request_json)
+  return true, string.format(
+    "Request %s queued (%s). Waiting for server…",
+    request.request_id, provenance)
+end
+
+json_encode = function(t)
   -- Factorio 2.0 exposes helpers.table_to_json; the older `game.table_to_json`
   -- is deprecated but kept for compat. Prefer helpers when present.
   if helpers and helpers.table_to_json then
@@ -400,43 +442,8 @@ end
 script.on_event("factorion-execute", function(event)
   local player = game.get_player(event.player_index)
   if not player then return end
-  local state = ensure_player_state(event.player_index)
-  ensure_pending_lookup()
-
-  if not state.footprint then
-    player.print("[Factorion] No footprint set.")
-    return
-  end
-
-  -- gather_request prefers in-world constant-combinators inside the
-  -- footprint; if there are none AND no click-marked sources/sinks
-  -- exist either, the resulting request will be empty.
-  local request = gather_request(state, event.player_index)
-  if #request.sources == 0 and #request.sinks == 0 then
-    player.print(
-      "[Factorion] No sources or sinks found. Place a constant-combinator " ..
-      "inside the footprint with signal-output/signal-input + an arrow + " ..
-      "an item, or use the marker tool.")
-    return
-  end
-  local request_json = json_encode(request)
-  table.insert(storage.outbox, request_json)
-  storage.pending_by_request[request.request_id] = event.player_index
-  state.pending = { request_id = request.request_id, tick = game.tick }
-
-  -- Log the full payload to factorio-current.log so we can inspect it
-  -- from outside the game when things look wrong.
-  log("[Factorion] enqueued request " .. request.request_id ..
-      " (footprint=" .. tostring(#request.footprint) ..
-      ", sources=" .. tostring(#request.sources) ..
-      ", sinks=" .. tostring(#request.sinks) ..
-      ") json=" .. request_json)
-
-  player.print(string.format(
-    "[Factorion] Request %s queued (footprint=%d sources=%d sinks=%d, " ..
-    "outbox depth %d). Waiting for server…",
-    request.request_id, #request.footprint,
-    #request.sources, #request.sinks, #storage.outbox))
+  local _, msg = try_request_prediction(event.player_index)
+  player.print("[Factorion] " .. msg)
 end)
 
 -- ----------------------------------------------------------------------------

--- a/factorion-mod/mod/control.lua
+++ b/factorion-mod/mod/control.lua
@@ -127,38 +127,59 @@ script.on_event(defines.events.on_player_selected_area, function(event)
       player.print("[Factorion] Set a footprint first.")
       return
     end
+    local added_positions = {}
     for _, tile in pairs(event.tiles or {}) do
       table.insert(state.sources, { x = tile.position.x, y = tile.position.y })
+      table.insert(added_positions,
+        string.format("(%d,%d)", tile.position.x, tile.position.y))
     end
-    player.print(string.format("[Factorion] +%d source(s); total %d.",
-      #(event.tiles or {}), #state.sources))
+    player.print(string.format("[Factorion] +%d source(s) at %s; total %d.",
+      #(event.tiles or {}), table.concat(added_positions, ","), #state.sources))
   end
 end)
 
-script.on_event(defines.events.on_player_alt_selected_area, function(event)
+-- The "alt" variants of selection events have moved around between
+-- Factorio versions. Wire up all three secondary modes so whichever the
+-- player's modifier hits (Shift, Ctrl-Shift, etc.) records sinks.
+
+local function handle_sink_select(event, mode_name)
   local state = ensure_player_state(event.player_index)
   local player = game.get_player(event.player_index)
   if not player then return end
 
   if event.item == "factorion-footprint-tool" then
-    -- alt-drag = clear footprint
+    -- any secondary on the footprint = clear it
     state.footprint = nil
     state.sources = {}
     state.sinks = {}
-    player.print("[Factorion] Footprint cleared.")
+    player.print(string.format("[Factorion] Footprint cleared (via %s).", mode_name))
 
   elseif event.item == "factorion-marker-tool" then
-    -- right-click = sinks
     if not state.footprint then
       player.print("[Factorion] Set a footprint first.")
       return
     end
+    local added_positions = {}
     for _, tile in pairs(event.tiles or {}) do
       table.insert(state.sinks, { x = tile.position.x, y = tile.position.y })
+      table.insert(added_positions,
+        string.format("(%d,%d)", tile.position.x, tile.position.y))
     end
-    player.print(string.format("[Factorion] +%d sink(s); total %d.",
-      #(event.tiles or {}), #state.sinks))
+    player.print(string.format(
+      "[Factorion] +%d sink(s) at %s; total %d. (via %s)",
+      #(event.tiles or {}), table.concat(added_positions, ","),
+      #state.sinks, mode_name))
   end
+end
+
+script.on_event(defines.events.on_player_alt_selected_area, function(e)
+  handle_sink_select(e, "alt_select")
+end)
+script.on_event(defines.events.on_player_reverse_selected_area, function(e)
+  handle_sink_select(e, "reverse_select")
+end)
+script.on_event(defines.events.on_player_alt_reverse_selected_area, function(e)
+  handle_sink_select(e, "alt_reverse_select")
 end)
 
 script.on_event("factorion-reset", function(event)
@@ -283,19 +304,36 @@ script.on_event("factorion-execute", function(event)
   end
 
   local request = gather_request(state, event.player_index)
-  table.insert(storage.outbox, json_encode(request))
+  local request_json = json_encode(request)
+  table.insert(storage.outbox, request_json)
   storage.pending_by_request[request.request_id] = event.player_index
   state.pending = { request_id = request.request_id, tick = game.tick }
 
+  -- Log the full payload to factorio-current.log so we can inspect it
+  -- from outside the game when things look wrong.
+  log("[Factorion] enqueued request " .. request.request_id ..
+      " (footprint=" .. tostring(#request.footprint) ..
+      ", sources=" .. tostring(#request.sources) ..
+      ", sinks=" .. tostring(#request.sinks) ..
+      ") json=" .. request_json)
+
   player.print(string.format(
-    "[Factorion] Request %s queued (outbox depth %d). " ..
-    "Waiting for the server to poll and reply…",
-    request.request_id, #storage.outbox))
+    "[Factorion] Request %s queued (footprint=%d sources=%d sinks=%d, " ..
+    "outbox depth %d). Waiting for server…",
+    request.request_id, #request.footprint,
+    #request.sources, #request.sinks, #storage.outbox))
 end)
 
 -- ----------------------------------------------------------------------------
 -- RCON interface: server pushes the prediction back here
 -- ----------------------------------------------------------------------------
+
+-- Re-registration safety: remote.add_interface errors if the name already
+-- exists. On /c game.reload_script() the old interface is still bound, so
+-- the new methods (e.g. dump_state) would never get added. Remove first.
+if remote.interfaces["factorion"] then
+  remote.remove_interface("factorion")
+end
 
 remote.add_interface("factorion", {
   -- The server's poll: pop and return the oldest pending request JSON, or
@@ -337,7 +375,8 @@ remote.add_interface("factorion", {
       player.print("[Factorion] No cursor_stack available.")
       return false
     end
-    if not cursor.is_empty() then
+    -- LuaItemStack:is_empty() was removed in 2.0; use valid_for_read instead.
+    if cursor.valid_for_read then
       cursor.clear()
     end
     if not cursor.set_stack({ name = "blueprint", count = 1 }) then
@@ -397,6 +436,38 @@ remote.add_interface("factorion", {
     return string.format("outbox=%d pending=%d players=%d",
       #storage.outbox, pending_n,
       storage.players and table_size(storage.players) or 0)
+  end,
+
+  -- Headless / debug: dump full state for a given player (or all players).
+  dump_state = function(player_index)
+    storage.players = storage.players or {}
+    local parts = {}
+    for k, p in pairs(storage.players) do
+      if player_index == nil or k == player_index then
+        local fp = p.footprint and string.format("x=%d,y=%d,w=%d,h=%d",
+            p.footprint.x, p.footprint.y, p.footprint.w, p.footprint.h)
+          or "nil"
+        table.insert(parts, string.format(
+          "player[%s]: footprint={%s} #sources=%d #sinks=%d",
+          tostring(k), fp, #(p.sources or {}), #(p.sinks or {})))
+        if p.sources and #p.sources > 0 then
+          local s = {}
+          for _, src in ipairs(p.sources) do
+            table.insert(s, string.format("(%d,%d)", src.x, src.y))
+          end
+          table.insert(parts, "  sources: " .. table.concat(s, ","))
+        end
+        if p.sinks and #p.sinks > 0 then
+          local s = {}
+          for _, snk in ipairs(p.sinks) do
+            table.insert(s, string.format("(%d,%d)", snk.x, snk.y))
+          end
+          table.insert(parts, "  sinks: " .. table.concat(s, ","))
+        end
+      end
+    end
+    if #parts == 0 then return "(no player state)" end
+    return table.concat(parts, "\n")
   end,
 })
 

--- a/factorion-mod/mod/control.lua
+++ b/factorion-mod/mod/control.lua
@@ -1,0 +1,417 @@
+-- Factorion mod runtime.
+--
+-- State per player lives in `storage.players[player_index]`:
+--   footprint = { x=int, y=int, w=int, h=int }   world-tile bbox
+--   sources   = { { x=int, y=int }, ... }        world-tile coords
+--   sinks     = { { x=int, y=int }, ... }
+--   pending   = { request_id=string, tick=int }  in-flight request, if any
+--
+-- Round trip (single-channel RCON, both directions):
+--   1. On key `factorion-execute`, we build a request JSON describing the
+--      footprint + sources + sinks (in footprint-relative coords) and
+--      enqueue it on `storage.outbox`. The Python server is polling our
+--      `poll_request` remote interface over RCON; when there's something
+--      in the queue it gets popped and returned as a JSON string.
+--   2. The server runs the model, then calls our `deliver_blueprint`
+--      remote interface (also over RCON). We import the blueprint string
+--      into the requesting player's cursor.
+--
+-- No script-output files are involved. The only outbound channel a
+-- vanilla mod has is RCON, and we use it both ways.
+
+local function get_grid_size()
+  return settings.global["factorion-grid-size"].value
+end
+
+local function get_default_item()
+  return settings.global["factorion-default-item"].value
+end
+
+local function ensure_player_state(player_index)
+  storage.players = storage.players or {}
+  if not storage.players[player_index] then
+    storage.players[player_index] = {
+      footprint = nil,
+      sources   = {},
+      sinks     = {},
+      pending   = nil,
+    }
+  end
+  return storage.players[player_index]
+end
+
+local function ensure_pending_lookup()
+  -- request_id -> player_index, so the RCON callback can find the player.
+  storage.pending_by_request = storage.pending_by_request or {}
+  -- FIFO of JSON request strings waiting for the server to pop via RCON.
+  storage.outbox = storage.outbox or {}
+end
+
+-- ----------------------------------------------------------------------------
+-- player onboarding
+-- ----------------------------------------------------------------------------
+
+local function give_tools(player)
+  local inv = player.get_main_inventory()
+  if not inv then return end
+  if inv.get_item_count("factorion-footprint-tool") == 0 then
+    inv.insert({ name = "factorion-footprint-tool", count = 1 })
+  end
+  if inv.get_item_count("factorion-marker-tool") == 0 then
+    inv.insert({ name = "factorion-marker-tool", count = 1 })
+  end
+  player.print({ "", "[Factorion] Tools added: ",
+    "drag the [item=factorion-footprint-tool] to set an ",
+    tostring(get_grid_size()), "x", tostring(get_grid_size()),
+    " footprint, then left/right-click with [item=factorion-marker-tool] ",
+    "to mark sources/sinks. Press CTRL+SHIFT+P to predict." })
+end
+
+script.on_event(defines.events.on_player_created, function(event)
+  ensure_player_state(event.player_index)
+  ensure_pending_lookup()
+  local player = game.get_player(event.player_index)
+  if player then give_tools(player) end
+end)
+
+script.on_event("factorion-give-tools", function(event)
+  local player = game.get_player(event.player_index)
+  if player then give_tools(player) end
+end)
+
+-- ----------------------------------------------------------------------------
+-- selection-tool handlers
+-- ----------------------------------------------------------------------------
+
+local function tile_floor(area_axis)
+  -- Selection-area coords are floats at tile *corners*; floor gives the
+  -- top-left tile index. Areas come back as {left_top, right_bottom}.
+  return math.floor(area_axis + 0.0001)
+end
+
+local function area_to_bbox(area)
+  local x = tile_floor(area.left_top.x)
+  local y = tile_floor(area.left_top.y)
+  -- right_bottom is exclusive in tile-space; subtract 1 for the inclusive
+  -- last tile, then +1 for the count.
+  local w = tile_floor(area.right_bottom.x) - x
+  local h = tile_floor(area.right_bottom.y) - y
+  return { x = x, y = y, w = w, h = h }
+end
+
+script.on_event(defines.events.on_player_selected_area, function(event)
+  local state = ensure_player_state(event.player_index)
+  local player = game.get_player(event.player_index)
+  if not player then return end
+
+  if event.item == "factorion-footprint-tool" then
+    local bbox = area_to_bbox(event.area)
+    local size = get_grid_size()
+    if bbox.w ~= size or bbox.h ~= size then
+      player.print(string.format(
+        "[Factorion] Footprint must be exactly %dx%d (got %dx%d). " ..
+        "Try again, or change `factorion-grid-size` in mod settings.",
+        size, size, bbox.w, bbox.h))
+      return
+    end
+    state.footprint = bbox
+    state.sources = {}
+    state.sinks = {}
+    player.print(string.format(
+      "[Factorion] Footprint set: (%d,%d) +%dx%d. Now mark sources/sinks.",
+      bbox.x, bbox.y, bbox.w, bbox.h))
+
+  elseif event.item == "factorion-marker-tool" then
+    -- left-click = sources
+    if not state.footprint then
+      player.print("[Factorion] Set a footprint first.")
+      return
+    end
+    for _, tile in pairs(event.tiles or {}) do
+      table.insert(state.sources, { x = tile.position.x, y = tile.position.y })
+    end
+    player.print(string.format("[Factorion] +%d source(s); total %d.",
+      #(event.tiles or {}), #state.sources))
+  end
+end)
+
+script.on_event(defines.events.on_player_alt_selected_area, function(event)
+  local state = ensure_player_state(event.player_index)
+  local player = game.get_player(event.player_index)
+  if not player then return end
+
+  if event.item == "factorion-footprint-tool" then
+    -- alt-drag = clear footprint
+    state.footprint = nil
+    state.sources = {}
+    state.sinks = {}
+    player.print("[Factorion] Footprint cleared.")
+
+  elseif event.item == "factorion-marker-tool" then
+    -- right-click = sinks
+    if not state.footprint then
+      player.print("[Factorion] Set a footprint first.")
+      return
+    end
+    for _, tile in pairs(event.tiles or {}) do
+      table.insert(state.sinks, { x = tile.position.x, y = tile.position.y })
+    end
+    player.print(string.format("[Factorion] +%d sink(s); total %d.",
+      #(event.tiles or {}), #state.sinks))
+  end
+end)
+
+script.on_event("factorion-reset", function(event)
+  local state = ensure_player_state(event.player_index)
+  state.footprint = nil
+  state.sources = {}
+  state.sinks = {}
+  local player = game.get_player(event.player_index)
+  if player then player.print("[Factorion] State cleared.") end
+end)
+
+-- ----------------------------------------------------------------------------
+-- direction inference: a source on the west edge faces east, etc.
+-- ----------------------------------------------------------------------------
+
+local function dir_toward_center(rel_x, rel_y, size)
+  -- "Toward center" snapped to cardinal. Larger of the two distances-to-
+  -- edge-center wins. Returns the Factorion Direction enum: 1=N,2=E,3=S,4=W.
+  local mid = (size - 1) / 2
+  local dx = mid - rel_x
+  local dy = mid - rel_y
+  if math.abs(dx) >= math.abs(dy) then
+    if dx >= 0 then return 2 else return 4 end  -- east or west
+  else
+    if dy >= 0 then return 3 else return 1 end  -- south or north
+  end
+end
+
+-- ----------------------------------------------------------------------------
+-- execute: write a request JSON the server picks up
+-- ----------------------------------------------------------------------------
+
+local function world_to_rel(p, fp)
+  return p.x - fp.x, p.y - fp.y
+end
+
+local function in_footprint(rel_x, rel_y, fp)
+  return rel_x >= 0 and rel_x < fp.w and rel_y >= 0 and rel_y < fp.h
+end
+
+local function new_request_id()
+  return string.format("%d-%d-%d", game.tick,
+    math.random(0, 2^30), math.random(0, 2^30))
+end
+
+local function build_footprint_mask(fp)
+  -- For now: every tile in the bbox is buildable. Later we may let the
+  -- player exclude tiles inside the bbox.
+  local tiles = {}
+  for y = 0, fp.h - 1 do
+    for x = 0, fp.w - 1 do
+      table.insert(tiles, { x, y })
+    end
+  end
+  return tiles
+end
+
+local function gather_request(state, player_index)
+  local fp = state.footprint
+  local size = get_grid_size()
+  local default_item = get_default_item()
+
+  local sources = {}
+  for _, s in ipairs(state.sources) do
+    local rx, ry = world_to_rel(s, fp)
+    if in_footprint(rx, ry, fp) then
+      table.insert(sources, {
+        x = rx, y = ry,
+        direction = dir_toward_center(rx, ry, size),
+        item = default_item,
+      })
+    end
+  end
+
+  local sinks = {}
+  for _, s in ipairs(state.sinks) do
+    local rx, ry = world_to_rel(s, fp)
+    if in_footprint(rx, ry, fp) then
+      -- Sink "faces" the same way (into the footprint). The server
+      -- knows the difference because we put it in the sinks array.
+      table.insert(sinks, {
+        x = rx, y = ry,
+        direction = dir_toward_center(rx, ry, size),
+        item = default_item,
+      })
+    end
+  end
+
+  return {
+    request_id    = new_request_id(),
+    player_index  = player_index,
+    grid_size     = size,
+    footprint     = build_footprint_mask(fp),
+    sources       = sources,
+    sinks         = sinks,
+    default_item  = default_item,
+  }
+end
+
+local function json_encode(t)
+  -- Factorio 2.0 exposes helpers.table_to_json; the older `game.table_to_json`
+  -- is deprecated but kept for compat. Prefer helpers when present.
+  if helpers and helpers.table_to_json then
+    return helpers.table_to_json(t)
+  end
+  return game.table_to_json(t)
+end
+
+script.on_event("factorion-execute", function(event)
+  local player = game.get_player(event.player_index)
+  if not player then return end
+  local state = ensure_player_state(event.player_index)
+  ensure_pending_lookup()
+
+  if not state.footprint then
+    player.print("[Factorion] No footprint set.")
+    return
+  end
+  if #state.sources == 0 and #state.sinks == 0 then
+    player.print("[Factorion] No sources or sinks marked.")
+    return
+  end
+
+  local request = gather_request(state, event.player_index)
+  table.insert(storage.outbox, json_encode(request))
+  storage.pending_by_request[request.request_id] = event.player_index
+  state.pending = { request_id = request.request_id, tick = game.tick }
+
+  player.print(string.format(
+    "[Factorion] Request %s queued (outbox depth %d). " ..
+    "Waiting for the server to poll and reply…",
+    request.request_id, #storage.outbox))
+end)
+
+-- ----------------------------------------------------------------------------
+-- RCON interface: server pushes the prediction back here
+-- ----------------------------------------------------------------------------
+
+remote.add_interface("factorion", {
+  -- The server's poll: pop and return the oldest pending request JSON, or
+  -- "" if the queue is empty. The server wraps the call in
+  -- `/silent-command rcon.print(remote.call('factorion','poll_request'))`
+  -- so whatever we return here ends up in the RCON response stream.
+  poll_request = function()
+    storage.outbox = storage.outbox or {}
+    if #storage.outbox == 0 then return "" end
+    return table.remove(storage.outbox, 1)
+  end,
+
+  -- Called via RCON: remote.call("factorion","deliver_blueprint", req_id, bp_str)
+  deliver_blueprint = function(request_id, blueprint_string)
+    ensure_pending_lookup()
+    local player_index = storage.pending_by_request[request_id]
+    if not player_index then
+      log("[Factorion] deliver_blueprint: unknown request_id " .. tostring(request_id))
+      return false
+    end
+    storage.pending_by_request[request_id] = nil
+
+    -- player_index == 0 is the headless-test sentinel: log the blueprint
+    -- to factorio-current.log instead of trying to inject into a cursor
+    -- that doesn't exist (no player connected in --start-server-load-
+    -- scenario without admin auth).
+    if player_index == 0 then
+      log("[Factorion] (headless) blueprint for " .. tostring(request_id) ..
+        " (" .. tostring(#blueprint_string) .. " chars): " ..
+        string.sub(blueprint_string, 1, 80) .. "...")
+      return true
+    end
+
+    local player = game.get_player(player_index)
+    if not player then return false end
+
+    local cursor = player.cursor_stack
+    if not cursor then
+      player.print("[Factorion] No cursor_stack available.")
+      return false
+    end
+    if not cursor.is_empty() then
+      cursor.clear()
+    end
+    if not cursor.set_stack({ name = "blueprint", count = 1 }) then
+      player.print("[Factorion] Could not place blueprint in cursor.")
+      return false
+    end
+
+    local rc = cursor.import_stack(blueprint_string)
+    if rc < 0 then
+      player.print(string.format(
+        "[Factorion] Blueprint imported with warnings (rc=%d).", rc))
+    elseif rc > 0 then
+      player.print("[Factorion] Blueprint import failed.")
+      cursor.clear()
+      return false
+    else
+      player.print("[Factorion] Prediction ready. Paste it on your footprint.")
+    end
+
+    local state = ensure_player_state(player_index)
+    state.pending = nil
+    return true
+  end,
+
+  -- Diagnostic: server can call this to check the mod is alive.
+  ping = function()
+    return "factorion-mod alive at tick " .. tostring(game.tick)
+  end,
+
+  -- Headless / debug: enqueue a request JSON as if the hotkey had fired.
+  -- /silent-command runs in *level scope*, not any mod's, so storage is
+  -- inaccessible from RCON directly — this interface is the only way to
+  -- poke an outbox entry in from outside the game.
+  --
+  -- Caller supplies the request JSON and a player_index to deliver the
+  -- response to. In headless tests with no player connected, pass 0 to
+  -- signal "log the blueprint string instead of injecting into a cursor".
+  inject_request = function(request_json, deliver_to_player_index)
+    storage.outbox = storage.outbox or {}
+    storage.pending_by_request = storage.pending_by_request or {}
+    table.insert(storage.outbox, request_json)
+    -- Parse to extract request_id; helpers.json_to_table is the 2.0+ API.
+    local ok, parsed = pcall(function() return helpers.json_to_table(request_json) end)
+    if ok and parsed and parsed.request_id then
+      storage.pending_by_request[parsed.request_id] =
+        deliver_to_player_index or 0
+    end
+    return "queued, depth=" .. #storage.outbox
+  end,
+
+  -- Headless / debug: introspect mod storage from outside.
+  introspect = function()
+    storage.outbox = storage.outbox or {}
+    storage.pending_by_request = storage.pending_by_request or {}
+    local pending_n = 0
+    for _ in pairs(storage.pending_by_request) do pending_n = pending_n + 1 end
+    return string.format("outbox=%d pending=%d players=%d",
+      #storage.outbox, pending_n,
+      storage.players and table_size(storage.players) or 0)
+  end,
+})
+
+-- ----------------------------------------------------------------------------
+-- migrations
+-- ----------------------------------------------------------------------------
+
+script.on_init(function()
+  storage.players = {}
+  storage.pending_by_request = {}
+  storage.outbox = {}
+end)
+
+script.on_configuration_changed(function()
+  storage.players = storage.players or {}
+  storage.pending_by_request = storage.pending_by_request or {}
+  storage.outbox = storage.outbox or {}
+end)

--- a/factorion-mod/mod/control.lua
+++ b/factorion-mod/mod/control.lua
@@ -269,35 +269,112 @@ local function build_footprint_mask(fp)
   return tiles
 end
 
+-- Map our arrow virtual signals to the Factorion Direction enum.
+local ARROW_TO_DIR = {
+  ["up-arrow"] = 1, ["right-arrow"] = 2,
+  ["down-arrow"] = 3, ["left-arrow"] = 4,
+}
+
+local function parse_combinator_marker(combi)
+  -- Inspect a constant-combinator's first section for our identifying
+  -- filters: signal-output / signal-input + arrow + item. Returns
+  --   { role="source"|"sink", item=<name>, direction=<1..4> }
+  -- or nil if this combinator isn't one of our markers.
+  local cb = combi.get_control_behavior()
+  if not cb or not cb.sections then return nil end
+  for _, section in pairs(cb.sections) do
+    local item_name, role, direction = nil, nil, nil
+    local n = section.filters_count or 0
+    for i = 1, n do
+      local f = section.get_slot(i)
+      if f and f.value and f.value.name then
+        local name = f.value.name
+        local typ = f.value.type
+        if name == "signal-output" then role = "source"
+        elseif name == "signal-input" then role = "sink"
+        elseif ARROW_TO_DIR[name] then direction = ARROW_TO_DIR[name]
+        elseif typ == nil or typ == "item" then item_name = name
+        end
+      end
+    end
+    if role then
+      return { role = role, item = item_name, direction = direction or 2 }
+    end
+  end
+  return nil
+end
+
+local function scan_footprint_for_markers(player, fp)
+  -- Returns (sources, sinks), each a list of {x_world, y_world, direction, item}.
+  -- Coordinates are world tiles (floor of the combinator's centre).
+  local sources, sinks = {}, {}
+  if not player or not player.surface then return sources, sinks end
+  local found = player.surface.find_entities_filtered{
+    area = { { fp.x, fp.y }, { fp.x + fp.w, fp.y + fp.h } },
+    name = "constant-combinator",
+  }
+  for _, combi in pairs(found) do
+    local m = parse_combinator_marker(combi)
+    if m then
+      local entry = {
+        x = math.floor(combi.position.x),
+        y = math.floor(combi.position.y),
+        direction = m.direction,
+        item = m.item,
+      }
+      if m.role == "source" then
+        table.insert(sources, entry)
+      else
+        table.insert(sinks, entry)
+      end
+    end
+  end
+  return sources, sinks
+end
+
 local function gather_request(state, player_index)
   local fp = state.footprint
   local size = get_grid_size()
   local default_item = get_default_item()
+  local player = game.get_player(player_index)
+
+  -- Prefer in-world constant-combinators with our identifying filters.
+  -- Falls back to the click-tool state lists if no combinators are
+  -- found inside the footprint.
+  local from_world_src, from_world_snk = scan_footprint_for_markers(player, fp)
+  local raw_sources = (#from_world_src > 0) and from_world_src or state.sources
+  local raw_sinks = (#from_world_snk > 0) and from_world_snk or state.sinks
+  local source_provenance = (#from_world_src > 0) and "combinator" or "click-tool"
+  local sink_provenance = (#from_world_snk > 0) and "combinator" or "click-tool"
 
   local sources = {}
-  for _, s in ipairs(state.sources) do
+  for _, s in ipairs(raw_sources) do
     local rx, ry = world_to_rel(s, fp)
     if in_footprint(rx, ry, fp) then
       table.insert(sources, {
         x = rx, y = ry,
-        direction = dir_toward_center(rx, ry, size),
-        item = default_item,
+        direction = s.direction or dir_toward_center(rx, ry, size),
+        item = s.item or default_item,
       })
     end
   end
 
   local sinks = {}
-  for _, s in ipairs(state.sinks) do
+  for _, s in ipairs(raw_sinks) do
     local rx, ry = world_to_rel(s, fp)
     if in_footprint(rx, ry, fp) then
-      -- Sink "faces" the same way (into the footprint). The server
-      -- knows the difference because we put it in the sinks array.
       table.insert(sinks, {
         x = rx, y = ry,
-        direction = dir_toward_center(rx, ry, size),
-        item = default_item,
+        direction = s.direction or dir_toward_center(rx, ry, size),
+        item = s.item or default_item,
       })
     end
+  end
+
+  if player then
+    player.print(string.format(
+      "[Factorion] %d source(s) from %s, %d sink(s) from %s.",
+      #sources, source_provenance, #sinks, sink_provenance))
   end
 
   return {
@@ -330,12 +407,18 @@ script.on_event("factorion-execute", function(event)
     player.print("[Factorion] No footprint set.")
     return
   end
-  if #state.sources == 0 and #state.sinks == 0 then
-    player.print("[Factorion] No sources or sinks marked.")
+
+  -- gather_request prefers in-world constant-combinators inside the
+  -- footprint; if there are none AND no click-marked sources/sinks
+  -- exist either, the resulting request will be empty.
+  local request = gather_request(state, event.player_index)
+  if #request.sources == 0 and #request.sinks == 0 then
+    player.print(
+      "[Factorion] No sources or sinks found. Place a constant-combinator " ..
+      "inside the footprint with signal-output/signal-input + an arrow + " ..
+      "an item, or use the marker tool.")
     return
   end
-
-  local request = gather_request(state, event.player_index)
   local request_json = json_encode(request)
   table.insert(storage.outbox, request_json)
   storage.pending_by_request[request.request_id] = event.player_index

--- a/factorion-mod/mod/control.lua
+++ b/factorion-mod/mod/control.lua
@@ -118,8 +118,10 @@ script.on_event(defines.events.on_player_selected_area, function(event)
     state.sources = {}
     state.sinks = {}
     player.print(string.format(
-      "[Factorion] Footprint set: (%d,%d) +%dx%d. Now mark sources/sinks.",
-      bbox.x, bbox.y, bbox.w, bbox.h))
+      "[Factorion] Footprint set: x=%d..%d (%d wide), y=%d..%d (%d tall). " ..
+      "Mark sources/sinks WITHIN these bounds.",
+      bbox.x, bbox.x + bbox.w - 1, bbox.w,
+      bbox.y, bbox.y + bbox.h - 1, bbox.h))
 
   elseif event.item == "factorion-marker-tool" then
     -- left-click = sources
@@ -127,14 +129,30 @@ script.on_event(defines.events.on_player_selected_area, function(event)
       player.print("[Factorion] Set a footprint first.")
       return
     end
-    local added_positions = {}
+    local added, skipped = {}, {}
+    local fp = state.footprint
     for _, tile in pairs(event.tiles or {}) do
-      table.insert(state.sources, { x = tile.position.x, y = tile.position.y })
-      table.insert(added_positions,
-        string.format("(%d,%d)", tile.position.x, tile.position.y))
+      local tx, ty = tile.position.x, tile.position.y
+      if tx >= fp.x and tx < fp.x + fp.w
+         and ty >= fp.y and ty < fp.y + fp.h then
+        table.insert(state.sources, { x = tx, y = ty })
+        table.insert(added, string.format("(%d,%d)", tx, ty))
+      else
+        table.insert(skipped, string.format("(%d,%d)", tx, ty))
+      end
     end
-    player.print(string.format("[Factorion] +%d source(s) at %s; total %d.",
-      #(event.tiles or {}), table.concat(added_positions, ","), #state.sources))
+    if #added > 0 then
+      player.print(string.format(
+        "[Factorion] +%d source(s) at %s; total %d.",
+        #added, table.concat(added, ","), #state.sources))
+    end
+    if #skipped > 0 then
+      player.print(string.format(
+        "[Factorion] Skipped %d source mark(s) outside footprint: %s. " ..
+        "Valid x=%d..%d y=%d..%d.",
+        #skipped, table.concat(skipped, ","),
+        fp.x, fp.x + fp.w - 1, fp.y, fp.y + fp.h - 1))
+    end
   end
 end)
 
@@ -159,16 +177,30 @@ local function handle_sink_select(event, mode_name)
       player.print("[Factorion] Set a footprint first.")
       return
     end
-    local added_positions = {}
+    local added, skipped = {}, {}
+    local fp = state.footprint
     for _, tile in pairs(event.tiles or {}) do
-      table.insert(state.sinks, { x = tile.position.x, y = tile.position.y })
-      table.insert(added_positions,
-        string.format("(%d,%d)", tile.position.x, tile.position.y))
+      local tx, ty = tile.position.x, tile.position.y
+      if tx >= fp.x and tx < fp.x + fp.w
+         and ty >= fp.y and ty < fp.y + fp.h then
+        table.insert(state.sinks, { x = tx, y = ty })
+        table.insert(added, string.format("(%d,%d)", tx, ty))
+      else
+        table.insert(skipped, string.format("(%d,%d)", tx, ty))
+      end
     end
-    player.print(string.format(
-      "[Factorion] +%d sink(s) at %s; total %d. (via %s)",
-      #(event.tiles or {}), table.concat(added_positions, ","),
-      #state.sinks, mode_name))
+    if #added > 0 then
+      player.print(string.format(
+        "[Factorion] +%d sink(s) at %s; total %d. (via %s)",
+        #added, table.concat(added, ","), #state.sinks, mode_name))
+    end
+    if #skipped > 0 then
+      player.print(string.format(
+        "[Factorion] Skipped %d sink mark(s) outside footprint: %s. " ..
+        "Valid x=%d..%d y=%d..%d.",
+        #skipped, table.concat(skipped, ","),
+        fp.x, fp.x + fp.w - 1, fp.y, fp.y + fp.h - 1))
+    end
   end
 end
 

--- a/factorion-mod/mod/data.lua
+++ b/factorion-mod/mod/data.lua
@@ -1,0 +1,2 @@
+require("prototypes.selection-tools")
+require("prototypes.custom-inputs")

--- a/factorion-mod/mod/info.json
+++ b/factorion-mod/mod/info.json
@@ -1,0 +1,11 @@
+{
+  "name": "factorion",
+  "version": "0.1.0",
+  "title": "Factorion",
+  "author": "Factorion",
+  "contact": "",
+  "homepage": "",
+  "description": "Bridge to a locally-running Factorion ML model: select a footprint with sources and sinks, get back a blueprint predicted by the policy.",
+  "factorio_version": "2.0",
+  "dependencies": ["base >= 2.0.0"]
+}

--- a/factorion-mod/mod/locale/en/factorion.cfg
+++ b/factorion-mod/mod/locale/en/factorion.cfg
@@ -1,0 +1,20 @@
+[item-name]
+factorion-footprint-tool=Factorion footprint tool
+factorion-marker-tool=Factorion source/sink marker
+
+[item-description]
+factorion-footprint-tool=Drag-select the rectangular region the model is allowed to place entities in.
+factorion-marker-tool=Left-click: mark tiles as input sources. Right-click: mark tiles as output sinks.
+
+[controls]
+factorion-execute=Factorion: request prediction
+factorion-reset=Factorion: clear footprint, sources and sinks
+factorion-give-tools=Factorion: give selection tools
+
+[mod-setting-name]
+factorion-grid-size=Factorion grid size
+factorion-default-item=Factorion default item
+
+[mod-setting-description]
+factorion-grid-size=Edge length (tiles) of the footprint the model expects. Must match what the checkpoint was trained on.
+factorion-default-item=Item that flows through source → sink for prediction requests until a per-source item picker is added.

--- a/factorion-mod/mod/prototypes/custom-inputs.lua
+++ b/factorion-mod/mod/prototypes/custom-inputs.lua
@@ -2,19 +2,19 @@ data:extend({
   {
     type = "custom-input",
     name = "factorion-execute",
-    key_sequence = "CONTROL + SHIFT + P",
+    key_sequence = "CONTROL + P",
     consuming = "none",
   },
   {
     type = "custom-input",
     name = "factorion-reset",
-    key_sequence = "CONTROL + SHIFT + R",
+    key_sequence = "CONTROL + R",
     consuming = "none",
   },
   {
     type = "custom-input",
     name = "factorion-give-tools",
-    key_sequence = "CONTROL + SHIFT + T",
+    key_sequence = "CONTROL + T",
     consuming = "none",
   },
 })

--- a/factorion-mod/mod/prototypes/custom-inputs.lua
+++ b/factorion-mod/mod/prototypes/custom-inputs.lua
@@ -1,0 +1,20 @@
+data:extend({
+  {
+    type = "custom-input",
+    name = "factorion-execute",
+    key_sequence = "CONTROL + SHIFT + P",
+    consuming = "none",
+  },
+  {
+    type = "custom-input",
+    name = "factorion-reset",
+    key_sequence = "CONTROL + SHIFT + R",
+    consuming = "none",
+  },
+  {
+    type = "custom-input",
+    name = "factorion-give-tools",
+    key_sequence = "CONTROL + SHIFT + T",
+    consuming = "none",
+  },
+})

--- a/factorion-mod/mod/prototypes/selection-tools.lua
+++ b/factorion-mod/mod/prototypes/selection-tools.lua
@@ -1,0 +1,56 @@
+-- Two selection tools the player uses to describe the prediction request:
+--   factorion-footprint-tool  drag-select an N×N region (the buildable area)
+--   factorion-marker-tool     left-click tiles to mark sources,
+--                             right-click (alt-select) to mark sinks
+--
+-- Both are spawned into the player's inventory the first time they join.
+-- See control.lua for the actual event wiring.
+
+local empty_sprite = {
+  filename = "__core__/graphics/empty.png",
+  priority = "extra-high",
+  width = 1,
+  height = 1,
+}
+
+data:extend({
+  {
+    type = "selection-tool",
+    name = "factorion-footprint-tool",
+    icon = "__base__/graphics/icons/blueprint.png",
+    icon_size = 64,
+    flags = { "only-in-cursor", "spawnable", "not-stackable" },
+    stack_size = 1,
+    stackable = false,
+    select = {
+      border_color = { r = 0.2, g = 0.6, b = 1.0 },
+      mode = { "any-tile" },
+      cursor_box_type = "copy",
+    },
+    alt_select = {
+      border_color = { r = 0.6, g = 0.2, b = 1.0 },
+      mode = { "any-tile" },
+      cursor_box_type = "copy",
+    },
+  },
+  {
+    type = "selection-tool",
+    name = "factorion-marker-tool",
+    icon = "__base__/graphics/icons/iron-plate.png",
+    icon_size = 64,
+    flags = { "only-in-cursor", "spawnable", "not-stackable" },
+    stack_size = 1,
+    stackable = false,
+    -- Left-click: add sources. Right-click (alt): add sinks.
+    select = {
+      border_color = { r = 0.2, g = 1.0, b = 0.2 },
+      mode = { "any-tile" },
+      cursor_box_type = "entity",
+    },
+    alt_select = {
+      border_color = { r = 1.0, g = 0.4, b = 0.2 },
+      mode = { "any-tile" },
+      cursor_box_type = "entity",
+    },
+  },
+})

--- a/factorion-mod/mod/settings.lua
+++ b/factorion-mod/mod/settings.lua
@@ -1,0 +1,18 @@
+data:extend({
+  {
+    type = "int-setting",
+    name = "factorion-grid-size",
+    setting_type = "runtime-global",
+    default_value = 8,
+    minimum_value = 4,
+    maximum_value = 16,
+    order = "a",
+  },
+  {
+    type = "string-setting",
+    name = "factorion-default-item",
+    setting_type = "runtime-global",
+    default_value = "iron-plate",
+    order = "b",
+  },
+})

--- a/factorion-mod/scripts/install_mod.sh
+++ b/factorion-mod/scripts/install_mod.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Symlink the mod/ directory into Factorio's mods/ folder so changes to
+# control.lua and friends are picked up on the next /mods reload (no zip
+# step needed during development).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MOD_SRC="$(cd "$SCRIPT_DIR/../mod" && pwd)"
+
+# Read the internal name + version from info.json
+NAME=$(grep -E '^\s*"name"' "$MOD_SRC/info.json" | head -1 | sed -E 's/.*"name"\s*:\s*"([^"]+)".*/\1/')
+VERSION=$(grep -E '^\s*"version"' "$MOD_SRC/info.json" | head -1 | sed -E 's/.*"version"\s*:\s*"([^"]+)".*/\1/')
+
+case "$(uname -s)" in
+  Darwin*) FACTORIO_DIR="$HOME/Library/Application Support/factorio" ;;
+  Linux*)  FACTORIO_DIR="$HOME/.factorio" ;;
+  MINGW*|MSYS*|CYGWIN*) FACTORIO_DIR="${APPDATA:-$HOME/AppData/Roaming}/Factorio" ;;
+  *)       echo "Unsupported OS: $(uname -s)" >&2; exit 1 ;;
+esac
+
+MODS_DIR="$FACTORIO_DIR/mods"
+if [[ ! -d "$MODS_DIR" ]]; then
+  echo "Factorio mods dir not found at $MODS_DIR — launch Factorio once to create it." >&2
+  exit 1
+fi
+
+TARGET="$MODS_DIR/${NAME}_${VERSION}"
+
+if [[ -L "$TARGET" || -e "$TARGET" ]]; then
+  echo "Removing existing $TARGET"
+  rm -rf "$TARGET"
+fi
+
+ln -s "$MOD_SRC" "$TARGET"
+echo "Linked $MOD_SRC -> $TARGET"
+
+# Make sure mod-list.json enables the mod (idempotent).
+MOD_LIST="$MODS_DIR/mod-list.json"
+if [[ -f "$MOD_LIST" ]]; then
+  if ! grep -q "\"$NAME\"" "$MOD_LIST"; then
+    echo "Note: '$NAME' is not in mod-list.json yet. Enable it from the in-game Mods menu."
+  fi
+else
+  echo "Note: mod-list.json missing — Factorio will create one on next launch."
+fi
+
+echo "Done. Launch Factorio and enable the mod from the Mods menu if it isn't already."

--- a/factorion-mod/scripts/launch.sh
+++ b/factorion-mod/scripts/launch.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Launch Factorio with RCON enabled (auto-generated port + password) and
+# start the Factorion model server pointed at the same RCON endpoint.
+# Wraps the flags the user would otherwise have to remember — they only
+# pass --checkpoint.
+#
+# Usage:
+#   factorion-mod/scripts/launch.sh path/to/agent.pt [extra server flags...]
+#
+# Env overrides:
+#   FACTORIO_BIN   path to the factorio binary (auto-detected per OS)
+#   RCON_PORT      port to bind (default: random free port in 27000..27999)
+#   RCON_PASSWORD  RCON password (default: random hex)
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <checkpoint.pt> [extra server flags...]" >&2
+  exit 1
+fi
+CHECKPOINT="$1"
+shift
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# ----- locate factorio binary ------------------------------------------------
+case "$(uname -s)" in
+  Darwin*)
+    DEFAULT_BINS=(
+      "/Applications/factorio.app/Contents/MacOS/factorio"
+      "$HOME/Library/Application Support/Steam/steamapps/common/Factorio/factorio.app/Contents/MacOS/factorio"
+    )
+    ;;
+  Linux*)
+    DEFAULT_BINS=(
+      "$HOME/.factorio/bin/x64/factorio"
+      "$HOME/.local/share/Steam/steamapps/common/Factorio/bin/x64/factorio"
+      "/usr/share/factorio/bin/x64/factorio"
+    )
+    ;;
+  MINGW*|MSYS*|CYGWIN*)
+    DEFAULT_BINS=(
+      "/c/Program Files/Factorio/bin/x64/factorio.exe"
+      "/c/Program Files (x86)/Steam/steamapps/common/Factorio/bin/x64/factorio.exe"
+    )
+    ;;
+  *) echo "Unsupported OS: $(uname -s)" >&2; exit 1 ;;
+esac
+
+if [[ -z "${FACTORIO_BIN:-}" ]]; then
+  for candidate in "${DEFAULT_BINS[@]}"; do
+    if [[ -x "$candidate" ]]; then FACTORIO_BIN="$candidate"; break; fi
+  done
+fi
+
+if [[ -z "${FACTORIO_BIN:-}" || ! -x "$FACTORIO_BIN" ]]; then
+  echo "Could not find Factorio binary. Set FACTORIO_BIN, e.g.:" >&2
+  echo "  FACTORIO_BIN=/path/to/factorio $0 $CHECKPOINT" >&2
+  exit 1
+fi
+
+# ----- pick port + password --------------------------------------------------
+pick_free_port() {
+  python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PY
+}
+
+: "${RCON_PORT:=$(pick_free_port)}"
+: "${RCON_PASSWORD:=$(python3 -c 'import secrets; print(secrets.token_hex(16))')}"
+
+echo "[launch] Factorio binary : $FACTORIO_BIN"
+echo "[launch] RCON port       : $RCON_PORT"
+echo "[launch] RCON password   : (hidden)"
+
+# ----- spawn Factorio --------------------------------------------------------
+"$FACTORIO_BIN" \
+  --rcon-bind "127.0.0.1:$RCON_PORT" \
+  --rcon-password "$RCON_PASSWORD" \
+  &
+FACTORIO_PID=$!
+echo "[launch] Factorio pid    : $FACTORIO_PID"
+
+cleanup() {
+  echo "[launch] Stopping…"
+  if kill -0 "$FACTORIO_PID" 2>/dev/null; then
+    kill "$FACTORIO_PID" 2>/dev/null || true
+  fi
+  if [[ -n "${SERVER_PID:-}" ]] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill "$SERVER_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+# Wait for the RCON port to accept connections. Factorio opens it only
+# once a save (or the title screen, depending on version) is fully loaded,
+# so this can take a few seconds. The server itself has reconnect logic
+# but giving it a head start avoids a spurious "auth failed" on launch.
+echo "[launch] Waiting for Factorio RCON on 127.0.0.1:$RCON_PORT …"
+for _ in $(seq 1 60); do
+  if python3 -c "import socket,sys; s=socket.socket(); s.settimeout(0.25); sys.exit(0 if s.connect_ex(('127.0.0.1', $RCON_PORT))==0 else 1)" 2>/dev/null; then
+    echo "[launch] RCON listening."
+    break
+  fi
+  sleep 1
+done
+
+# ----- start the server ------------------------------------------------------
+cd "$REPO_ROOT"
+echo "[launch] Starting Factorion server (uv run python factorion-mod/server/server.py)…"
+uv run python factorion-mod/server/server.py \
+  --checkpoint "$CHECKPOINT" \
+  --rcon-host 127.0.0.1 \
+  --rcon-port "$RCON_PORT" \
+  --rcon-password "$RCON_PASSWORD" \
+  "$@" &
+SERVER_PID=$!
+
+wait "$FACTORIO_PID"

--- a/factorion-mod/server/README.md
+++ b/factorion-mod/server/README.md
@@ -1,0 +1,104 @@
+# Factorion server
+
+Loads a trained Factorion `AgentCNN` checkpoint, polls a running
+Factorio instance over RCON for prediction requests, runs iterative
+greedy inference, and pushes the resulting blueprint back via the same
+RCON connection.
+
+## Run
+
+Easiest path: use the launcher in `scripts/`, which spawns Factorio +
+server together with auto-generated RCON port/password:
+
+```bash
+bash factorion-mod/scripts/launch.sh path/to/agent.pt
+```
+
+Manual path:
+
+```bash
+# from the repo root, so `factorion` and `factorion_rs` import cleanly
+uv run python factorion-mod/server/server.py \
+  --checkpoint path/to/agent.pt \
+  --rcon-host 127.0.0.1 \
+  --rcon-port 27015 \
+  --rcon-password factorion
+```
+
+If you go manual, start Factorio with matching flags:
+
+```bash
+factorio --rcon-bind 127.0.0.1:27015 --rcon-password factorion
+```
+
+Required flags for the server:
+
+- `--checkpoint` — the `torch.save(agent.state_dict(), ...)` file from
+  PPO (`runs/<run>/agent.pt`) or SFT (`sft_runs/<run>/agent.pt`).
+- `--rcon-port` / `--rcon-password` — must match what Factorio was
+  launched with.
+
+Architecture knobs (must match how the checkpoint was trained):
+
+- `--grid-size 8` (default 8)
+- `--chan1 32 --chan2 64 --chan3 64`
+
+If you put a sidecar JSON next to the checkpoint named `agent.hp.json`
+with `{"grid_size": 8, "chan1": 32, ...}`, the server reads it
+automatically (CLI flags override only when explicitly non-default).
+
+## Protocol
+
+The server runs a poll loop. Every 250 ms it sends, over RCON:
+
+```
+/silent-command rcon.print(remote.call('factorion','poll_request'))
+```
+
+The mod's `poll_request` returns either an empty string (queue empty)
+or the next pending request JSON:
+
+```json
+{
+  "request_id": "1234-5-7",
+  "player_index": 1,
+  "grid_size": 8,
+  "footprint": [[0, 0], [0, 1], ...],
+  "sources": [{"x": 0, "y": 3, "direction": 2, "item": "iron-plate"}],
+  "sinks":   [{"x": 7, "y": 3, "direction": 2, "item": "iron-plate"}],
+  "default_item": "iron-plate"
+}
+```
+
+`direction` uses Factorion's enum (1=N, 2=E, 3=S, 4=W), *not* Factorio's
+16-step blueprint convention; the server converts before emitting.
+
+The server's response leg goes back over the same RCON connection:
+
+```
+/silent-command remote.call('factorion','deliver_blueprint','<req_id>','<bp_b64>')
+```
+
+The mod's `deliver_blueprint` handler looks up which player asked, sets
+their cursor stack to a blueprint, and `import_stack`s the b64 string.
+
+## Reconnect
+
+The poll loop survives Factorio restarts: on `RconError` / `OSError`,
+it closes the socket, sleeps 2 s, and tries `connect()` again. So you
+can leave the server running across save reloads or even full Factorio
+relaunches.
+
+## Debugging without Factorio
+
+Spin up `nc` as a fake RCON endpoint to verify the wire format, or run
+just the inference path:
+
+```python
+from server import load_agent, request_to_obs, run_inference
+from blueprint import world_tensor_to_blueprint_string
+import torch
+agent = load_agent(...)
+obs = run_inference(agent, fake_req, max_steps=64, device=torch.device("cpu"))
+print(world_tensor_to_blueprint_string(obs))
+```

--- a/factorion-mod/server/blueprint.py
+++ b/factorion-mod/server/blueprint.py
@@ -54,7 +54,12 @@ def _make_entity(
     return e
 
 
-def world_tensor_to_blueprint_dict(world_CWH: np.ndarray) -> dict:
+def world_tensor_to_blueprint_dict(
+    world_CWH: np.ndarray,
+    *,
+    label: str | None = None,
+    description: str | None = None,
+) -> dict:
     """Convert a (channels, W, H) numpy tensor to a Factorio blueprint dict.
 
     Skips:
@@ -138,14 +143,24 @@ def world_tensor_to_blueprint_dict(world_CWH: np.ndarray) -> dict:
     for i, e in enumerate(out_entities, start=1):
         e["entity_number"] = i
 
-    return {
-        "blueprint": {
-            "entities": out_entities,
-            "item": "blueprint",
-            "version": 281479275675648,  # Factorio 2.0 version stamp
-        }
+    bp: dict = {
+        "entities": out_entities,
+        "item": "blueprint",
+        "version": 281479275675648,  # Factorio 2.0 version stamp
     }
+    if label is not None:
+        bp["label"] = label
+    if description is not None:
+        bp["description"] = description
+    return {"blueprint": bp}
 
 
-def world_tensor_to_blueprint_string(world_CWH: np.ndarray) -> str:
-    return dict2b64(world_tensor_to_blueprint_dict(world_CWH))
+def world_tensor_to_blueprint_string(
+    world_CWH: np.ndarray,
+    *,
+    label: str | None = None,
+    description: str | None = None,
+) -> str:
+    return dict2b64(world_tensor_to_blueprint_dict(
+        world_CWH, label=label, description=description,
+    ))

--- a/factorion-mod/server/blueprint.py
+++ b/factorion-mod/server/blueprint.py
@@ -23,9 +23,18 @@ from factorion import Channel, Misc, dict2b64, entities, items
 
 _DIR_MODEL_TO_BP = {0: None, 1: 0, 2: 4, 3: 8, 4: 12}
 
-# Source/sink are flagged is_placeable=True in the catalogue but they're
-# env-spawned, not blueprint-pasteable. Skip them by name when encoding.
-_SKIP_ENTITY_NAMES = {"stack_inserter", "bulk_inserter"}
+# The mod's source / sink markers live as stack_inserter / bulk_inserter in
+# the obs tensor (they're env-spawned, never placed by the model). For the
+# emitted blueprint, render them as actual placeable Factorio entities so
+# the pasted blueprint visibly shows the source/sink:
+#   - source → infinity-chest with an infinity_settings filter for the
+#     source item (it auto-spawns that item, infinite supply).
+#   - sink   → bottomless-chest (debug void entity that destroys whatever
+#     is inserted).
+_SOURCE_MARKER_NAME = "stack_inserter"
+_SINK_MARKER_NAME = "bulk_inserter"
+_SOURCE_REPLACEMENT = "infinity-chest"
+_SINK_REPLACEMENT = "bottomless-chest"
 
 
 def _hyphenate(name: str) -> str:
@@ -93,10 +102,6 @@ def world_tensor_to_blueprint_dict(
             ent_meta = entities.get(ent_id)
             if ent_meta is None or not ent_meta.is_placeable:
                 continue
-            if ent_meta.name in _SKIP_ENTITY_NAMES:
-                # Source/sink markers — pre-existing in the request, not
-                # part of the model's output, never belong in the blueprint.
-                continue
 
             dir_model = int(dir_ch[x, y])
             dir_bp = _DIR_MODEL_TO_BP.get(dir_model, None)
@@ -105,6 +110,39 @@ def world_tensor_to_blueprint_dict(
             # tile span. For 1×1 this is +0.5 on both axes.
             cx = x + ent_meta.width / 2.0
             cy = y + ent_meta.height / 2.0
+
+            # Source/sink markers from the request: re-render as visible
+            # chest entities so the player can see them in the blueprint.
+            if ent_meta.name == _SOURCE_MARKER_NAME:
+                item_id = int(item_ch[x, y])
+                item_meta = items.get(item_id)
+                inf_settings: dict | None = None
+                if item_meta is not None and item_meta.name != "empty":
+                    inf_settings = {
+                        "remove_unfiltered_items": False,
+                        "filters": [{
+                            "name": _hyphenate(item_meta.name),
+                            "count": 200,
+                            "mode": "at-least",
+                            "index": 1,
+                        }],
+                    }
+                src_entity: dict = {
+                    "name": _SOURCE_REPLACEMENT,
+                    "position": {"x": cx, "y": cy},
+                }
+                if inf_settings is not None:
+                    src_entity["infinity_settings"] = inf_settings
+                out_entities.append(src_entity)
+                seen[x, y] = True
+                continue
+            if ent_meta.name == _SINK_MARKER_NAME:
+                out_entities.append({
+                    "name": _SINK_REPLACEMENT,
+                    "position": {"x": cx, "y": cy},
+                })
+                seen[x, y] = True
+                continue
 
             name = _hyphenate(ent_meta.name)
             recipe: str | None = None

--- a/factorion-mod/server/blueprint.py
+++ b/factorion-mod/server/blueprint.py
@@ -25,16 +25,75 @@ _DIR_MODEL_TO_BP = {0: None, 1: 0, 2: 4, 3: 8, 4: 12}
 
 # The mod's source / sink markers live as stack_inserter / bulk_inserter in
 # the obs tensor (they're env-spawned, never placed by the model). For the
-# emitted blueprint, render them as actual placeable Factorio entities so
-# the pasted blueprint visibly shows the source/sink:
-#   - source → infinity-chest with an infinity_settings filter for the
-#     source item (it auto-spawns that item, infinite supply).
-#   - sink   → bottomless-chest (debug void entity that destroys whatever
-#     is inserted).
+# emitted blueprint, render them as `constant-combinator` entities carrying
+# two filter signals in their first section:
+#   - the item that flows (e.g. "electronic-circuit"), as an item filter
+#   - the virtual signal `signal-output` (for source) or `signal-input`
+#     (for sink), which round-trip-identifies the marker on re-import.
+# This gives a single, paste-able blueprint that visibly distinguishes
+# source from sink and tells the player what item the marker is for.
 _SOURCE_MARKER_NAME = "stack_inserter"
 _SINK_MARKER_NAME = "bulk_inserter"
-_SOURCE_REPLACEMENT = "infinity-chest"
-_SINK_REPLACEMENT = "bottomless-chest"
+_COMBINATOR_NAME = "constant-combinator"
+_SIGNAL_SOURCE = "signal-output"   # virtual signal name for sources
+_SIGNAL_SINK = "signal-input"      # virtual signal name for sinks
+
+# Model Direction enum (1=N, 2=E, 3=S, 4=W) → arrow virtual signal.
+# Note these are NOT prefixed with "signal-" despite the related
+# signal-input / signal-output / signal-anything prototypes that ARE
+# prefixed. The four arrow signals just live as bare "up-arrow", etc.
+_DIR_SIGNAL = {
+    1: "up-arrow",
+    2: "right-arrow",
+    3: "down-arrow",
+    4: "left-arrow",
+}
+
+
+def _combinator_marker(cx: float, cy: float, item_name: str | None,
+                       signal_name: str, direction_model: int) -> dict:
+    """Build a constant-combinator dict carrying three filters in its
+    first section: the flowing item, a source/sink virtual signal, and
+    an arrow virtual signal for the marker's direction."""
+    filters = []
+    if item_name and item_name != "empty":
+        filters.append({
+            "index": 2,
+            "name": _hyphenate(item_name),
+            "quality": "normal",
+            "comparator": "=",
+            "count": 1,
+        })
+    filters.append({
+        "index": 3,
+        "type": "virtual",
+        "name": signal_name,
+        "quality": "normal",
+        "comparator": "=",
+        "count": 1,
+    })
+    arrow = _DIR_SIGNAL.get(direction_model)
+    if arrow is not None:
+        filters.append({
+            "index": 4,
+            "type": "virtual",
+            "name": arrow,
+            "quality": "normal",
+            "comparator": "=",
+            "count": 1,
+        })
+    return {
+        "name": _COMBINATOR_NAME,
+        "position": {"x": cx, "y": cy},
+        "direction": 4,  # face East — combinators don't direct flow visually
+        "control_behavior": {
+            "sections": {
+                "sections": [
+                    {"index": 1, "filters": filters},
+                ],
+            },
+        },
+    }
 
 
 def _hyphenate(name: str) -> str:
@@ -111,36 +170,19 @@ def world_tensor_to_blueprint_dict(
             cx = x + ent_meta.width / 2.0
             cy = y + ent_meta.height / 2.0
 
-            # Source/sink markers from the request: re-render as visible
-            # chest entities so the player can see them in the blueprint.
-            if ent_meta.name == _SOURCE_MARKER_NAME:
+            # Source/sink markers from the request: re-render as
+            # constant-combinators carrying virtual-signal labels so the
+            # blueprint visibly shows source vs sink and which item.
+            if ent_meta.name in (_SOURCE_MARKER_NAME, _SINK_MARKER_NAME):
                 item_id = int(item_ch[x, y])
                 item_meta = items.get(item_id)
-                inf_settings: dict | None = None
-                if item_meta is not None and item_meta.name != "empty":
-                    inf_settings = {
-                        "remove_unfiltered_items": False,
-                        "filters": [{
-                            "name": _hyphenate(item_meta.name),
-                            "count": 200,
-                            "mode": "at-least",
-                            "index": 1,
-                        }],
-                    }
-                src_entity: dict = {
-                    "name": _SOURCE_REPLACEMENT,
-                    "position": {"x": cx, "y": cy},
-                }
-                if inf_settings is not None:
-                    src_entity["infinity_settings"] = inf_settings
-                out_entities.append(src_entity)
-                seen[x, y] = True
-                continue
-            if ent_meta.name == _SINK_MARKER_NAME:
-                out_entities.append({
-                    "name": _SINK_REPLACEMENT,
-                    "position": {"x": cx, "y": cy},
-                })
+                item_name = item_meta.name if item_meta is not None else None
+                signal = (_SIGNAL_SOURCE
+                          if ent_meta.name == _SOURCE_MARKER_NAME
+                          else _SIGNAL_SINK)
+                out_entities.append(_combinator_marker(
+                    cx, cy, item_name, signal, dir_model,
+                ))
                 seen[x, y] = True
                 continue
 
@@ -184,7 +226,10 @@ def world_tensor_to_blueprint_dict(
     bp: dict = {
         "entities": out_entities,
         "item": "blueprint",
-        "version": 281479275675648,  # Factorio 2.0 version stamp
+        # Factorio 2.0.x version stamp. The wrong one (1.x: 281479275675648)
+        # makes Factorio silently strip 2.0-only entities like
+        # constant-combinators with the new sections-of-sections schema.
+        "version": 562949958402048,
     }
     if label is not None:
         bp["label"] = label

--- a/factorion-mod/server/blueprint.py
+++ b/factorion-mod/server/blueprint.py
@@ -1,0 +1,151 @@
+"""Tensor → Factorio blueprint string.
+
+We reuse `factorion.dict2b64` for the final compression step; the only work
+here is walking the (channels, W, H) world tensor and emitting the
+entities-array dict that Factorio's `LuaItemStack.import_stack` consumes.
+
+Conventions matter:
+- Position of an N×M entity is at its *center* (so a 1×1 transport belt at
+  tile (3, 5) has position {x: 3.5, y: 5.5}).
+- Direction in Factorio 2.0 blueprints is a 16-step enum: 0=N, 4=E, 8=S,
+  12=W. The model uses factorion.Direction (1..4); convert with `dir*4-4`.
+- Inserters' blueprint direction points to their *drop tile*, not pickup.
+  The training-time decoder flips them by +8; encoding must flip back.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import numpy as np
+
+from factorion import Channel, Misc, dict2b64, entities, items
+
+_DIR_MODEL_TO_BP = {0: None, 1: 0, 2: 4, 3: 8, 4: 12}
+
+# Source/sink are flagged is_placeable=True in the catalogue but they're
+# env-spawned, not blueprint-pasteable. Skip them by name when encoding.
+_SKIP_ENTITY_NAMES = {"stack_inserter", "bulk_inserter"}
+
+
+def _hyphenate(name: str) -> str:
+    return name.replace("_", "-")
+
+
+def _make_entity(
+    name: str,
+    cx: float,
+    cy: float,
+    direction: int | None,
+    *,
+    recipe: str | None = None,
+    type_: str | None = None,
+) -> dict:
+    e: dict = {"name": name, "position": {"x": cx, "y": cy}}
+    if direction is not None and direction != 0:
+        # Inserter pickup→drop flip
+        if "inserter" in name:
+            direction = (direction + 8) % 16
+        e["direction"] = direction
+    if recipe is not None:
+        e["recipe"] = recipe
+    if type_ is not None:
+        e["type"] = type_
+    return e
+
+
+def world_tensor_to_blueprint_dict(world_CWH: np.ndarray) -> dict:
+    """Convert a (channels, W, H) numpy tensor to a Factorio blueprint dict.
+
+    Skips:
+      - empty cells (entity id 0)
+      - source/sink (entity ids 6/7) — these are env-spawned markers, not
+        things the player wants in their blueprint.
+      - non-anchor tiles of multi-tile entities (we use the ITEMS channel
+        being non-zero, plus MISC for undergrounds, to disambiguate; for
+        the MVP we emit one entity per *unique anchor* by tracking visited
+        tiles via a simple "first sighting wins" rule on the (entity,
+        direction) pair).
+    """
+    assert world_CWH.ndim == 3, f"expected (C, W, H), got {world_CWH.shape}"
+    _, W, H = world_CWH.shape
+
+    ent_ch = world_CWH[Channel.ENTITIES.value]
+    dir_ch = world_CWH[Channel.DIRECTION.value]
+    item_ch = world_CWH[Channel.ITEMS.value]
+    misc_ch = world_CWH[Channel.MISC.value]
+
+    out_entities: List[dict] = []
+    seen = np.zeros((W, H), dtype=bool)
+
+    for x in range(W):
+        for y in range(H):
+            if seen[x, y]:
+                continue
+            ent_id = int(ent_ch[x, y])
+            if ent_id == 0:
+                continue
+            ent_meta = entities.get(ent_id)
+            if ent_meta is None or not ent_meta.is_placeable:
+                continue
+            if ent_meta.name in _SKIP_ENTITY_NAMES:
+                # Source/sink markers — pre-existing in the request, not
+                # part of the model's output, never belong in the blueprint.
+                continue
+
+            dir_model = int(dir_ch[x, y])
+            dir_bp = _DIR_MODEL_TO_BP.get(dir_model, None)
+
+            # Center of an N×M entity is at the geometric midpoint of its
+            # tile span. For 1×1 this is +0.5 on both axes.
+            cx = x + ent_meta.width / 2.0
+            cy = y + ent_meta.height / 2.0
+
+            name = _hyphenate(ent_meta.name)
+            recipe: str | None = None
+            type_: str | None = None
+
+            item_id = int(item_ch[x, y])
+            if name == "assembling-machine-1" and item_id != 0:
+                recipe_meta = items.get(item_id)
+                if recipe_meta is not None:
+                    recipe = _hyphenate(recipe_meta.name)
+
+            if name == "underground-belt":
+                misc = int(misc_ch[x, y])
+                if misc == Misc.UNDERGROUND_DOWN.value:
+                    type_ = "input"
+                elif misc == Misc.UNDERGROUND_UP.value:
+                    type_ = "output"
+
+            out_entities.append(
+                _make_entity(name, cx, cy, dir_bp, recipe=recipe, type_=type_)
+            )
+
+            # Mark every tile this entity occupies as visited so we don't
+            # emit it again. For axis-rotated entities width/height swap.
+            w, h = ent_meta.width, ent_meta.height
+            if dir_model in (2, 4):  # EAST or WEST → swap dims
+                w, h = h, w
+            for dx in range(w):
+                for dy in range(h):
+                    tx, ty = x + dx, y + dy
+                    if 0 <= tx < W and 0 <= ty < H:
+                        seen[tx, ty] = True
+
+    # Number entities — Factorio doesn't strictly require entity_number on
+    # import but blueprint tooling expects it, so we add one.
+    for i, e in enumerate(out_entities, start=1):
+        e["entity_number"] = i
+
+    return {
+        "blueprint": {
+            "entities": out_entities,
+            "item": "blueprint",
+            "version": 281479275675648,  # Factorio 2.0 version stamp
+        }
+    }
+
+
+def world_tensor_to_blueprint_string(world_CWH: np.ndarray) -> str:
+    return dict2b64(world_tensor_to_blueprint_dict(world_CWH))

--- a/factorion-mod/server/server.py
+++ b/factorion-mod/server/server.py
@@ -265,15 +265,26 @@ def _apply_placement(obs_CWH: np.ndarray, action: dict) -> bool:
     return True
 
 
-def run_inference(agent: AgentCNN, req: dict, max_steps: int, device) -> np.ndarray:
+def run_inference(
+    agent: AgentCNN, req: dict, max_steps: int, device, eot_threshold: float = 0.5,
+) -> np.ndarray:
+    """Iteratively place entities until eot_head signals "done", the model
+    emits a no-op, or we hit the safety budget."""
     obs = request_to_obs(req)
     for step in range(max_steps):
+        # Ask the model first: do you think we're done?
+        with torch.no_grad():
+            x = torch.from_numpy(obs).unsqueeze(0).to(device)
+            stop = bool(agent.eot_should_stop(x, threshold=eot_threshold).item())
+        if stop:
+            log.info("Stopped after %d placements (eot_head fired).", step)
+            break
         action = _argmax_action(agent, obs, device)
         if not _apply_placement(obs, action):
             log.info("Stopped after %d placements (model emitted empty).", step)
             break
     else:
-        log.info("Reached max_steps=%d without an empty action.", max_steps)
+        log.info("Reached max_steps=%d without eot/empty.", max_steps)
     return obs
 
 

--- a/factorion-mod/server/server.py
+++ b/factorion-mod/server/server.py
@@ -445,12 +445,25 @@ def handle_request(
                 f"{dir_label}{_MISC_LABEL.get(p['misc'], '')}{item_tag}")
 
     placements = stats.get("placements", [])
-    # Description char budget is ~500. Each line is ~25-35 chars; show
-    # the first 20 and tail-summary if there's more.
-    MAX_LINES = 20
-    trace_lines = [_fmt_step(p) for p in placements[:MAX_LINES]]
-    if len(placements) > MAX_LINES:
-        trace_lines.append(f"...{len(placements) - MAX_LINES} more")
+    # Description has a hard ~500 char limit in Factorio 2.0; truncation
+    # leaves a half-written rich-text tag at the end. Budget conservatively
+    # and stop as soon as we'd exceed it.
+    MAX_DESCRIPTION_CHARS = 480
+    header_lines = [
+        f"sources={len(req.get('sources', []))} "
+        f"sinks={len(req.get('sinks', []))} "
+        f"steps={stats['steps_taken']} stop={stats['stop_reason']}",
+        "",
+    ]
+    used = sum(len(s) + 1 for s in header_lines)  # +1 for the newline
+    trace_lines = []
+    for p in placements:
+        line = _fmt_step(p)
+        if used + len(line) + 1 + len("...N more") > MAX_DESCRIPTION_CHARS:
+            trace_lines.append(f"...{len(placements) - len(trace_lines)} more")
+            break
+        trace_lines.append(line)
+        used += len(line) + 1
 
     label = (f"Factorion: {total_entities} entities "
              f"({placed_count} placed + {marker_count} markers)")

--- a/factorion-mod/server/server.py
+++ b/factorion-mod/server/server.py
@@ -282,11 +282,12 @@ def run_inference(
     fp_count = int(obs[Channel.FOOTPRINT.value].sum())
     log.info("  footprint tiles: %d", fp_count)
 
-    stats = {
+    stats: dict = {
         "steps_taken": 0,
         "stop_reason": "max_steps",
         "first_eot_prob": None,
         "final_eot_prob": None,
+        "placements": [],  # list of dicts, one per step
     }
 
     for step in range(max_steps):
@@ -307,6 +308,18 @@ def run_inference(
         ent_name = entities[ent_id].name if ent_id in entities else "?"
         item_id = action["item"]
         item_name = entities[item_id].name if item_id in entities else "?"
+        stats["placements"].append({
+            "step": step,
+            "eot": eot_p,
+            "entity_id": ent_id,
+            "entity_name": ent_name,
+            "x": int(action["xy"][0]),
+            "y": int(action["xy"][1]),
+            "direction": int(action["direction"]),
+            "item_id": item_id,
+            "item_name": item_name,
+            "misc": int(action["misc"]),
+        })
         log.info(
             "  step %d: eot=%.3f place=%s(id=%d) at (%d,%d) dir=%d item=%s(id=%d) misc=%d",
             step, eot_p, ent_name, ent_id,
@@ -400,20 +413,54 @@ def handle_request(
     # the player's cursor / inventory — particularly useful for empty
     # results, where the player would otherwise see a blank blueprint with
     # no clue why.
-    placeable_count = sum(
-        1 for x in range(obs_CWH.shape[1]) for y in range(obs_CWH.shape[2])
-        if int(obs_CWH[Channel.ENTITIES.value, x, y]) not in (0, _source_id(), _sink_id())
-    )
-    label = f"Factorion: {placeable_count} entities"
-    description = (
-        f"request_id={req['request_id']}\n"
-        f"grid={req['grid_size']}x{req['grid_size']} "
-        f"sources={len(req.get('sources', []))} sinks={len(req.get('sinks', []))}\n"
-        f"steps_taken={stats['steps_taken']} stop_reason={stats['stop_reason']}\n"
-        f"eot_prob first={stats['first_eot_prob']:.3f} final={stats['final_eot_prob']:.3f}\n"
-        f"placeable_entities_in_blueprint={placeable_count}\n"
-        f"non_empty_tiles={stats['nonzero_entities_tiles']}"
-    )
+    src_id, snk_id = _source_id(), _sink_id()
+    placed_count = 0   # model-placed entities (belts, inserters, etc.)
+    marker_count = 0   # source/sink markers (rendered as chests)
+    for xx in range(obs_CWH.shape[1]):
+        for yy in range(obs_CWH.shape[2]):
+            eid = int(obs_CWH[Channel.ENTITIES.value, xx, yy])
+            if eid == 0:
+                continue
+            if eid in (src_id, snk_id):
+                marker_count += 1
+            else:
+                placed_count += 1
+    total_entities = placed_count + marker_count  # matches blueprint contents
+
+    # Direction enum (1=N, 2=E, 3=S, 4=W) → short label.
+    _DIR_LABEL = {0: "-", 1: "N", 2: "E", 3: "S", 4: "W"}
+    _MISC_LABEL = {0: "", 1: " UG_DOWN", 2: " UG_UP"}
+
+    def _fmt_step(p: dict) -> str:
+        # Factorio rich-text icon, then position + direction. No entity
+        # name (the icon shows it) and no eot prob per step (keeps the
+        # trace short — Factorio's blueprint description has a tight
+        # character limit, ~500 chars in 2.0).
+        ent_tag = "[item=" + p["entity_name"].replace("_", "-") + "]"
+        dir_label = _DIR_LABEL.get(p["direction"], str(p["direction"]))
+        item_tag = ""
+        if p["item_name"] not in ("empty", "?", ""):
+            item_tag = " [item=" + p["item_name"].replace("_", "-") + "]"
+        return (f"{p['step']}: {ent_tag} ({p['x']},{p['y']}) "
+                f"{dir_label}{_MISC_LABEL.get(p['misc'], '')}{item_tag}")
+
+    placements = stats.get("placements", [])
+    # Description char budget is ~500. Each line is ~25-35 chars; show
+    # the first 20 and tail-summary if there's more.
+    MAX_LINES = 20
+    trace_lines = [_fmt_step(p) for p in placements[:MAX_LINES]]
+    if len(placements) > MAX_LINES:
+        trace_lines.append(f"...{len(placements) - MAX_LINES} more")
+
+    label = (f"Factorion: {total_entities} entities "
+             f"({placed_count} placed + {marker_count} markers)")
+    description_parts = [
+        f"sources={len(req.get('sources', []))} "
+        f"sinks={len(req.get('sinks', []))} "
+        f"steps={stats['steps_taken']} stop={stats['stop_reason']}",
+        "",
+    ] + trace_lines
+    description = "\n".join(description_parts)
     bp_str = world_tensor_to_blueprint_string(
         obs_CWH, label=label, description=description,
     )

--- a/factorion-mod/server/server.py
+++ b/factorion-mod/server/server.py
@@ -267,25 +267,67 @@ def _apply_placement(obs_CWH: np.ndarray, action: dict) -> bool:
 
 def run_inference(
     agent: AgentCNN, req: dict, max_steps: int, device, eot_threshold: float = 0.5,
-) -> np.ndarray:
+) -> tuple[np.ndarray, dict]:
     """Iteratively place entities until eot_head signals "done", the model
     emits a no-op, or we hit the safety budget."""
     obs = request_to_obs(req)
+
+    # Dump the initial obs summary so we can see what the model is starting from
+    src_ids = [(int(s["x"]), int(s["y"]), s.get("direction"), s.get("item"))
+               for s in req.get("sources", [])]
+    snk_ids = [(int(s["x"]), int(s["y"]), s.get("direction"), s.get("item"))
+               for s in req.get("sinks", [])]
+    log.info("  initial sources (x,y,dir,item): %s", src_ids)
+    log.info("  initial sinks   (x,y,dir,item): %s", snk_ids)
+    fp_count = int(obs[Channel.FOOTPRINT.value].sum())
+    log.info("  footprint tiles: %d", fp_count)
+
+    stats = {
+        "steps_taken": 0,
+        "stop_reason": "max_steps",
+        "first_eot_prob": None,
+        "final_eot_prob": None,
+    }
+
     for step in range(max_steps):
         # Ask the model first: do you think we're done?
         with torch.no_grad():
             x = torch.from_numpy(obs).unsqueeze(0).to(device)
-            stop = bool(agent.eot_should_stop(x, threshold=eot_threshold).item())
-        if stop:
-            log.info("Stopped after %d placements (eot_head fired).", step)
+            eot_p = float(agent.eot_prob(x).item())
+        if step == 0:
+            stats["first_eot_prob"] = eot_p
+        stats["final_eot_prob"] = eot_p
+        if eot_p > eot_threshold:
+            log.info("  step %d: eot_prob=%.3f > %.2f → STOP", step, eot_p, eot_threshold)
+            stats["stop_reason"] = "eot"
+            stats["steps_taken"] = step
             break
         action = _argmax_action(agent, obs, device)
+        ent_id = action["entity"]
+        ent_name = entities[ent_id].name if ent_id in entities else "?"
+        item_id = action["item"]
+        item_name = entities[item_id].name if item_id in entities else "?"
+        log.info(
+            "  step %d: eot=%.3f place=%s(id=%d) at (%d,%d) dir=%d item=%s(id=%d) misc=%d",
+            step, eot_p, ent_name, ent_id,
+            action["xy"][0], action["xy"][1],
+            action["direction"], item_name, item_id, action["misc"],
+        )
         if not _apply_placement(obs, action):
-            log.info("Stopped after %d placements (model emitted empty).", step)
+            log.info("  → empty/no-op placement, stopping")
+            stats["stop_reason"] = "empty"
+            stats["steps_taken"] = step + 1
             break
+        stats["steps_taken"] = step + 1
     else:
         log.info("Reached max_steps=%d without eot/empty.", max_steps)
-    return obs
+
+    # Summarise final state
+    ent_ch = obs[Channel.ENTITIES.value]
+    placed = int((ent_ch != 0).sum())
+    log.info("Final: %d non-empty tiles in ENTITIES channel", placed)
+    stats["nonzero_entities_tiles"] = placed
+    return obs, stats
 
 
 # --------------------------------------------------------------------------- #
@@ -352,9 +394,50 @@ def handle_request(
              len(req.get("sources", [])), len(req.get("sinks", [])))
 
     t0 = time.time()
-    obs_CWH = run_inference(agent, req, max_steps=max_steps, device=device)
-    bp_str = world_tensor_to_blueprint_string(obs_CWH)
-    log.info("Inference %.2fs; blueprint %d chars", time.time() - t0, len(bp_str))
+    obs_CWH, stats = run_inference(agent, req, max_steps=max_steps, device=device)
+
+    # Embed prediction metadata in the blueprint itself so it's visible in
+    # the player's cursor / inventory — particularly useful for empty
+    # results, where the player would otherwise see a blank blueprint with
+    # no clue why.
+    placeable_count = sum(
+        1 for x in range(obs_CWH.shape[1]) for y in range(obs_CWH.shape[2])
+        if int(obs_CWH[Channel.ENTITIES.value, x, y]) not in (0, _source_id(), _sink_id())
+    )
+    label = f"Factorion: {placeable_count} entities"
+    description = (
+        f"request_id={req['request_id']}\n"
+        f"grid={req['grid_size']}x{req['grid_size']} "
+        f"sources={len(req.get('sources', []))} sinks={len(req.get('sinks', []))}\n"
+        f"steps_taken={stats['steps_taken']} stop_reason={stats['stop_reason']}\n"
+        f"eot_prob first={stats['first_eot_prob']:.3f} final={stats['final_eot_prob']:.3f}\n"
+        f"placeable_entities_in_blueprint={placeable_count}\n"
+        f"non_empty_tiles={stats['nonzero_entities_tiles']}"
+    )
+    bp_str = world_tensor_to_blueprint_string(
+        obs_CWH, label=label, description=description,
+    )
+    log.info("Inference %.2fs; blueprint %d chars  label=%r",
+             time.time() - t0, len(bp_str), label)
+
+    # Decode the blueprint so we can log what's actually inside (entity
+    # counts, names, positions) — easier than eyeballing the b64.
+    try:
+        from factorion import b64_to_dict
+        decoded = b64_to_dict(bp_str)
+        entities_list = decoded.get("blueprint", {}).get("entities", [])
+        log.info("  blueprint contains %d entities:", len(entities_list))
+        for e in entities_list[:40]:  # cap to 40 to avoid log spam
+            log.info("    %s @ (%s,%s) dir=%s%s%s",
+                     e.get("name"), e["position"]["x"], e["position"]["y"],
+                     e.get("direction", "-"),
+                     " recipe=" + e["recipe"] if "recipe" in e else "",
+                     " type=" + e["type"] if "type" in e else "")
+        if len(entities_list) > 40:
+            log.info("    ... and %d more", len(entities_list) - 40)
+        log.info("  blueprint string: %s", bp_str)
+    except Exception:
+        log.exception("Could not decode blueprint for logging")
 
     # Single-quoted Lua string: blueprint b64 alphabet [A-Za-z0-9+/=] plus
     # our "0" version prefix contains no single quotes, so this is safe.
@@ -363,7 +446,9 @@ def handle_request(
     )
     resp = rcon.exec(cmd)
     if resp:
-        log.info("RCON: %s", resp.strip())
+        log.info("RCON reply: %s", resp.strip())
+    else:
+        log.info("RCON reply: (empty — success)")
 
 
 # --------------------------------------------------------------------------- #

--- a/factorion-mod/server/server.py
+++ b/factorion-mod/server/server.py
@@ -1,0 +1,416 @@
+"""Factorion model server.
+
+Watches a directory for `req-*.json` files written by the Factorio mod,
+runs the trained AgentCNN policy on each, and pushes the resulting
+blueprint back into the running game over RCON.
+
+Run from the repo root so the `factorion` and `factorion_rs` modules are
+importable (e.g. via `uv run python factorion-mod/server/server.py ...`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import socket
+import struct
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Optional
+
+import numpy as np
+import torch
+
+# Make the repo root importable when this script is run via uv from elsewhere.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from factorion import Channel, entities, str2ent  # noqa: E402
+from ppo import AgentCNN  # noqa: E402
+
+import factorion_rs  # noqa: E402
+
+from blueprint import world_tensor_to_blueprint_string  # noqa: E402
+
+log = logging.getLogger("factorion-server")
+
+
+# --------------------------------------------------------------------------- #
+# RCON client (inlined; no extra deps).
+# --------------------------------------------------------------------------- #
+
+class RconError(RuntimeError):
+    pass
+
+
+class RconClient:
+    """Minimal Source-RCON client. Factorio implements the same protocol."""
+
+    AUTH = 3
+    EXEC = 2
+    RESP = 0
+
+    def __init__(self, host: str, port: int, password: str, timeout: float = 5.0):
+        self.host, self.port, self.password, self.timeout = host, port, password, timeout
+        self._sock: Optional[socket.socket] = None
+        self._counter = 1
+
+    def __enter__(self):
+        self.connect()
+        return self
+
+    def __exit__(self, *a):
+        self.close()
+
+    def connect(self):
+        self._sock = socket.create_connection((self.host, self.port), self.timeout)
+        rid = self._send(self.AUTH, self.password)
+        # Factorio sends an empty RESP first, then an AUTH response.
+        resp_id, _, _ = self._recv()
+        if resp_id == -1:
+            raise RconError("RCON auth failed (bad password)")
+        if resp_id != rid:
+            # Drain the empty packet and read again.
+            resp_id, _, _ = self._recv()
+            if resp_id == -1:
+                raise RconError("RCON auth failed (bad password)")
+
+    def close(self):
+        if self._sock:
+            try:
+                self._sock.close()
+            finally:
+                self._sock = None
+
+    def exec(self, command: str) -> str:
+        if self._sock is None:
+            self.connect()
+        self._send(self.EXEC, command)
+        _, _, body = self._recv()
+        return body
+
+    def _send(self, ptype: int, body: str) -> int:
+        rid = self._counter
+        self._counter += 1
+        payload = body.encode("utf-8")
+        # length = id(4) + type(4) + body(N) + 2 null bytes
+        packet = struct.pack("<ii", rid, ptype) + payload + b"\x00\x00"
+        self._sock.sendall(struct.pack("<i", len(packet)) + packet)
+        return rid
+
+    def _recv(self):
+        assert self._sock is not None
+        raw_len = self._read_exact(4)
+        (length,) = struct.unpack("<i", raw_len)
+        data = self._read_exact(length)
+        rid, ptype = struct.unpack("<ii", data[:8])
+        body = data[8:-2].decode("utf-8", errors="replace")
+        return rid, ptype, body
+
+    def _read_exact(self, n: int) -> bytes:
+        buf = b""
+        while len(buf) < n:
+            chunk = self._sock.recv(n - len(buf))
+            if not chunk:
+                raise RconError("RCON socket closed")
+            buf += chunk
+        return buf
+
+
+# --------------------------------------------------------------------------- #
+# Model loading & inference.
+# --------------------------------------------------------------------------- #
+
+def _duck_envs(size: int):
+    """AgentCNN reads grid size off `envs.envs[0].unwrapped.size`."""
+    return SimpleNamespace(envs=[SimpleNamespace(unwrapped=SimpleNamespace(size=size))])
+
+
+@dataclass
+class Hyperparams:
+    grid_size: int = 8
+    chan1: int = 32
+    chan2: int = 64
+    chan3: int = 64
+
+    @classmethod
+    def from_json_sibling(cls, ckpt_path: Path) -> "Hyperparams":
+        sidecar = ckpt_path.with_suffix(".hp.json")
+        if sidecar.exists():
+            with sidecar.open() as f:
+                return cls(**json.load(f))
+        return cls()
+
+
+def load_agent(ckpt_path: Path, hp: Hyperparams, device: torch.device) -> AgentCNN:
+    log.info("Loading checkpoint %s (grid=%d, chans=%d/%d/%d)",
+             ckpt_path, hp.grid_size, hp.chan1, hp.chan2, hp.chan3)
+    agent = AgentCNN(_duck_envs(hp.grid_size),
+                     chan1=hp.chan1, chan2=hp.chan2, chan3=hp.chan3).to(device)
+    state = torch.load(ckpt_path, map_location=device, weights_only=True)
+    agent.load_state_dict(state)
+    agent.eval()
+    return agent
+
+
+# --------------------------------------------------------------------------- #
+# Request → obs tensor.
+# --------------------------------------------------------------------------- #
+
+def _source_id() -> int:
+    e = str2ent("source")
+    assert e is not None, "factorion is missing the 'source' entity"
+    return e.value
+
+
+def _sink_id() -> int:
+    e = str2ent("sink")
+    assert e is not None, "factorion is missing the 'sink' entity"
+    return e.value
+
+
+def request_to_obs(req: dict) -> np.ndarray:
+    """Build the (C, W, H) tensor the policy expects from a request dict."""
+    size = req["grid_size"]
+    C = len(Channel)
+    obs = np.zeros((C, size, size), dtype=np.float32)
+
+    # Footprint mask
+    for x, y in req["footprint"]:
+        obs[Channel.FOOTPRINT.value, x, y] = 1.0
+
+    src_id, snk_id = _source_id(), _sink_id()
+
+    for s in req.get("sources", []):
+        x, y = s["x"], s["y"]
+        obs[Channel.ENTITIES.value, x, y] = src_id
+        obs[Channel.DIRECTION.value, x, y] = s["direction"]
+        item = str2ent(s["item"])
+        if item is not None:
+            obs[Channel.ITEMS.value, x, y] = item.value
+
+    for s in req.get("sinks", []):
+        x, y = s["x"], s["y"]
+        obs[Channel.ENTITIES.value, x, y] = snk_id
+        obs[Channel.DIRECTION.value, x, y] = s["direction"]
+        item = str2ent(s["item"])
+        if item is not None:
+            obs[Channel.ITEMS.value, x, y] = item.value
+
+    return obs
+
+
+# --------------------------------------------------------------------------- #
+# Iterative inference: place one entity at a time, greedy (argmax).
+# --------------------------------------------------------------------------- #
+
+def _argmax_action(agent: AgentCNN, obs_CWH: np.ndarray, device) -> dict:
+    x = torch.from_numpy(obs_CWH).unsqueeze(0).to(device)
+    with torch.no_grad():
+        encoded = agent.encoder(x)
+        B = encoded.shape[0]
+        tile_logits = agent.tile_logits(encoded).reshape(B, -1)
+        tile_idx = tile_logits.argmax(dim=-1)
+        x_B = tile_idx // agent.height
+        y_B = tile_idx % agent.height
+        feat = encoded[torch.arange(B), :, x_B, y_B]
+        ent = agent.ent_head(feat).argmax(dim=-1)
+        dir_ = agent.dir_head(feat).argmax(dim=-1)
+        item = agent.item_head(feat).argmax(dim=-1)
+        misc = agent.misc_head(feat).argmax(dim=-1)
+    return {
+        "xy": (int(x_B.item()), int(y_B.item())),
+        "entity": int(ent.item()),
+        "direction": int(dir_.item()),
+        "item": int(item.item()),
+        "misc": int(misc.item()),
+    }
+
+
+def _apply_placement(obs_CWH: np.ndarray, action: dict) -> bool:
+    """Update obs in-place with the predicted entity. Returns True if the
+    placement was non-empty (so we should keep iterating)."""
+    ent_id = action["entity"]
+    if ent_id == 0:  # no-op / empty
+        return False
+    x, y = action["xy"]
+    ent_meta = entities.get(ent_id)
+    if ent_meta is None or not ent_meta.is_placeable:
+        # Head can technically emit recipe IDs (8+) since it's sized
+        # len(entities)-2 to only exclude source/sink. Treat those as no-ops.
+        log.debug("Skipping non-placeable predicted entity id %d", ent_id)
+        return True
+
+    direction = action["direction"]
+    width, height = ent_meta.width, ent_meta.height
+
+    try:
+        tiles = factorion_rs.py_entity_tiles(x, y, direction, width, height)
+    except Exception:
+        # Fall back to the anchor tile; better to under-mark than crash.
+        tiles = [(x, y)]
+
+    _, W, H = obs_CWH.shape
+    for tx, ty in tiles:
+        if 0 <= tx < W and 0 <= ty < H:
+            obs_CWH[Channel.ENTITIES.value, tx, ty] = ent_id
+            obs_CWH[Channel.DIRECTION.value, tx, ty] = direction
+    obs_CWH[Channel.ITEMS.value, x, y] = action["item"]
+    obs_CWH[Channel.MISC.value, x, y] = action["misc"]
+    return True
+
+
+def run_inference(agent: AgentCNN, req: dict, max_steps: int, device) -> np.ndarray:
+    obs = request_to_obs(req)
+    for step in range(max_steps):
+        action = _argmax_action(agent, obs, device)
+        if not _apply_placement(obs, action):
+            log.info("Stopped after %d placements (model emitted empty).", step)
+            break
+    else:
+        log.info("Reached max_steps=%d without an empty action.", max_steps)
+    return obs
+
+
+# --------------------------------------------------------------------------- #
+# RCON poll loop: single channel both ways.
+# --------------------------------------------------------------------------- #
+
+POLL_CMD = "/silent-command rcon.print(remote.call('factorion','poll_request'))"
+
+
+def poll_loop(
+    agent: AgentCNN,
+    rcon: RconClient,
+    *,
+    poll_interval: float = 0.25,
+    max_steps: int = 64,
+    device: torch.device,
+):
+    """Poll Factorio over RCON for queued requests; handle each as it arrives.
+
+    The transport is symmetric: both legs go through the same RCON
+    connection. Reconnect on transient failures so the server survives a
+    Factorio restart without needing to be restarted itself.
+    """
+    log.info("Polling factorion.poll_request every %.0f ms", poll_interval * 1000)
+
+    while True:
+        try:
+            raw = rcon.exec(POLL_CMD).strip()
+        except (RconError, OSError) as e:
+            log.warning("RCON poll failed (%s); reconnecting in 2s…", e)
+            try:
+                rcon.close()
+            except Exception:
+                pass
+            time.sleep(2.0)
+            try:
+                rcon.connect()
+                log.info("RCON reconnected.")
+            except Exception as e2:
+                log.warning("RCON reconnect failed: %s", e2)
+            continue
+
+        if not raw:
+            time.sleep(poll_interval)
+            continue
+
+        try:
+            req = json.loads(raw)
+        except json.JSONDecodeError:
+            log.warning("Non-JSON RCON response (first 200 chars): %r", raw[:200])
+            continue
+
+        try:
+            handle_request(req, agent, rcon, max_steps=max_steps, device=device)
+        except Exception:
+            log.exception("Failed to handle request %s", req.get("request_id"))
+
+
+def handle_request(
+    req: dict, agent: AgentCNN, rcon: RconClient, *, max_steps: int, device
+):
+    log.info("Request %s: grid=%dx%d, %d sources, %d sinks",
+             req["request_id"], req["grid_size"], req["grid_size"],
+             len(req.get("sources", [])), len(req.get("sinks", [])))
+
+    t0 = time.time()
+    obs_CWH = run_inference(agent, req, max_steps=max_steps, device=device)
+    bp_str = world_tensor_to_blueprint_string(obs_CWH)
+    log.info("Inference %.2fs; blueprint %d chars", time.time() - t0, len(bp_str))
+
+    # Single-quoted Lua string: blueprint b64 alphabet [A-Za-z0-9+/=] plus
+    # our "0" version prefix contains no single quotes, so this is safe.
+    cmd = "/silent-command remote.call('factorion','deliver_blueprint','{}','{}')".format(
+        req["request_id"], bp_str
+    )
+    resp = rcon.exec(cmd)
+    if resp:
+        log.info("RCON: %s", resp.strip())
+
+
+# --------------------------------------------------------------------------- #
+# CLI.
+# --------------------------------------------------------------------------- #
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--checkpoint", required=True, type=Path,
+                    help="Path to a torch.save'd AgentCNN state_dict.")
+    ap.add_argument("--rcon-host", default="127.0.0.1")
+    ap.add_argument("--rcon-port", type=int, default=27015)
+    ap.add_argument("--rcon-password", default="factorion")
+    ap.add_argument("--grid-size", type=int, default=8)
+    ap.add_argument("--chan1", type=int, default=32)
+    ap.add_argument("--chan2", type=int, default=64)
+    ap.add_argument("--chan3", type=int, default=64)
+    ap.add_argument("--max-steps", type=int, default=64,
+                    help="Iterative inference budget per request.")
+    ap.add_argument("--device", default="cpu", choices=["cpu", "cuda", "mps"])
+    ap.add_argument("--log-level", default="INFO")
+    args = ap.parse_args()
+
+    logging.basicConfig(
+        level=args.log_level.upper(),
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+
+    device = torch.device(args.device)
+    # Sidecar JSON next to the checkpoint is the source of truth; CLI flags
+    # override it if explicitly different from the defaults.
+    sidecar = Hyperparams.from_json_sibling(args.checkpoint)
+    defaults = Hyperparams()
+    hp = Hyperparams(
+        grid_size=args.grid_size if args.grid_size != defaults.grid_size else sidecar.grid_size,
+        chan1=args.chan1 if args.chan1 != defaults.chan1 else sidecar.chan1,
+        chan2=args.chan2 if args.chan2 != defaults.chan2 else sidecar.chan2,
+        chan3=args.chan3 if args.chan3 != defaults.chan3 else sidecar.chan3,
+    )
+    agent = load_agent(args.checkpoint, hp, device)
+
+    with RconClient(args.rcon_host, args.rcon_port, args.rcon_password) as rcon:
+        log.info("RCON connected to %s:%d", args.rcon_host, args.rcon_port)
+        # Sanity check: ping the mod. If a save isn't loaded yet, this
+        # call will succeed at the RCON layer but the remote interface
+        # won't exist; treat that as "wait, the user hasn't joined a
+        # game yet" rather than a fatal error.
+        try:
+            r = rcon.exec("/silent-command rcon.print(remote.call('factorion','ping'))")
+            log.info("Mod ping: %s", (r or "(no response — load a save with factorion enabled)").strip())
+        except Exception:
+            log.warning("Could not ping factorion mod — is the save loaded with the mod enabled?")
+
+        poll_loop(
+            agent, rcon,
+            poll_interval=0.25, max_steps=args.max_steps, device=device,
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- New top-level `factorion-mod/` dir with a Factorio 2.0 mod and a Python inference server.
- Round trip: player marks an N×N footprint in-game → mod auto-detects `constant-combinator` source/sink markers inside it → server polls over RCON, runs iterative `AgentCNN` greedy inference (stops on `eot_head`), and pushes a Factorio blueprint back with both the marker combinators and the model's placements.
- `scripts/launch.sh` wraps the Factorio binary with auto-generated RCON port/password so the player never types `--rcon-port` themselves.

## Source/sink representation

A source or sink is a **constant-combinator** with three filter signals in its first section:

| filter | role            | values                                            |
| ------ | --------------- | ------------------------------------------------- |
| item   | what flows      | `iron-plate`, `electronic-circuit`, …             |
| role   | source vs sink  | virtual `signal-output` (source) or `signal-input` (sink) |
| arrow  | direction       | virtual `up-arrow` / `right-arrow` / `down-arrow` / `left-arrow` |

The player drops a combinator inside the footprint with those three signals; the mod auto-detects it on the next predict (no marker-tool clicks needed). The server re-renders source/sink markers as the same combinator-with-filters in the output blueprint, so the round trip is loss-free for the markers and adds the model's belts/inserters around them.

## Why single-channel RCON (not file+RCON or HTTP)

Factorio's modding Lua has no file-read API, no socket access, and no HTTP — the sandbox is intentional for multiplayer determinism. RCON is the only inbound channel for an external process. The server polls a `poll_request` remote interface and pushes responses via `deliver_blueprint`. One TCP connection, two directions.

## Layout

```
factorion-mod/
├── README.md
├── mod/
│   ├── info.json
│   ├── .luarc.json                ← lua-language-server config with Factorio globals
│   ├── control.lua                ← event handlers + RCON interface (poll, deliver, dump_state, inject_request, ping, introspect)
│   ├── data.lua / settings.lua
│   ├── locale/en/factorion.cfg
│   └── prototypes/                ← selection tools + hotkeys
├── server/
│   ├── server.py                  ← RCON poll loop → model (with eot stop) → RCON push
│   ├── blueprint.py               ← tensor → Factorio blueprint b64 (combinator-as-marker render)
│   └── README.md
└── scripts/
    ├── install_mod.sh             ← symlink mod/ into Factorio's mods dir
    └── launch.sh                  ← spawn Factorio + start server
```

## Verified end-to-end against real Factorio 2.0.76

- Mod loads cleanly, `lua-language-server --check` reports clean.
- Tested with W&B SFT checkpoint `0g9hfjna` (11×11, chan widths 64/64/48).
- Full flow: place combinator markers → drag footprint → mod auto-fires prediction → server polls + runs inference + emits blueprint → blueprint lands in player's cursor → paste populates the world with markers + model placements.
- Constant-combinator markers round-trip through Factorio's blueprint import/export with no warnings.
- Per-step inference trace embedded in the blueprint description with Factorio rich-text icons.
- Failure modes surface in chat: marks outside footprint warn at mark-time; empty requests give actionable guidance.

## Key gotchas surfaced (saved to project memory for future Claude)

1. **`/silent-command` runs in level scope, not mod scope** — mod storage is unreachable from raw RCON; everything needs a `remote.add_interface` method.
2. **`game.reload_script()` reloads from save, not disk** — edits to `control.lua` only stick after save → exit → host-saved-game.
3. **RCON in GUI-hosted multiplayer needs `config.ini`, not `--rcon-bind`** — `local-rcon-socket` / `local-rcon-password` in the `[other]` section; CLI flags are ignored for non-headless modes.
4. **Blueprint version stamp matters** — Factorio silently drops entities whose schema doesn't match the declared version; use the 2.0 stamp `562949958402048` for the new sections-of-sections combinator format.
5. **Arrow virtual signals are unprefixed** (`up-arrow`, not `signal-up-arrow`), unlike `signal-input`/`signal-output`.
6. **`remote.add_interface` errors on re-add** — call `remove_interface` first so `game.reload_script()` picks up new methods.

## Not yet integrated

- **Stochastic / temperature sampling** — currently argmax-only; with the current SFT checkpoint the model occasionally argmax-loops on the same tile. A `--temperature` flag with `Categorical(logits)` sampling would break degenerate loops. ~10 LoC; left out for now since the plan is to train a better model.
- **Multi-tile entities** in the server's iterative state update are best-effort (1×1 fallback if `factorion_rs.py_entity_tiles` errors). Blueprint emission handles them correctly.

## Test plan

- [x] Headless Factorio round trip (proved wire correctness, 2026-05-12).
- [x] Live GUI Factorio round trip with SFT checkpoint (proved UX flow + combinator round-tripping, 2026-05-13).
- [ ] Re-test with a stronger checkpoint to validate prediction quality (model quality is the current bottleneck; mod plumbing is working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)