### PR TITLE
Make 12x12 the default factory size

### DIFF
--- a/factorion.py
+++ b/factorion.py
@@ -1433,7 +1433,7 @@ def _remove_entities(
 
 
 def build_factory(
-    size: int = 5,
+    size: int = 12,
     kind: LessonKind = LessonKind.MOVE_ONE_ITEM,
     *,
     seed: Optional[int] = None,

--- a/ppo.py
+++ b/ppo.py
@@ -137,7 +137,7 @@ class Args:
     """Output size of the fully connected layer after the encoder"""
     tile_head_std: float = 0.06503
     """Initialization std for the tile selection conv head (smaller = more uniform initial exploration)"""
-    size: int = 8
+    size: int = 12
     """The width and height of the factory"""
     summary_path: Optional[str] = None
     """path to write summary JSON (default: summary.json next to ppo.py)"""
@@ -225,7 +225,7 @@ def get_pretty_format(tensor, entity_dir_map):
 class FactorioEnv(gym.Env):
     def __init__(
         self,
-        size: int = 5,
+        size: int = 12,
         max_steps: Optional[int] = None,
         render_mode: Optional[str] = None,
         idx: Optional[int] = None,

--- a/sft.py
+++ b/sft.py
@@ -153,11 +153,13 @@ def extract_expert_actions(solved_CWH, task_CWH):
 @dataclass
 class SFTArgs:
     # Defaults below are the rank-1 result from the first SFT sweep
-    # (wandb sweep ncqdnvmt, PR #104) — val/acc=0.901 on size=11. Override
-    # any individual flag at the command line.
+    # (wandb sweep ncqdnvmt, PR #104) — val/acc=0.901 on size=11. The
+    # `size` default is set to 12 to match the project-wide default;
+    # all other hyperparameters are from the sweep. Override any
+    # individual flag at the command line.
     seed: int = 1
     """random seed"""
-    size: int = 11
+    size: int = 12
     """grid size (width and height)"""
     num_samples: int = 300000
     """number of (state, action) pairs to generate"""

--- a/tests/test_grid_sizes.py
+++ b/tests/test_grid_sizes.py
@@ -1,6 +1,6 @@
 """Tests that FactorioEnv works with various grid sizes.
 
-Verifies that creating environments with size=8 (new default) and size=12
+Verifies that creating environments with size=8 and size=12 (the default)
 and running random steps doesn't crash.
 """
 
@@ -69,8 +69,8 @@ class TestGridSizes:
                 obs, info = env.reset()
         env.close()
 
-    def test_default_size_is_8(self):
-        """Verify the default size in Args is 8."""
+    def test_default_size_is_12(self):
+        """Verify the default size in Args is 12."""
         from ppo import Args
         args = Args()
-        assert args.size == 8
+        assert args.size == 12

--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -776,9 +776,10 @@ class TestArtifactNameHelpers:
         assert _humanize_lr(0) == "0"
 
     def test_artifact_name_default(self):
-        # SFTArgs defaults track the sweep winner: size=11, n=300k, chan3=64,
-        # lr=2.542e-3, so the auto-name expands the channel suffix.
-        assert _artifact_name(SFTArgs()) == "sft-s11-n300k-e30-bs512-lr2.5e-3-c48-48-64"
+        # SFTArgs defaults track the sweep winner (n=300k, chan3=64,
+        # lr=2.542e-3) with size bumped to the project default of 12.
+        # The auto-name expands the channel suffix.
+        assert _artifact_name(SFTArgs()) == "sft-s12-n300k-e30-bs512-lr2.5e-3-c48-48-64"
 
     def test_artifact_name_larger_run(self):
         args = SFTArgs(
@@ -792,7 +793,7 @@ class TestArtifactNameHelpers:
         to a single c{N} — so a c32-64-64 run can't accidentally be filed
         under the same artifact as a c48 run."""
         args = SFTArgs(chan1=32, chan2=64, chan3=64)
-        assert _artifact_name(args) == "sft-s11-n300k-e30-bs512-lr2.5e-3-c32-64-64"
+        assert _artifact_name(args) == "sft-s12-n300k-e30-bs512-lr2.5e-3-c32-64-64"
 
     def test_artifact_name_stable_across_runs(self):
         """Two SFTArgs with the same hyperparams must produce the same


### PR DESCRIPTION
## Summary

- Bumps every factory-size default to 12 so PPO, SFT, and `build_factory` start on the same grid: `Args.size` (ppo.py) 8 → 12, `FactorioEnv.__init__` 5 → 12, `build_factory` 5 → 12, `SFTArgs.size` 11 → 12.
- Updates the two tests that hard-coded the previous defaults (`test_default_size_is_8` and the artifact-name tests in test_sft.py).
- The SFT sweep winner was originally tuned at size=11; that note is preserved in the `SFTArgs` docstring with a callout that `size` is now overridden to the project-wide default of 12.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo test --no-default-features` — 48 passed
- [x] `maturin develop --release`
- [x] `pytest tests/` — 3291 passed, 77 skipped
- [x] `ruff check .` — clean
- [x] PPO smoke (`--total-timesteps 5000`) — completes, envs report `size=12`
- [x] SFT smoke (`--size 5 --num-samples 200 --epochs 2`) — completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)