### PR TITLE
Add manual SFT training workflow with sample-scaled timeout

### DIFF
--- a/.github/workflows/sft-train.yml
+++ b/.github/workflows/sft-train.yml
@@ -1,0 +1,140 @@
+name: SFT Train (manual)
+
+# Kick off a real SFT training run from any branch (no PR required) using
+# the existing sft_smoke_test.sh in-pod pipeline. The pod-side watchdog
+# and the GH Actions job timeout are both calculated from
+# num_samples * epochs so longer runs get more headroom automatically.
+
+on:
+  workflow_dispatch:
+    inputs:
+      num_samples:
+        description: "Number of SFT samples"
+        required: true
+        default: "100000"
+        type: string
+      epochs:
+        description: "Number of training epochs"
+        required: true
+        default: "30"
+        type: string
+      ref:
+        description: "Git ref to train (branch / SHA / tag)"
+        required: false
+        default: "main"
+        type: string
+      gpu_type:
+        description: "RunPod GPU type"
+        required: false
+        default: "NVIDIA A100 80GB PCIe"
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  WANDB_CI_PROJECT: factorion
+  PYTHON_VERSION: "3.11"
+
+jobs:
+  # ──────────────────────────────────────────────
+  # Job 0: Compute time budget from num_samples × epochs
+  # ──────────────────────────────────────────────
+  calc-budget:
+    runs-on: ubuntu-latest
+    outputs:
+      job_timeout: ${{ steps.calc.outputs.job_timeout }}
+      watchdog_seconds: ${{ steps.calc.outputs.watchdog_seconds }}
+    steps:
+      - name: Compute budget
+        id: calc
+        env:
+          NUM_SAMPLES: ${{ inputs.num_samples }}
+          EPOCHS: ${{ inputs.epochs }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import os
+          n = int(os.environ["NUM_SAMPLES"])
+          e = int(os.environ["EPOCHS"])
+          # Calibration: the existing 4h (14400s) watchdog for the 300k × 30
+          # default implies ~1000 sample-epochs/sec on A100 once you back out
+          # a 1.5× safety margin. Reuse that rate so 300k × 30 lines up with
+          # the historical default; longer runs scale linearly.
+          base_seconds = (n * e) / 1000
+          watchdog = int(base_seconds * 1.5 + 600)
+          # Floor: never less than 15 min, so tiny runs survive warmup.
+          watchdog = max(watchdog, 900)
+          # GH Actions job timeout: watchdog + 30 min for pod create/teardown.
+          job_minutes = int(watchdog / 60) + 30
+          # Hosted runners cap at 6h. Cap to stay below that.
+          job_minutes = min(job_minutes, 360)
+          print(f"watchdog_seconds={watchdog}")
+          print(f"job_timeout={job_minutes}")
+          PY
+          echo "Budget:"
+          cat "$GITHUB_OUTPUT"
+
+  # ──────────────────────────────────────────────
+  # Job 1: SFT training on RunPod GPU
+  # ──────────────────────────────────────────────
+  sft-train:
+    needs: [calc-budget]
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ fromJSON(needs.calc-budget.outputs.job_timeout) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          ref: ${{ inputs.ref }}
+
+      - name: Setup RunPod
+        id: runpod
+        uses: ./.github/actions/runpod-setup
+        with:
+          runpod_api_key: ${{ secrets.RUNPOD_API_KEY }}
+          ssh_private_key: ${{ secrets.RUNPOD_SSH_PRIVATE_KEY }}
+          gpu_type: ${{ inputs.gpu_type }}
+          name_prefix: ci-sft-train
+
+      - name: Run SFT training on GPU
+        env:
+          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+          RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
+        run: |
+          SSH_HOST="${{ steps.runpod.outputs.ssh_host }}"
+          SSH_PORT="${{ steps.runpod.outputs.ssh_port }}"
+          POD_ID="${{ steps.runpod.outputs.pod_id }}"
+          NUM_SAMPLES="${{ inputs.num_samples }}"
+          EPOCHS="${{ inputs.epochs }}"
+          REF="${{ inputs.ref }}"
+          WATCHDOG_SECONDS="${{ needs.calc-budget.outputs.watchdog_seconds }}"
+
+          scp -i ~/.ssh/runpod_ci -P "$SSH_PORT" \
+            scripts/ci/sft_smoke_test.sh \
+            root@"$SSH_HOST":/workspace/sft_smoke_test.sh
+
+          ssh -i ~/.ssh/runpod_ci -p "$SSH_PORT" root@"$SSH_HOST" \
+            WANDB_API_KEY="$WANDB_API_KEY" \
+            WANDB_PROJECT="${{ env.WANDB_CI_PROJECT }}" \
+            NUM_SAMPLES="$NUM_SAMPLES" \
+            EPOCHS="$EPOCHS" \
+            WATCHDOG_SECONDS="$WATCHDOG_SECONDS" \
+            PR_NUMBER="manual-${REF}" \
+            COMMIT_SHA="$GITHUB_SHA" \
+            RUNPOD_API_KEY="$RUNPOD_API_KEY" \
+            RUNPOD_POD_ID="$POD_ID" \
+            bash /workspace/sft_smoke_test.sh
+
+      - name: Teardown RunPod
+        if: always()
+        uses: ./.github/actions/runpod-teardown
+        with:
+          runpod_api_key: ${{ secrets.RUNPOD_API_KEY }}
+          summary_file: /tmp/sft_summary.md
+
+      - name: Publish summary to job
+        if: always()
+        run: |
+          if [ -f /tmp/sft_summary.md ]; then
+            cat /tmp/sft_summary.md >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/scripts/ci/sft_smoke_test.sh
+++ b/scripts/ci/sft_smoke_test.sh
@@ -11,8 +11,9 @@
 #   WANDB_PROJECT       - W&B project name (e.g. factorion)
 #
 # Optional env vars:
-#   NUM_SAMPLES         - Number of SFT samples (default: 5000)
-#   EPOCHS              - Number of training epochs (default: 10)
+#   NUM_SAMPLES         - Number of SFT samples (default: 300000)
+#   EPOCHS              - Number of training epochs (default: 30)
+#   WATCHDOG_SECONDS    - Self-terminate watchdog timeout (default: 14400 = 4h)
 #   PR_NUMBER           - PR number for tagging
 #   COMMIT_SHA          - Git commit SHA for tagging
 #   RUNPOD_POD_ID       - RunPod pod ID (for self-terminate watchdog)
@@ -22,6 +23,7 @@ set -euo pipefail
 
 NUM_SAMPLES="${NUM_SAMPLES:-300000}"
 EPOCHS="${EPOCHS:-30}"
+WATCHDOG_SECONDS="${WATCHDOG_SECONDS:-14400}"
 WANDB_PROJECT="${WANDB_PROJECT:-factorion}"
 PR_NUMBER="${PR_NUMBER:-unknown}"
 COMMIT_SHA="${COMMIT_SHA:-unknown}"
@@ -33,16 +35,17 @@ echo "  GPU:             $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/
 echo "  CUDA:            $(nvcc --version 2>/dev/null | tail -1 || echo 'unknown')"
 echo "  Samples:         ${NUM_SAMPLES}"
 echo "  Epochs:          ${EPOCHS}"
+echo "  Watchdog:        ${WATCHDOG_SECONDS}s"
 echo "  W&B project:     ${WANDB_PROJECT}"
 echo "  PR:              ${PR_NUMBER}"
 echo "  Commit:          ${COMMIT_SHA}"
 echo "============================================"
 
-# ── Safety net: self-terminate after 4 hours if cleanup fails ─────
+# ── Safety net: self-terminate after WATCHDOG_SECONDS if cleanup fails ─
 if [ -n "${RUNPOD_POD_ID:-}" ] && [ -n "${RUNPOD_API_KEY:-}" ]; then
-    echo ">>> Starting self-terminate watchdog (4h timeout)..."
+    echo ">>> Starting self-terminate watchdog (${WATCHDOG_SECONDS}s timeout)..."
     nohup bash -c "
-      sleep 14400
+      sleep ${WATCHDOG_SECONDS}
       curl -s 'https://api.runpod.io/graphql?api_key=${RUNPOD_API_KEY}' \
         -H 'Content-Type: application/json' \
         -d '{\"query\": \"mutation { podTerminate(input: {podId: \\\"${RUNPOD_POD_ID}\\\"}) }\"}'


### PR DESCRIPTION
## Summary

- New \`workflow_dispatch\`-only workflow at \`.github/workflows/sft-train.yml\` to kick off real SFT training from any ref (default \`main\`) without opening a PR.
- Inputs: \`num_samples\`, \`epochs\`, \`ref\`, \`gpu_type\`.
- A \`calc-budget\` job derives the in-pod watchdog and the GH Actions \`timeout-minutes\` from \`num_samples × epochs\` so longer runs get more headroom automatically. Calibrated so 300k × 30 reproduces the existing 4h watchdog; floored at 15 min, capped at the 6h hosted-runner ceiling.
- \`scripts/ci/sft_smoke_test.sh\` now reads a \`WATCHDOG_SECONDS\` env var (defaults to the previous \`14400\`), so the existing PR-label-triggered smoke test path is unchanged.

## Test plan

- [ ] Run workflow from Actions UI on \`main\` with the defaults (100k samples, 30 epochs) and confirm the budget step picks ~85 min watchdog / ~115 min job timeout.
- [ ] Confirm the W&B run appears in \`factorion\` project and the SFT summary lands in the GitHub Actions step summary.
- [ ] Verify the existing PR-label-triggered \`sft-smoketest\` job still works on a separate PR (unchanged defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)