### PR TITLE
Add greedy-rollout throughput eval to SFT

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -331,17 +331,21 @@ class FactorioEnv(gym.Env):
         self._num_missing_entities = self._reset_options['num_missing_entities'] # TODO also change max_steps in tandem
 
         self.actions = []
+        # Lesson kind is settable per-reset so SFT rollout eval can sweep
+        # every LessonKind on the same env. PPO callers don't pass it and
+        # get the historical MOVE_ONE_ITEM default.
+        kind = self._reset_options.get('kind', LessonKind.MOVE_ONE_ITEM)
         # Generate the solved factory first (same seed → same layout),
         # then re-generate with missing entities for the actual episode.
         self._solved_world_CWH, _ = generate_lesson(
             size=self.size,
-            kind=LessonKind.MOVE_ONE_ITEM,
+            kind=kind,
             num_missing_entities=0,
             seed=self._seed,
         )
         self._world_CWH, min_entities_required = generate_lesson(
             size=self.size,
-            kind=LessonKind.MOVE_ONE_ITEM,
+            kind=kind,
             num_missing_entities=self._num_missing_entities,
             seed=self._seed,
         )
@@ -491,18 +495,22 @@ class FactorioEnv(gym.Env):
         frac_reachable = 0 if num_entities == 2 else max(0, 1.0 - (float(num_unreachable) / (num_entities - 2)))
         frac_hallucin = 0
 
-        # Give some small reward for having the belt be the right direction
+        # Give some small reward for having the belt be the right direction.
+        # Only meaningful when the layout has exactly one sink (the
+        # MOVE_ONE_ITEM case). Other lesson kinds (e.g. SPLITTER_SPLIT,
+        # INSERTER_TRANSFER) place multiple sinks or none, so this shaping
+        # term gets zeroed instead of asserting.
         sink_locs = torch.where(self._world_CWH[Channel.ENTITIES.value] == self._sink_id)
-        assert len(sink_locs[0]) == len(sink_locs[1]) == 1, f"Expected 1 bulk inserter, found {sink_locs} in world {self._world_CWH}"
         C, W, H = self._world_CWH.shape
-        w_sink, h_sink = sink_locs[0][0], sink_locs[1][0]
-        w_belt = torch.clamp(w_sink, 1, W-2)
-        h_belt = torch.clamp(h_sink, 1, H-2)
-
-        final_belt_dir = self._world_CWH[Channel.DIRECTION.value, w_belt, h_belt]
-        sink_dir = self._world_CWH[Channel.DIRECTION.value, w_sink, h_sink]
-
-        final_dir_reward = 1.0 if final_belt_dir == sink_dir else 0.0
+        if len(sink_locs[0]) == 1:
+            w_sink, h_sink = sink_locs[0][0], sink_locs[1][0]
+            w_belt = torch.clamp(w_sink, 1, W-2)
+            h_belt = torch.clamp(h_sink, 1, H-2)
+            final_belt_dir = self._world_CWH[Channel.DIRECTION.value, w_belt, h_belt]
+            sink_dir = self._world_CWH[Channel.DIRECTION.value, w_sink, h_sink]
+            final_dir_reward = 1.0 if final_belt_dir == sink_dir else 0.0
+        else:
+            final_dir_reward = 0.0
 
         material_cost = (
             1.0 * (self._world_CWH[Channel.DIRECTION.value] == str2ent('transport_belt').value).sum()

--- a/ppo.py
+++ b/ppo.py
@@ -331,24 +331,47 @@ class FactorioEnv(gym.Env):
         self._num_missing_entities = self._reset_options['num_missing_entities'] # TODO also change max_steps in tandem
 
         self.actions = []
-        # Lesson kind is settable per-reset so SFT rollout eval can sweep
-        # every LessonKind on the same env. PPO callers don't pass it and
-        # get the historical MOVE_ONE_ITEM default.
-        kind = self._reset_options.get('kind', LessonKind.MOVE_ONE_ITEM)
-        # Generate the solved factory first (same seed → same layout),
-        # then re-generate with missing entities for the actual episode.
-        self._solved_world_CWH, _ = generate_lesson(
-            size=self.size,
-            kind=kind,
-            num_missing_entities=0,
-            seed=self._seed,
-        )
-        self._world_CWH, min_entities_required = generate_lesson(
-            size=self.size,
-            kind=kind,
-            num_missing_entities=self._num_missing_entities,
-            seed=self._seed,
-        )
+        # Lesson kind is settable per-reset. Default (omitted or None) is
+        # uniform random sampling across LessonKind on every reset —
+        # matches the project direction where lessons are data generators
+        # rather than a fixed curriculum, so a single env naturally sees
+        # all kinds. Pass a concrete LessonKind to pin one. The sampler
+        # uses self.np_random which super().reset() seeded above, so the
+        # choice is deterministic per episode seed.
+        kind_opt = self._reset_options.get('kind', None)
+        if kind_opt is None:
+            kinds_list = list(LessonKind)
+            for _ in range(16):
+                kind = kinds_list[int(self.np_random.integers(0, len(kinds_list)))]
+                try:
+                    self._solved_world_CWH, _ = generate_lesson(
+                        size=self.size, kind=kind,
+                        num_missing_entities=0, seed=self._seed,
+                    )
+                    self._world_CWH, min_entities_required = generate_lesson(
+                        size=self.size, kind=kind,
+                        num_missing_entities=self._num_missing_entities,
+                        seed=self._seed,
+                    )
+                    break
+                except Exception:
+                    continue
+            else:
+                raise RuntimeError(
+                    f"Failed to sample a valid LessonKind for seed={self._seed} "
+                    f"after 16 attempts"
+                )
+        else:
+            kind = kind_opt
+            self._solved_world_CWH, _ = generate_lesson(
+                size=self.size, kind=kind,
+                num_missing_entities=0, seed=self._seed,
+            )
+            self._world_CWH, min_entities_required = generate_lesson(
+                size=self.size, kind=kind,
+                num_missing_entities=self._num_missing_entities,
+                seed=self._seed,
+            )
 
         self.min_entities_required = min_entities_required
         self._original_world_CWH = torch.clone(self._world_CWH)

--- a/sft.py
+++ b/sft.py
@@ -190,6 +190,10 @@ class SFTArgs:
     """loss weight for the EOT (end-of-trajectory) BCE head"""
     val_frac: float = 0.1
     """fraction of data for validation"""
+    eval_rollouts_every_n_epochs: int = 5
+    """run greedy rollout eval (log final throughput on val factories) every N epochs (0 disables)"""
+    eval_rollouts_max_seeds: int = 100
+    """cap on number of val seeds per rollout eval — bounds eval cost"""
     checkpoint_path: str = "sft_checkpoint.pt"
     """path to save the trained model"""
     chan1: int = 48
@@ -385,6 +389,106 @@ def build_lr_schedule(optimizer, total_steps: int, args: "SFTArgs"):
     )
 
 
+def run_rollout_eval(
+    agent,
+    args: SFTArgs,
+    val_seeds_to_kind: dict[int, int],
+    device,
+    max_seeds: int = 100,
+    eot_threshold: float = 0.5,
+) -> tuple[float, dict[str, float], dict[str, int]]:
+    """Greedy rollout eval on the held-out val factories.
+
+    For each held-out (seed, kind), spin up FactorioEnv, take greedy
+    argmax actions on every head, and let the EOT head decide when to
+    stop. Final throughput is read directly from the Rust solver after
+    the rollout ends (env step → eot threshold → env max_steps cap).
+
+    The (seed, kind) pairs are exactly the val_accuracy set — so a rise
+    in `val/throughput` over training is directly comparable to the
+    existing per-kind val accuracy curves.
+
+    Returns:
+        overall_throughput, per_kind_throughput (keyed by LessonKind.name),
+        per_kind_n (sample count per kind in the eval).
+    """
+    agent.eval()
+    was_training = agent.training
+
+    # Reuse the env id registered in train_sft. SyncVectorEnv-of-one is
+    # unnecessary; we work directly on a FactorioEnv instance.
+    env = FactorioEnv(size=args.size, idx=0)
+
+    max_level = args.max_level if args.max_level > 0 else 2 * args.size
+
+    # Deterministic, run-stable subsample of val seeds. Sorting first
+    # makes the selection independent of dict iteration order, then we
+    # shuffle with args.seed so different runs see the same selection.
+    seeds_sorted = sorted(val_seeds_to_kind.keys())
+    rng = random.Random(args.seed)
+    rng.shuffle(seeds_sorted)
+    seeds_sorted = seeds_sorted[:max_seeds]
+
+    per_kind_throughputs: dict[str, list[float]] = {k.name: [] for k in LessonKind}
+    all_throughputs: list[float] = []
+
+    with torch.no_grad():
+        for seed in seeds_sorted:
+            kind = LessonKind(val_seeds_to_kind[seed])
+
+            obs, _info = env.reset(seed=seed, options={
+                'num_missing_entities': max_level,
+                'kind': kind,
+            })
+            obs_t = torch.as_tensor(obs, dtype=torch.float32, device=device).unsqueeze(0)
+
+            for _ in range(env.max_steps):
+                encoded = agent.encoder(obs_t)
+                eot_p = float(torch.sigmoid(agent.eot_head(encoded).squeeze(-1))[0])
+                if eot_p > eot_threshold:
+                    break
+
+                tile_logits = agent.tile_logits(encoded).reshape(1, -1)
+                tile_idx = int(tile_logits.argmax(dim=1)[0])
+                x = tile_idx // env.size
+                y = tile_idx % env.size
+                tile_features = encoded[0, :, x, y].unsqueeze(0)
+
+                action = {
+                    'xy': np.array([x, y], dtype=int),
+                    'entity': int(agent.ent_head(tile_features).argmax(dim=1)[0]),
+                    'direction': int(agent.dir_head(tile_features).argmax(dim=1)[0]),
+                    'item': int(agent.item_head(tile_features).argmax(dim=1)[0]),
+                    'misc': int(agent.misc_head(tile_features).argmax(dim=1)[0]),
+                }
+
+                next_obs, _reward, terminated, truncated, _info = env.step(action)
+                if terminated or truncated:
+                    break
+                obs_t = torch.as_tensor(next_obs, dtype=torch.float32, device=device).unsqueeze(0)
+
+            # Read final throughput directly from the Rust solver: handles
+            # the corner case of immediate EOT (env never stepped → info
+            # would be stale) and matches the env's normalisation.
+            world_np = env._world_CWH.permute(1, 2, 0).to(torch.int64).numpy()
+            thp, _ = factorion_rs.simulate_throughput(world_np)
+            final_throughput = float(thp) / 15.0
+
+            per_kind_throughputs[kind.name].append(final_throughput)
+            all_throughputs.append(final_throughput)
+
+    overall = float(np.mean(all_throughputs)) if all_throughputs else 0.0
+    per_kind = {
+        kn: (float(np.mean(ts)) if ts else 0.0)
+        for kn, ts in per_kind_throughputs.items()
+    }
+    per_kind_n = {kn: len(ts) for kn, ts in per_kind_throughputs.items()}
+
+    if was_training:
+        agent.train()
+    return overall, per_kind, per_kind_n
+
+
 def train_sft(args: SFTArgs):
     """Main SFT training loop."""
     random.seed(args.seed)
@@ -421,6 +525,16 @@ def train_sft(args: SFTArgs):
         f"{n_seeds - n_val_seeds} lessons, {len(val_idx)} val pairs from "
         f"{n_val_seeds} lessons (no factory overlap)"
     )
+
+    # (seed -> kind_int) for every held-out lesson. generate_dataset bumps
+    # `seed` once per lesson, so each val seed maps to a unique kind. This
+    # is the set of factories the rollout eval will replay end-to-end —
+    # same lessons as val accuracy, so the two metrics are directly
+    # comparable.
+    val_seeds_to_kind: dict[int, int] = {}
+    for s, k in zip(lesson_seeds.tolist(), lesson_kinds.tolist()):
+        if s in val_seeds:
+            val_seeds_to_kind[s] = k
 
     train_ds = TensorDataset(
         obs[train_idx], tiles[train_idx], ents[train_idx], dirs[train_idx],
@@ -855,6 +969,29 @@ def train_sft(args: SFTArgs):
             per_kind_metrics[f"val/{k.name}/item_acc"] = per_kind_item_correct[k.name] / n
             per_kind_metrics[f"val/{k.name}/misc_acc"] = per_kind_misc_correct[k.name] / n
 
+        # Rollout eval: every N epochs greedy-play the held-out factories
+        # and record final throughput. Same lessons as val accuracy, so
+        # val/throughput is directly comparable to val/acc curves.
+        do_rollout = (
+            args.eval_rollouts_every_n_epochs > 0
+            and (epoch % args.eval_rollouts_every_n_epochs == 0 or epoch == args.epochs)
+        )
+        if do_rollout and len(val_seeds_to_kind) > 0:
+            overall_thp, per_kind_thp, per_kind_thp_n = run_rollout_eval(
+                agent,
+                args,
+                val_seeds_to_kind,
+                device,
+                max_seeds=args.eval_rollouts_max_seeds,
+            )
+            per_kind_metrics["val/throughput"] = overall_thp
+            for kn, thp in per_kind_thp.items():
+                if per_kind_thp_n[kn] > 0:
+                    per_kind_metrics[f"val/{kn}/throughput"] = thp
+        else:
+            overall_thp = None
+            per_kind_thp_n = {}
+
         print(
             f"Epoch {epoch:3d}/{args.epochs} | "
             f"train_loss={train_loss:.4f} train_acc={train_acc:.3f} "
@@ -863,6 +1000,7 @@ def train_sft(args: SFTArgs):
             f"(tile={val_tile_acc:.3f} ent={val_ent_acc:.3f} dir={val_dir_acc:.3f} "
             f"item={val_item_acc:.3f} misc={val_misc_acc:.3f} "
             f"eot={val_eot_acc:.3f} eot+={val_eot_pos_recall:.3f})"
+            + (f"  val_thp={overall_thp:.3f}" if overall_thp is not None else "")
         )
         if per_kind_metrics:
             kind_summary = "  ".join(

--- a/sft.py
+++ b/sft.py
@@ -446,9 +446,12 @@ def run_rollout_eval(
         return 0.0, per_kind, per_kind_n
 
     # Cap K at the number of seeds — spinning up more envs than work
-    # items wastes memory.
+    # items wastes memory. All envs use idx=0 so the seed we pass to
+    # reset() is the seed generate_lesson sees: FactorioEnv.reset adds
+    # self.idx to the seed for env-diversity in PPO, but here we need
+    # exact seed pass-through to replay the held-out val factories.
     K = max(1, min(num_envs, len(seeds_sorted)))
-    envs = [FactorioEnv(size=args.size, idx=i) for i in range(K)]
+    envs = [FactorioEnv(size=args.size, idx=0) for _ in range(K)]
 
     # Pop seeds off the front; each slot harvests its result then pulls
     # the next one. `current` holds the (seed, kind, last_throughput)

--- a/sft.py
+++ b/sft.py
@@ -1032,6 +1032,7 @@ def train_sft(args: SFTArgs):
             and (epoch % args.eval_rollouts_every_n_epochs == 0 or epoch == args.epochs)
         )
         if do_rollout and len(val_seeds_to_kind) > 0:
+            t_rollout = time.time()
             overall_thp, per_kind_thp, per_kind_thp_n = run_rollout_eval(
                 agent,
                 args,
@@ -1040,12 +1041,15 @@ def train_sft(args: SFTArgs):
                 max_seeds=args.eval_rollouts_max_seeds,
                 num_envs=args.eval_rollouts_num_envs,
             )
+            rollout_seconds = time.time() - t_rollout
             per_kind_metrics["val/throughput"] = overall_thp
+            per_kind_metrics["val/rollout_seconds"] = rollout_seconds
             for kn, thp in per_kind_thp.items():
                 if per_kind_thp_n[kn] > 0:
                     per_kind_metrics[f"val/{kn}/throughput"] = thp
         else:
             overall_thp = None
+            rollout_seconds = None
             per_kind_thp_n = {}
 
         print(
@@ -1056,7 +1060,10 @@ def train_sft(args: SFTArgs):
             f"(tile={val_tile_acc:.3f} ent={val_ent_acc:.3f} dir={val_dir_acc:.3f} "
             f"item={val_item_acc:.3f} misc={val_misc_acc:.3f} "
             f"eot={val_eot_acc:.3f} eot+={val_eot_pos_recall:.3f})"
-            + (f"  val_thp={overall_thp:.3f}" if overall_thp is not None else "")
+            + (
+                f"  val_thp={overall_thp:.3f} ({rollout_seconds:.1f}s)"
+                if overall_thp is not None else ""
+            )
         )
         if per_kind_metrics:
             kind_summary = "  ".join(

--- a/sft.py
+++ b/sft.py
@@ -194,6 +194,8 @@ class SFTArgs:
     """run greedy rollout eval (log final throughput on val factories) every N epochs (0 disables)"""
     eval_rollouts_max_seeds: int = 100
     """cap on number of val seeds per rollout eval — bounds eval cost"""
+    eval_rollouts_num_envs: int = 8
+    """parallel envs for rollout eval; batches the CNN forward across them"""
     checkpoint_path: str = "sft_checkpoint.pt"
     """path to save the trained model"""
     chan1: int = 48
@@ -396,13 +398,21 @@ def run_rollout_eval(
     device,
     max_seeds: int = 100,
     eot_threshold: float = 0.5,
+    num_envs: int = 8,
 ) -> tuple[float, dict[str, float], dict[str, int]]:
     """Greedy rollout eval on the held-out val factories.
 
-    For each held-out (seed, kind), spin up FactorioEnv, take greedy
-    argmax actions on every head, and let the EOT head decide when to
-    stop. Final throughput is read directly from the Rust solver after
-    the rollout ends (env step → eot threshold → env max_steps cap).
+    Runs K=num_envs FactorioEnvs in parallel and batches the CNN forward
+    across them, so the cost per eval is ~K× cheaper than the serial
+    version (the big win on GPU/MPS where the batch=1 forward dominates).
+    Envs are refilled from the seed queue as they finish, so all K slots
+    stay busy until the queue drains.
+
+    For each held-out (seed, kind) we greedy-argmax every head and let
+    the EOT head decide when to stop. Final throughput is the last
+    `info['throughput']` the env reported — the env already calls the
+    Rust solver every step, so we don't re-run it. An env that EOTs
+    before stepping inherits the reset-time throughput of 0.
 
     The (seed, kind) pairs are exactly the val_accuracy set — so a rise
     in `val/throughput` over training is directly comparable to the
@@ -412,12 +422,8 @@ def run_rollout_eval(
         overall_throughput, per_kind_throughput (keyed by LessonKind.name),
         per_kind_n (sample count per kind in the eval).
     """
-    agent.eval()
     was_training = agent.training
-
-    # Reuse the env id registered in train_sft. SyncVectorEnv-of-one is
-    # unnecessary; we work directly on a FactorioEnv instance.
-    env = FactorioEnv(size=args.size, idx=0)
+    agent.eval()
 
     max_level = args.max_level if args.max_level > 0 else 2 * args.size
 
@@ -432,50 +438,99 @@ def run_rollout_eval(
     per_kind_throughputs: dict[str, list[float]] = {k.name: [] for k in LessonKind}
     all_throughputs: list[float] = []
 
+    if not seeds_sorted:
+        if was_training:
+            agent.train()
+        per_kind = {kn: 0.0 for kn in per_kind_throughputs}
+        per_kind_n = {kn: 0 for kn in per_kind_throughputs}
+        return 0.0, per_kind, per_kind_n
+
+    # Cap K at the number of seeds — spinning up more envs than work
+    # items wastes memory.
+    K = max(1, min(num_envs, len(seeds_sorted)))
+    envs = [FactorioEnv(size=args.size, idx=i) for i in range(K)]
+
+    # Pop seeds off the front; each slot harvests its result then pulls
+    # the next one. `current` holds the (seed, kind, last_throughput)
+    # owned by each slot; `active[i]=False` means the slot has no more
+    # work and should be skipped.
+    queue = list(seeds_sorted)
+    active = [True] * K
+    current: list[tuple[int, LessonKind, float]] = [(0, LessonKind.MOVE_ONE_ITEM, 0.0)] * K
+    obs_stack = []
+
+    for i in range(K):
+        s = queue.pop(0)
+        k = LessonKind(val_seeds_to_kind[s])
+        obs, info = envs[i].reset(seed=s, options={
+            'num_missing_entities': max_level, 'kind': k,
+        })
+        current[i] = (s, k, float(info.get('throughput', 0.0)))
+        obs_stack.append(obs)
+
+    obs_batch = torch.as_tensor(np.stack(obs_stack), dtype=torch.float32, device=device)
+    batch_idx_K = torch.arange(K, device=device)
+
     with torch.no_grad():
-        for seed in seeds_sorted:
-            kind = LessonKind(val_seeds_to_kind[seed])
+        while any(active):
+            # Single CNN forward across all K slots. Inactive slots'
+            # outputs are discarded; the per-eval cost of K-1 stale
+            # forwards at the tail is negligible compared to the
+            # batching win earlier in the queue.
+            encoded = agent.encoder(obs_batch)
+            eot_probs = torch.sigmoid(agent.eot_head(encoded).squeeze(-1))
 
-            obs, _info = env.reset(seed=seed, options={
-                'num_missing_entities': max_level,
-                'kind': kind,
-            })
-            obs_t = torch.as_tensor(obs, dtype=torch.float32, device=device).unsqueeze(0)
+            tile_logits = agent.tile_logits(encoded).reshape(K, -1)
+            tile_idx_K = tile_logits.argmax(dim=1)
+            x_K = tile_idx_K // args.size
+            y_K = tile_idx_K % args.size
+            tile_features = encoded[batch_idx_K, :, x_K, y_K]
 
-            for _ in range(env.max_steps):
-                encoded = agent.encoder(obs_t)
-                eot_p = float(torch.sigmoid(agent.eot_head(encoded).squeeze(-1))[0])
-                if eot_p > eot_threshold:
-                    break
+            ent_K = agent.ent_head(tile_features).argmax(dim=1)
+            dir_K = agent.dir_head(tile_features).argmax(dim=1)
+            item_K = agent.item_head(tile_features).argmax(dim=1)
+            misc_K = agent.misc_head(tile_features).argmax(dim=1)
 
-                tile_logits = agent.tile_logits(encoded).reshape(1, -1)
-                tile_idx = int(tile_logits.argmax(dim=1)[0])
-                x = tile_idx // env.size
-                y = tile_idx % env.size
-                tile_features = encoded[0, :, x, y].unsqueeze(0)
+            for i in range(K):
+                if not active[i]:
+                    continue
 
-                action = {
-                    'xy': np.array([x, y], dtype=int),
-                    'entity': int(agent.ent_head(tile_features).argmax(dim=1)[0]),
-                    'direction': int(agent.dir_head(tile_features).argmax(dim=1)[0]),
-                    'item': int(agent.item_head(tile_features).argmax(dim=1)[0]),
-                    'misc': int(agent.misc_head(tile_features).argmax(dim=1)[0]),
-                }
+                finished_via_eot = float(eot_probs[i]) > eot_threshold
+                if not finished_via_eot:
+                    action = {
+                        'xy': np.array([int(x_K[i]), int(y_K[i])], dtype=int),
+                        'entity': int(ent_K[i]),
+                        'direction': int(dir_K[i]),
+                        'item': int(item_K[i]),
+                        'misc': int(misc_K[i]),
+                    }
+                    next_obs, _r, terminated, truncated, info = envs[i].step(action)
+                    s, k, _last = current[i]
+                    current[i] = (s, k, float(info.get('throughput', 0.0)))
+                    finished_via_env = bool(terminated or truncated)
+                    if not finished_via_env:
+                        obs_batch[i] = torch.as_tensor(
+                            next_obs, dtype=torch.float32, device=device,
+                        )
+                        continue
 
-                next_obs, _reward, terminated, truncated, _info = env.step(action)
-                if terminated or truncated:
-                    break
-                obs_t = torch.as_tensor(next_obs, dtype=torch.float32, device=device).unsqueeze(0)
+                # Slot is finished — harvest and refill (or deactivate).
+                s, k, last_thp = current[i]
+                per_kind_throughputs[k.name].append(last_thp)
+                all_throughputs.append(last_thp)
 
-            # Read final throughput directly from the Rust solver: handles
-            # the corner case of immediate EOT (env never stepped → info
-            # would be stale) and matches the env's normalisation.
-            world_np = env._world_CWH.permute(1, 2, 0).to(torch.int64).numpy()
-            thp, _ = factorion_rs.simulate_throughput(world_np)
-            final_throughput = float(thp) / 15.0
-
-            per_kind_throughputs[kind.name].append(final_throughput)
-            all_throughputs.append(final_throughput)
+                if queue:
+                    s = queue.pop(0)
+                    k = LessonKind(val_seeds_to_kind[s])
+                    obs, info = envs[i].reset(seed=s, options={
+                        'num_missing_entities': max_level, 'kind': k,
+                    })
+                    current[i] = (s, k, float(info.get('throughput', 0.0)))
+                    obs_batch[i] = torch.as_tensor(
+                        obs, dtype=torch.float32, device=device,
+                    )
+                else:
+                    active[i] = False
 
     overall = float(np.mean(all_throughputs)) if all_throughputs else 0.0
     per_kind = {
@@ -983,6 +1038,7 @@ def train_sft(args: SFTArgs):
                 val_seeds_to_kind,
                 device,
                 max_seeds=args.eval_rollouts_max_seeds,
+                num_envs=args.eval_rollouts_num_envs,
             )
             per_kind_metrics["val/throughput"] = overall_thp
             for kn, thp in per_kind_thp.items():

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -55,16 +55,21 @@ class TestFootprintChannel:
         assert world.shape[2] == 5
 
     def test_default_lesson_footprint_is_all_available(self, env):
-        """Default lessons must NOT touch FOOTPRINT — every cell stays
-        AVAILABLE. A prior version marked every empty cell in the
+        """MOVE_ONE_ITEM lessons must NOT touch FOOTPRINT — every cell
+        stays AVAILABLE. A prior version marked every empty cell in the
         completed layout as UNAVAILABLE, which gave the optimal
         placement set away to the agent (AVAILABLE cells were exactly
         the cells the agent needed to fill). Bounded build regions are
-        an opt-in per-lesson override, not a default."""
-        obs, _ = env.reset(options={"num_missing_entities": 1})
+        an opt-in per-lesson override; SPLITTER / ASSEMBLE kinds use
+        them legitimately so we pin MOVE_ONE_ITEM here."""
+        from helpers import LessonKind  # noqa: E402
+        obs, _ = env.reset(options={
+            "num_missing_entities": 1,
+            "kind": LessonKind.MOVE_ONE_ITEM,
+        })
         footprint = obs[Channel.FOOTPRINT.value]
         assert (footprint == 1).all(), (
-            "FOOTPRINT must be all-AVAILABLE for default lessons; "
+            "FOOTPRINT must be all-AVAILABLE for MOVE_ONE_ITEM lessons; "
             "leaking the placement set is the regression."
         )
 

--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -23,6 +23,7 @@ from sft import (
     build_lr_schedule,
     extract_expert_actions,
     generate_dataset,
+    run_rollout_eval,
     train_sft,
 )
 from ppo import FactorioEnv, AgentCNN, make_env
@@ -464,6 +465,94 @@ class TestTrainSFTEndToEnd:
         assert "best_val_acc" in s
         assert s["num_samples"] == 100
         assert s["epochs"] == 2
+
+
+class TestRunRolloutEval:
+    """End-to-end coverage of greedy rollout eval on held-out val factories."""
+
+    def _build_val_seeds_to_kind(self, size, num_kinds=4, start_seed=10_000):
+        """Iterate seeds until we have `num_kinds` (seed -> kind) pairs each
+        of which produces a valid lesson at max_level. Mirrors the
+        try/except-continue pattern that generate_dataset uses for malformed
+        seeds, so this fixture doesn't get flaky when an enum value lands a
+        bad seed."""
+        from factorion import generate_lesson  # noqa: E402
+        kinds = list(LessonKind)
+        out: dict[int, int] = {}
+        seed = start_seed
+        max_level = 2 * size
+        while len(out) < num_kinds and seed < start_seed + 1000:
+            kind = kinds[len(out) % len(kinds)]
+            try:
+                generate_lesson(size=size, kind=kind, num_missing_entities=max_level, seed=seed)
+            except Exception:
+                seed += 1
+                continue
+            out[seed] = kind.value
+            seed += 1
+        return out
+
+    def test_returns_throughput_in_unit_range(self, registered_env):
+        """Untrained agent on tiny grid should return well-formed throughput
+        numbers — overall in [0, 1] and per-kind in [0, 1] for any kind that
+        was eval'd."""
+        size = 5
+        envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, size, "test")])
+        agent = AgentCNN(envs, chan1=16, chan2=16, chan3=16, flat_dim=64)
+        envs.close()
+
+        args = SFTArgs(seed=1, size=size, num_samples=50, max_level=2 * size,
+                       chan1=16, chan2=16, chan3=16, flat_dim=64)
+        val_seeds_to_kind = self._build_val_seeds_to_kind(size=size, num_kinds=4)
+        assert len(val_seeds_to_kind) >= 1, "Sanity: at least one valid lesson"
+
+        overall, per_kind, per_kind_n = run_rollout_eval(
+            agent, args, val_seeds_to_kind, device=torch.device("cpu"),
+            max_seeds=len(val_seeds_to_kind),
+        )
+
+        assert 0.0 <= overall <= 1.5, f"overall throughput out of range: {overall}"
+        total_n = sum(per_kind_n.values())
+        assert total_n == len(val_seeds_to_kind), (
+            f"per-kind n totals {total_n}, expected {len(val_seeds_to_kind)}"
+        )
+        for kn, thp in per_kind.items():
+            assert 0.0 <= thp <= 1.5, f"{kn}: throughput out of range: {thp}"
+
+    def test_max_seeds_caps_eval(self, registered_env):
+        """max_seeds should bound the rollout count even when the val set
+        is larger."""
+        size = 5
+        envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, size, "test")])
+        agent = AgentCNN(envs, chan1=16, chan2=16, chan3=16, flat_dim=64)
+        envs.close()
+
+        args = SFTArgs(seed=1, size=size, num_samples=50, max_level=2 * size,
+                       chan1=16, chan2=16, chan3=16, flat_dim=64)
+        val_seeds_to_kind = self._build_val_seeds_to_kind(size=size, num_kinds=6)
+        assert len(val_seeds_to_kind) >= 3
+
+        _overall, _per_kind, per_kind_n = run_rollout_eval(
+            agent, args, val_seeds_to_kind, device=torch.device("cpu"),
+            max_seeds=2,
+        )
+        assert sum(per_kind_n.values()) == 2
+
+    def test_empty_val_seeds_is_safe(self, registered_env):
+        """Empty val_seeds_to_kind should return zero/empty results without
+        crashing (defensive — the caller already guards on len(...)>0)."""
+        size = 5
+        envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, size, "test")])
+        agent = AgentCNN(envs, chan1=16, chan2=16, chan3=16, flat_dim=64)
+        envs.close()
+
+        args = SFTArgs(seed=1, size=size, num_samples=50, max_level=2 * size,
+                       chan1=16, chan2=16, chan3=16, flat_dim=64)
+        overall, per_kind, per_kind_n = run_rollout_eval(
+            agent, args, {}, device=torch.device("cpu"),
+        )
+        assert overall == 0.0
+        assert sum(per_kind_n.values()) == 0
 
 
 class TestEotHead:


### PR DESCRIPTION
## Summary
- SFT now runs greedy-policy rollouts on the held-out val factories every N epochs (and on the final epoch) and logs final throughput per `LessonKind` plus an overall number. Same (seed, kind) pairs as val accuracy, so `val/throughput` is directly comparable to the per-kind val accuracy curves.
- Rollouts run in parallel across `K = --eval-rollouts-num-envs` (default 8) FactorioEnvs with a single batched CNN forward across slots — wandb gets `val/rollout_seconds` so the eval cost is visible.
- `FactorioEnv.reset` now defaults to uniform-random `LessonKind` (omitted or `kind=None`); pass a concrete `LessonKind` to pin one. Matches the project direction where lessons are data generators, not curriculum rungs.

## Commits
- `ecbf388` baseline rollout-eval helper + CLI flags + tests
- `c746cee` env default → uniform random kind (with retry on bad seeds)
- `962ed46` parallelise across K envs (batched CNN forward, slot refilling)
- `403267d` log `val/rollout_seconds`
- `f0df04f` fixups caught by pre-push hook (env idx seed-drift + footprint test pinning)

## Test plan
- [x] `cargo fmt`, `cargo clippy -- -D warnings`, `cargo test --no-default-features`
- [x] `maturin develop --release`
- [x] `WANDB_MODE=disabled WANDB_DISABLED=true uv run python -m pytest tests/ -v` (3060 passed, 77 skipped)
- [x] `ruff check .`
- [x] PPO smoke test (`--total-timesteps 5000`)
- [x] SFT smoke test (size=5, 2 epochs) — observed `val_thp=0.000 (0.4s)` on final epoch

🤖 Generated with [Claude Code](https://claude.com/claude-code)