### PR TITLE
Overfit experiment: SFT on MOVE_ONE_ITEM only

### DIFF
--- a/.github/workflows/ppo-train.yml
+++ b/.github/workflows/ppo-train.yml
@@ -47,6 +47,16 @@ on:
         required: false
         default: "0.02"
         type: string
+      lr_anneal_timesteps:
+        description: "Anneal LR -> min_lr over the first N env steps, then hold (decoupled from total_timesteps). 0 = legacy anneal-to-0 over the whole run"
+        required: false
+        default: "500000"
+        type: string
+      min_lr:
+        description: "LR floor held after lr_anneal_timesteps (keeps a long run improving instead of freezing at 0)"
+        required: false
+        default: "1e-5"
+        type: string
       seed:
         description: "Random seed"
         required: false
@@ -150,6 +160,8 @@ jobs:
             ENT_COEF="${{ inputs.ent_coef }}" \
             LEARNING_RATE="${{ inputs.learning_rate }}" \
             TARGET_KL="${{ inputs.target_kl }}" \
+            LR_ANNEAL_TIMESTEPS="${{ inputs.lr_anneal_timesteps }}" \
+            MIN_LR="${{ inputs.min_lr }}" \
             SEED="${{ inputs.seed }}" \
             WATCHDOG_SECONDS="$WATCHDOG_SECONDS" \
             PR_NUMBER="manual-${REF}" \

--- a/.github/workflows/ppo-train.yml
+++ b/.github/workflows/ppo-train.yml
@@ -32,6 +32,21 @@ on:
         required: false
         default: "22"
         type: string
+      ent_coef:
+        description: "Entropy bonus (constant; sets both start & end). 0 = no entropy bonus, right for finetuning an SFT policy"
+        required: false
+        default: "0"
+        type: string
+      learning_rate:
+        description: "Peak LR. Small (e.g. 5e-5) for stable SFT finetuning"
+        required: false
+        default: "5e-5"
+        type: string
+      target_kl:
+        description: "KL early-stop threshold per rollout (trust region). e.g. 0.02"
+        required: false
+        default: "0.02"
+        type: string
       seed:
         description: "Random seed"
         required: false
@@ -132,6 +147,9 @@ jobs:
             SIZE="${{ inputs.size }}" \
             CRITIC_WARMUP="${{ inputs.critic_warmup }}" \
             START_CURRICULUM_LEVEL="${{ inputs.start_curriculum_level }}" \
+            ENT_COEF="${{ inputs.ent_coef }}" \
+            LEARNING_RATE="${{ inputs.learning_rate }}" \
+            TARGET_KL="${{ inputs.target_kl }}" \
             SEED="${{ inputs.seed }}" \
             WATCHDOG_SECONDS="$WATCHDOG_SECONDS" \
             PR_NUMBER="manual-${REF}" \

--- a/.github/workflows/ppo-train.yml
+++ b/.github/workflows/ppo-train.yml
@@ -1,0 +1,155 @@
+name: PPO Train (manual)
+
+# Kick off a real PPO (RL) training run from any branch (no PR required),
+# continuing from an SFT checkpoint, using the ppo_train.sh in-pod pipeline.
+# The pod-side watchdog and the GH Actions job timeout are both derived from
+# total_timesteps so longer runs get more headroom automatically.
+
+on:
+  workflow_dispatch:
+    inputs:
+      start_from:
+        description: "SFT checkpoint to continue from: a W&B run id OR a local .pt path"
+        required: true
+        type: string
+      total_timesteps:
+        description: "PPO total timesteps"
+        required: true
+        default: "500000"
+        type: string
+      size:
+        description: "Grid size (must match the SFT checkpoint)"
+        required: false
+        default: "11"
+        type: string
+      critic_warmup:
+        description: "Critic-only warm-up iterations before joint PPO"
+        required: false
+        default: "10"
+        type: string
+      start_curriculum_level:
+        description: "num_missing_entities cap (~2*size blanks the whole factory)"
+        required: false
+        default: "22"
+        type: string
+      seed:
+        description: "Random seed"
+        required: false
+        default: "1"
+        type: string
+      ref:
+        description: "Git ref to run (branch / SHA / tag)"
+        required: false
+        default: "main"
+        type: string
+      gpu_type:
+        description: "RunPod GPU type"
+        required: false
+        default: "NVIDIA A100 80GB PCIe"
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  WANDB_CI_PROJECT: factorion
+  PYTHON_VERSION: "3.11"
+
+jobs:
+  # ──────────────────────────────────────────────
+  # Job 0: Compute time budget from total_timesteps
+  # ──────────────────────────────────────────────
+  calc-budget:
+    runs-on: ubuntu-latest
+    outputs:
+      job_timeout: ${{ steps.calc.outputs.job_timeout }}
+      watchdog_seconds: ${{ steps.calc.outputs.watchdog_seconds }}
+    steps:
+      - name: Compute budget
+        id: calc
+        env:
+          TOTAL_TIMESTEPS: ${{ inputs.total_timesteps }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import os
+          t = int(os.environ["TOTAL_TIMESTEPS"])
+          # Conservative A100 PPO rate (~200 env-steps/sec incl. the Rust
+          # throughput sim + curriculum eval), with a 2x safety margin so the
+          # watchdog never kills a legitimate run early. Calibratable.
+          base_seconds = t / 200
+          watchdog = int(base_seconds * 2 + 900)
+          watchdog = max(watchdog, 1800)          # floor: 30 min
+          job_minutes = int(watchdog / 60) + 30   # + pod create/teardown
+          job_minutes = min(job_minutes, 360)     # hosted-runner 6h cap
+          print(f"watchdog_seconds={watchdog}")
+          print(f"job_timeout={job_minutes}")
+          PY
+          echo "Budget:"
+          cat "$GITHUB_OUTPUT"
+
+  # ──────────────────────────────────────────────
+  # Job 1: PPO training on RunPod GPU
+  # ──────────────────────────────────────────────
+  ppo-train:
+    needs: [calc-budget]
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ fromJSON(needs.calc-budget.outputs.job_timeout) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          ref: ${{ inputs.ref }}
+
+      - name: Setup RunPod
+        id: runpod
+        uses: ./.github/actions/runpod-setup
+        with:
+          runpod_api_key: ${{ secrets.RUNPOD_API_KEY }}
+          ssh_private_key: ${{ secrets.RUNPOD_SSH_PRIVATE_KEY }}
+          gpu_type: ${{ inputs.gpu_type }}
+          name_prefix: ci-ppo-train
+
+      - name: Run PPO training on GPU
+        env:
+          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+          RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
+        run: |
+          SSH_HOST="${{ steps.runpod.outputs.ssh_host }}"
+          SSH_PORT="${{ steps.runpod.outputs.ssh_port }}"
+          POD_ID="${{ steps.runpod.outputs.pod_id }}"
+          REF="${{ inputs.ref }}"
+          WATCHDOG_SECONDS="${{ needs.calc-budget.outputs.watchdog_seconds }}"
+
+          scp -i ~/.ssh/runpod_ci -P "$SSH_PORT" \
+            scripts/ci/ppo_train.sh \
+            root@"$SSH_HOST":/workspace/ppo_train.sh
+
+          ssh -i ~/.ssh/runpod_ci -p "$SSH_PORT" root@"$SSH_HOST" \
+            WANDB_API_KEY="$WANDB_API_KEY" \
+            WANDB_PROJECT="${{ env.WANDB_CI_PROJECT }}" \
+            START_FROM="${{ inputs.start_from }}" \
+            TOTAL_TIMESTEPS="${{ inputs.total_timesteps }}" \
+            SIZE="${{ inputs.size }}" \
+            CRITIC_WARMUP="${{ inputs.critic_warmup }}" \
+            START_CURRICULUM_LEVEL="${{ inputs.start_curriculum_level }}" \
+            SEED="${{ inputs.seed }}" \
+            WATCHDOG_SECONDS="$WATCHDOG_SECONDS" \
+            PR_NUMBER="manual-${REF}" \
+            COMMIT_SHA="$GITHUB_SHA" \
+            RUNPOD_API_KEY="$RUNPOD_API_KEY" \
+            RUNPOD_POD_ID="$POD_ID" \
+            bash /workspace/ppo_train.sh
+
+      - name: Teardown RunPod
+        if: always()
+        uses: ./.github/actions/runpod-teardown
+        with:
+          runpod_api_key: ${{ secrets.RUNPOD_API_KEY }}
+          summary_file: /tmp/ppo_summary.md
+
+      - name: Publish summary to job
+        if: always()
+        run: |
+          if [ -f /tmp/ppo_summary.md ]; then
+            cat /tmp/ppo_summary.md >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,27 @@ uv pip install -r requirements.txt
 uv run maturin develop --release --manifest-path factorion_rs/Cargo.toml
 ```
 
+### Fresh worktree / venv setup
+
+Each `.claude/worktrees/<name>/` is a brand-new checkout with an **empty
+`.venv`**. The `pre-push` git hook runs the full pre-completion checklist
+(`cargo fmt/clippy/test`, `maturin`, `ruff`, `pytest`) and will fail with
+`command not found` until the venv is populated.
+
+**Do not use `requirements.txt` in a worktree** — it does not resolve cleanly
+under `uv` (fastapi/runpod/starlette pin conflicts). Instead mirror CI's
+per-package install list (kept in sync with `.github/workflows/ci.yml`):
+
+```bash
+uv pip install ruff==0.11.8 pytest pytest-timeout
+uv pip install torch --index-url https://download.pytorch.org/whl/cpu
+uv pip install numpy gymnasium networkx tyro pydantic marimo maturin tqdm matplotlib pandas plotly wandb tensorboard runpod
+uv run maturin develop --release --manifest-path factorion_rs/Cargo.toml
+```
+
+`runpod` is required at pytest **collection** time (`tests/test_runpod_cost.py`
+imports `scripts/ci/runpod_destroy.py`), so don't omit it.
+
 ## Running
 
 ```bash
@@ -70,6 +91,35 @@ Run a W&B sweep:
 ```bash
 bash run_sweep.sh
 ```
+
+## CI & RunPod GPU jobs
+
+CI lives in `.github/workflows/ci.yml`. The cheap jobs (`lint`, `python-tests`,
+`rust-tests`) run on every PR. The **GPU jobs run on RunPod and are
+label-gated** — they do **not** fire on a plain PR open. The `check-gpu-trigger`
+job decides what runs based on PR **labels** or a manual `workflow_dispatch`.
+Because `labeled` is in the trigger list, **adding a label to an existing PR
+kicks the job off** (no new push needed).
+
+Existing labels → what they run:
+
+| Label | Job / script | What it does |
+|-------|--------------|--------------|
+| `gpu-test` | `gpu-smoke-test` → `scripts/ci/gpu_smoke_test.sh` | Quick PPO/env GPU smoke |
+| `gpu-benchmark` | `gpu-benchmark` | Multi-seed PPO throughput comparison vs baseline |
+| `sweep` | `sweep-setup` → `gpu-sweep` → `sweep-report` | PPO W&B Bayesian sweep (`sweep.yaml`) |
+| `sft-smoketest` | `sft-smoke-test` → `scripts/ci/sft_smoke_test.sh` | **One** tracked run: `sft.py --size 11 --num-samples 300000 --epochs 30 --track`. Despite the name it's a full run (4h watchdog). |
+| `sft-sweep` | `sft-sweep-setup` → `sft-sweep` → `sft-sweep-report` | SFT W&B Bayesian sweep (`sft_sweep.yaml`): every run pinned to size=11 / 300k samples / 30 epochs, searches LR schedule, regularisation, per-head loss weights, encoder channels. `run_cap: 60`, ~20 runs / 5 agents by default. Optimises `val/acc`. |
+
+**Gotcha:** the trigger logic also checks for an `sft-benchmark` label
+(`scripts/ci/sft_benchmark.sh`, a multi-seed SFT comparison), **but no such
+GitHub label exists** in the repo — so the benchmark can only be launched via
+`workflow_dispatch`, or by creating the label first.
+
+RunPod pods self-terminate via a watchdog (4h smoketest / 2h benchmark) plus a
+teardown action; result summaries (and sweep URLs) are posted back as PR
+comments. All SFT runs log to the `factorion` W&B project; the north-star
+metric for the current MOVE_ONE_ITEM overfit work is `val/MOVE_ONE_ITEM/throughput`.
 
 ## Linting
 

--- a/factorion.py
+++ b/factorion.py
@@ -193,9 +193,7 @@ DIR_TO_DELTA = {
 
 
 def b64_to_dict(blueprint_string):
-    decoded = base64.b64decode(
-        blueprint_string.strip()[1:]
-    )  # Skip the version byte
+    decoded = base64.b64decode(blueprint_string.strip()[1:])  # Skip the version byte
     json_data = zlib.decompress(decoded).decode("utf-8")
     return json.loads(json_data)
 
@@ -209,9 +207,7 @@ def dict2b64(dictionary):
 
 def str2item(s):
     assert s is not None, "input cannot be None"
-    return next(
-        (v for k, v in items.items() if v.name == s.replace("-", "_")), None
-    )
+    return next((v for k, v in items.items() if v.name == s.replace("-", "_")), None)
 
 
 def str2ent(s):
@@ -302,9 +298,7 @@ def world2html(world_WHC, highlights=None):
     (overrides the default unavailable-footprint shading). Useful for
     visualising diffs, model predictions, etc.
     """
-    assert len(world_WHC.shape) == 3, (
-        f"Expected 3 dimensions got {world_WHC.shape}"
-    )
+    assert len(world_WHC.shape) == 3, f"Expected 3 dimensions got {world_WHC.shape}"
     assert world_WHC.shape[0] == world_WHC.shape[1], (
         f"Expected square got {world_WHC.shape}"
     )
@@ -334,7 +328,9 @@ def world2html(world_WHC, highlights=None):
             if proto.width == 1 and proto.height == 1:
                 continue
             d_val = world_WHC[x, y, Channel.DIRECTION.value]
-            tile_list = factorion_rs.py_entity_tiles(x, y, int(d_val), proto.width, proto.height)
+            tile_list = factorion_rs.py_entity_tiles(
+                x, y, int(d_val), proto.width, proto.height
+            )
             if tile_list is None:
                 continue
             anchor = tuple(tile_list[0])
@@ -406,8 +402,7 @@ def world2html(world_WHC, highlights=None):
 
             #             print(direction_arrow, direction)
             available = (
-                world_WHC[x, y, Channel.FOOTPRINT.value]
-                == Footprint.AVAILABLE.value
+                world_WHC[x, y, Channel.FOOTPRINT.value] == Footprint.AVAILABLE.value
             )
             if highlights and (x, y) in highlights:
                 bg_style = f"background: {highlights[(x, y)]};"
@@ -453,8 +448,14 @@ def world2html(world_WHC, highlights=None):
             def _border_css(prefix, color):
                 return "; ".join(
                     f"border-{side}: 1px solid {'transparent' if hide else color}"
-                    for side, hide in (("top", hide_n), ("right", hide_e), ("bottom", hide_s), ("left", hide_w))
+                    for side, hide in (
+                        ("top", hide_n),
+                        ("right", hide_e),
+                        ("bottom", hide_s),
+                        ("left", hide_w),
+                    )
                 )
+
             td_border_css = _border_css("td", "black")
             div_border_css = _border_css("div", "grey")
 
@@ -469,9 +470,7 @@ def world2html(world_WHC, highlights=None):
     <div style=' position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);  font-size: 20px; font-weight: bold; color: white; '>{underground_symbol}</div>
 </div>
             """
-            html.append(
-                f"<td style='{td_border_css}; padding: 0;'>{cell_content}</td>"
-            )
+            html.append(f"<td style='{td_border_css}; padding: 0;'>{cell_content}</td>")
         html.append("</tr>")
     html.append("</table>")
     return Html("".join(html))
@@ -508,9 +507,7 @@ def _parse_combinator_marker(e):
     arrow virtual signal (`up/right/down/left-arrow` → direction).
     Returns (role, item_name, direction) or None if the combinator
     isn't a recognized marker."""
-    sections = (
-        e.get("control_behavior", {}).get("sections", {}).get("sections", [])
-    )
+    sections = e.get("control_behavior", {}).get("sections", {}).get("sections", [])
     if not sections:
         return None
     filters = sections[0].get("filters", [])
@@ -566,10 +563,7 @@ def blueprint2world(bp):
         if name == "constant-combinator":
             parsed = _parse_combinator_marker(e)
             if parsed is None:
-                print(
-                    f"WARN: skipping unrecognized constant-combinator at "
-                    f"({cx},{cy})"
-                )
+                print(f"WARN: skipping unrecognized constant-combinator at ({cx},{cy})")
                 continue
             role, item_name, model_dir = parsed
             ent_name = "stack_inserter" if role == "source" else "bulk_inserter"
@@ -623,9 +617,7 @@ def blueprint2world(bp):
         elif e.get("type") == "output":
             misc = Misc.UNDERGROUND_UP
 
-        placements.append(
-            (proto.name, tlx, tly, w, h, model_dir, item_val, misc)
-        )
+        placements.append((proto.name, tlx, tly, w, h, model_dir, item_val, misc))
 
     if not placements:
         raise ValueError("blueprint contains no recognized entities")
@@ -682,10 +674,14 @@ def read_blueprint_file(path):
 # Direction enum has NONE=0 plus NORTH=1, EAST=2, SOUTH=3, WEST=4 —
 # entries omitted from the maps stay put (NONE is unchanged by either
 # flip, N/S are unchanged by horizontal flip, E/W by vertical).
-_DIR_FLIP_H = {Direction.EAST.value: Direction.WEST.value,
-               Direction.WEST.value: Direction.EAST.value}
-_DIR_FLIP_V = {Direction.NORTH.value: Direction.SOUTH.value,
-               Direction.SOUTH.value: Direction.NORTH.value}
+_DIR_FLIP_H = {
+    Direction.EAST.value: Direction.WEST.value,
+    Direction.WEST.value: Direction.EAST.value,
+}
+_DIR_FLIP_V = {
+    Direction.NORTH.value: Direction.SOUTH.value,
+    Direction.SOUTH.value: Direction.NORTH.value,
+}
 
 
 def _flip_world(world_CWH, axis):
@@ -737,7 +733,8 @@ def _substitute_gears_recipe(world_CWH):
     Caller must have already verified eligibility via
     :func:`_is_gears_factory`."""
     one_in_one_out = [
-        (name, r) for name, r in recipes.items()
+        (name, r)
+        for name, r in recipes.items()
         if len(r.consumes) == 1 and len(r.produces) == 1
     ]
     if not one_in_one_out:
@@ -847,10 +844,7 @@ def _extend_belt_chains(world_CWH):
     item_ch = out[Channel.ITEMS.value]
 
     markers = [
-        (x, y)
-        for x in range(W)
-        for y in range(H)
-        if int(ent_ch[x, y]) in marker_ids
+        (x, y) for x in range(W) for y in range(H) if int(ent_ch[x, y]) in marker_ids
     ]
     random.shuffle(markers)
 
@@ -961,9 +955,7 @@ def plot_loss_history(loss_history):
     for k in loss_history[-1].keys():
         fig.add_trace(
             go.Scatter(
-                x=list(
-                    range(len(loss_history))
-                ),  # X-axis: range of iterations
+                x=list(range(len(loss_history))),  # X-axis: range of iterations
                 y=[
                     float(v[k]) if k in v else np.nan for v in loss_history
                 ],  # Y-axis: values for the current key
@@ -985,12 +977,8 @@ def plot_loss_history(loss_history):
 
 
 def normalise_world(world_T, og_world):
-    assert torch.is_tensor(world_T), (
-        f"world_T is {type(world_T)}, not a tensor"
-    )
-    assert torch.is_tensor(og_world), (
-        f"og_world is {type(og_world)}, not a tensor"
-    )
+    assert torch.is_tensor(world_T), f"world_T is {type(world_T)}, not a tensor"
+    assert torch.is_tensor(og_world), f"og_world is {type(og_world)}, not a tensor"
     assert len(world_T.shape) == 3, (
         f"Expected world_T to have 3 dimensions, but is of shape {world_T.shape}"
     )
@@ -1009,32 +997,21 @@ def normalise_world(world_T, og_world):
     bulk_inserter_mask = (
         world_T[:, :, Channel.ENTITIES.value] == str2ent("bulk_inserter").value
     )
-    world_T[:, :, Channel.ENTITIES.value][bulk_inserter_mask] = (
-        empty_entity_value
-    )
+    world_T[:, :, Channel.ENTITIES.value][bulk_inserter_mask] = empty_entity_value
 
     stack_inserter_mask = (
-        world_T[:, :, Channel.ENTITIES.value]
-        == str2ent("stack_inserter").value
+        world_T[:, :, Channel.ENTITIES.value] == str2ent("stack_inserter").value
     )
-    world_T[:, :, Channel.ENTITIES.value][stack_inserter_mask] = (
-        empty_entity_value
-    )
+    world_T[:, :, Channel.ENTITIES.value][stack_inserter_mask] = empty_entity_value
 
     green_circ_mask = (
-        world_T[:, :, Channel.ENTITIES.value]
-        == str2ent("electronic_circuit").value
+        world_T[:, :, Channel.ENTITIES.value] == str2ent("electronic_circuit").value
     )
     world_T[:, :, Channel.ENTITIES.value][green_circ_mask] = empty_entity_value
 
     # Remove all transport belts without direction
-    belt_mask = (
-        world_T[:, :, Channel.ENTITIES.value]
-        == str2ent("transport_belt").value
-    )
-    no_direction_mask = (
-        world_T[:, :, Channel.DIRECTION.value] == Direction.NONE.value
-    )
+    belt_mask = world_T[:, :, Channel.ENTITIES.value] == str2ent("transport_belt").value
+    no_direction_mask = world_T[:, :, Channel.DIRECTION.value] == Direction.NONE.value
     world_T[:, :, Channel.ENTITIES.value][belt_mask & no_direction_mask] = (
         empty_entity_value
     )
@@ -1052,9 +1029,7 @@ def normalise_world(world_T, og_world):
     # Ensure the model can't just overwrite existing factories with a simpler thing.
     tworld = og_world.clone().detach().to(torch.int64)
     # tworld = torch.tensor(og_world, dtype=torch.int64)
-    original_had_something = (
-        tworld[:, :, Channel.ENTITIES.value] != empty_entity_value
-    )
+    original_had_something = tworld[:, :, Channel.ENTITIES.value] != empty_entity_value
     for ch in list(Channel):
         replacements = tworld[:, :, ch.value][original_had_something]
         world_T[:, :, ch.value][original_had_something] = replacements
@@ -1062,24 +1037,18 @@ def normalise_world(world_T, og_world):
 
 
 def get_min_belts(world_CWH):
-    assert world_CWH.shape[1] == world_CWH.shape[2], (
-        "Wrong shape: {world_CWH.shape}"
-    )
+    assert world_CWH.shape[1] == world_CWH.shape[2], "Wrong shape: {world_CWH.shape}"
     C, W, H = world_CWH.shape
 
     stack_inserter_id = str2ent("stack_inserter").value
     bulk_inserter_id = str2ent("bulk_inserter").value
-    coords1 = torch.where(
-        world_CWH[Channel.ENTITIES.value] == bulk_inserter_id
-    )
+    coords1 = torch.where(world_CWH[Channel.ENTITIES.value] == bulk_inserter_id)
     assert len(coords1[0]) == len(coords1[1]) == 1, (
         f"Expected 1 bulk inserter, found {coords1} in world {world_CWH}"
     )
     w1, h1 = coords1[0][0], coords1[1][0]
 
-    coords2 = torch.where(
-        world_CWH[Channel.ENTITIES.value] == stack_inserter_id
-    )
+    coords2 = torch.where(world_CWH[Channel.ENTITIES.value] == stack_inserter_id)
     assert len(coords2[0]) == len(coords2[1]) == 1, (
         f"Expected 1 stack inserter, found {coords2} in world {world_CWH}"
     )
@@ -1192,9 +1161,7 @@ def eval_model(actor, critic, pars, num_evaluations=1_000, pbar=False):
     for seed in iterator:
         original_world = get_new_world(seed, n=4)
         probabilities = actor(original_world)
-        normalised_world = normalise_world(
-            sample_world(probabilities), original_world
-        )
+        normalised_world = normalise_world(sample_world(probabilities), original_world)
         # value = critic(normalised_world)
         value = critic(normalised_world.to(torch.float))
         # Maybe having throughput being calculated as a black box is the problem?
@@ -1203,8 +1170,7 @@ def eval_model(actor, critic, pars, num_evaluations=1_000, pbar=False):
             dtype=value.dtype,
         )
         num_entities = (
-            normalised_world[:, :, Channel.ENTITIES.value]
-            != str2ent("empty").value
+            normalised_world[:, :, Channel.ENTITIES.value] != str2ent("empty").value
         ).sum()
         evals.append(
             {
@@ -1217,9 +1183,7 @@ def eval_model(actor, critic, pars, num_evaluations=1_000, pbar=False):
         )
 
     avg_throughput = sum([eval["throughput"] for eval in evals]) / len(evals)
-    avg_num_entities = sum([eval["num_entities"] for eval in evals]) / len(
-        evals
-    )
+    avg_num_entities = sum([eval["num_entities"] for eval in evals]) / len(evals)
 
     return evals, avg_throughput, float(avg_num_entities)
 
@@ -1233,9 +1197,7 @@ def funge_throughput(world, debug=False):
 
 
 def world2graph(world_WHC, debug=False):
-    assert torch.is_tensor(world_WHC), (
-        f"world is {type(world_WHC)}, not a tensor"
-    )
+    assert torch.is_tensor(world_WHC), f"world is {type(world_WHC)}, not a tensor"
     assert len(world_WHC.shape) == 3, (
         f"Expected world to have 3 dimensions, but is of shape {world_WHC.shape}"
     )
@@ -1339,13 +1301,13 @@ def world2graph(world_WHC, debug=False):
                     )
                     src_not_empty = src_entity.name != "empty"
                     if src_not_empty:
-                        pending_edges.append((
-                            f"{src_entity.name}\n@{src[0]},{src[1]}",
-                            f"{e.name}\n@{x},{y}",
-                        ))
-                        dbg(
-                            f"{src_entity.name}@{src[0]},{src[1]} -> {e.name}@{x},{y}"
+                        pending_edges.append(
+                            (
+                                f"{src_entity.name}\n@{src[0]},{src[1]}",
+                                f"{e.name}\n@{x},{y}",
+                            )
                         )
+                        dbg(f"{src_entity.name}@{src[0]},{src[1]} -> {e.name}@{x},{y}")
                 if x_dst_valid and y_dst_valid:
                     dst_entity = entities[
                         world_WHC[dst[0], dst[1], Channel.ENTITIES.value]
@@ -1358,13 +1320,13 @@ def world2graph(world_WHC, debug=False):
                         or "assembling_machine" in dst_entity.name
                     )
                     if dst_is_insertable:
-                        pending_edges.append((
-                            f"{e.name}\n@{x},{y}",
-                            f"{dst_entity.name}\n@{dst[0]},{dst[1]}",
-                        ))
-                        dbg(
-                            f"{e.name}@{x},{y} -> {dst_entity.name}@{dst[0]},{dst[1]}"
+                        pending_edges.append(
+                            (
+                                f"{e.name}\n@{x},{y}",
+                                f"{dst_entity.name}\n@{dst[0]},{dst[1]}",
+                            )
                         )
+                        dbg(f"{e.name}@{x},{y} -> {dst_entity.name}@{dst[0]},{dst[1]}")
 
             elif "transport_belt" in e.name:
                 if x_src_valid and y_src_valid:
@@ -1374,9 +1336,7 @@ def world2graph(world_WHC, debug=False):
                     src_direction = Direction(
                         world_WHC[src[0], src[1], Channel.DIRECTION.value]
                     )
-                    src_misc = Misc(
-                        world_WHC[src[0], src[1], Channel.MISC.value]
-                    )
+                    src_misc = Misc(world_WHC[src[0], src[1], Channel.MISC.value])
                     src_is_beltish = (
                         "belt" in src_entity.name
                         # Check the other belt is directly behind me and
@@ -1389,10 +1349,12 @@ def world2graph(world_WHC, debug=False):
                         )
                     )
                     if src_is_beltish:
-                        pending_edges.append((
-                            f"{src_entity.name}\n@{src[0]},{src[1]}",
-                            f"{e.name}\n@{x},{y}",
-                        ))
+                        pending_edges.append(
+                            (
+                                f"{src_entity.name}\n@{src[0]},{src[1]}",
+                                f"{e.name}\n@{x},{y}",
+                            )
+                        )
                         dbg(
                             f"{src_entity.name}@{src[0]},{src[1]} -> {e.name}@{x},{y}",
                         )
@@ -1404,15 +1366,12 @@ def world2graph(world_WHC, debug=False):
                     dst_direction = Direction(
                         world_WHC[dst[0], dst[1], Channel.DIRECTION.value]
                     )
-                    dst_misc = Misc(
-                        world_WHC[dst[0], dst[1], Channel.MISC.value]
-                    )
+                    dst_misc = Misc(world_WHC[dst[0], dst[1], Channel.MISC.value])
                     dst_not_empty = dst_entity.name != "empty"
                     dst_is_belt = "belt" in dst_entity.name
                     opposite = Direction.SOUTH.value - Direction.NORTH.value
                     dst_opposing_belt = (
-                        dst_is_belt
-                        and abs(dst_direction.value - d.value) == opposite
+                        dst_is_belt and abs(dst_direction.value - d.value) == opposite
                     )
                     # various underground belt checks
                     # TODO figure out these checks
@@ -1423,15 +1382,13 @@ def world2graph(world_WHC, debug=False):
                         #     (dst_direction.value == d.value and dst_misc.value == Misc.UNDERGROUND_DOWN)
                         # )
                     )
-                    if (
-                        dst_is_belt
-                        and not dst_opposing_belt
-                        and dest_underground_ok
-                    ):
-                        pending_edges.append((
-                            f"{e.name}\n@{x},{y}",
-                            f"{dst_entity.name}\n@{dst[0]},{dst[1]}",
-                        ))
+                    if dst_is_belt and not dst_opposing_belt and dest_underground_ok:
+                        pending_edges.append(
+                            (
+                                f"{e.name}\n@{x},{y}",
+                                f"{dst_entity.name}\n@{dst[0]},{dst[1]}",
+                            )
+                        )
                         dbg(
                             f"{e.name}@{x},{y} -> {dst_entity.name}@{dst[0]},{dst[1]}",
                         )
@@ -1533,10 +1490,12 @@ def world2graph(world_WHC, debug=False):
                             and m == Misc.UNDERGROUND_UP
                         )
                         if going_underground or cxn_to_belt:
-                            pending_edges.append((
-                                f"{e.name}\n@{x},{y}",
-                                f"{dst_entity.name}\n@{dst[0]},{dst[1]}",
-                            ))
+                            pending_edges.append(
+                                (
+                                    f"{e.name}\n@{x},{y}",
+                                    f"{dst_entity.name}\n@{dst[0]},{dst[1]}",
+                                )
+                            )
             elif "splitter" in e.name:
                 tiles = factorion_rs.py_entity_tiles(x, y, d.value, e.width, e.height)
                 if tiles is None:
@@ -1567,14 +1526,17 @@ def world2graph(world_WHC, debug=False):
                         # Only accept belt-like entities or sources/sinks
                         # pointing in the same direction as the splitter
                         in_is_belt = "belt" in in_ent.name and in_dir == d
-                        in_is_source_sink = in_ent.name in (
-                            "stack_inserter", "bulk_inserter"
-                        ) and in_dir == d
+                        in_is_source_sink = (
+                            in_ent.name in ("stack_inserter", "bulk_inserter")
+                            and in_dir == d
+                        )
                         if in_is_belt or in_is_source_sink:
-                            pending_edges.append((
-                                f"{in_ent.name}\n@{in_cell[0]},{in_cell[1]}",
-                                self_name,
-                            ))
+                            pending_edges.append(
+                                (
+                                    f"{in_ent.name}\n@{in_cell[0]},{in_cell[1]}",
+                                    self_name,
+                                )
+                            )
 
                     # Output: cell ahead of this tile
                     out_cell = (tx + dx, ty + dy)
@@ -1584,26 +1546,25 @@ def world2graph(world_WHC, debug=False):
                         and out_cell not in tiles
                     ):
                         out_ent = entities[
-                            world_WHC[
-                                out_cell[0], out_cell[1], Channel.ENTITIES.value
-                            ]
+                            world_WHC[out_cell[0], out_cell[1], Channel.ENTITIES.value]
                         ]
                         out_dir = Direction(
-                            world_WHC[
-                                out_cell[0], out_cell[1], Channel.DIRECTION.value
-                            ]
+                            world_WHC[out_cell[0], out_cell[1], Channel.DIRECTION.value]
                         )
                         # Only connect to belt-like entities or sinks,
                         # not facing the opposite direction
                         out_is_belt = "belt" in out_ent.name
                         out_is_sink = out_ent.name in (
-                            "stack_inserter", "bulk_inserter"
+                            "stack_inserter",
+                            "bulk_inserter",
                         )
                         if (out_is_belt or out_is_sink) and out_dir != opposite_dir:
-                            pending_edges.append((
-                                self_name,
-                                f"{out_ent.name}\n@{out_cell[0]},{out_cell[1]}",
-                            ))
+                            pending_edges.append(
+                                (
+                                    self_name,
+                                    f"{out_ent.name}\n@{out_cell[0]},{out_cell[1]}",
+                                )
+                            )
 
             else:
                 assert False, f"Don't know how to handle {e.name} at {x} {y}"
@@ -1661,7 +1622,9 @@ def _remove_entities(
             if ent.width == 1 and ent.height == 1:
                 continue
             d_val = world_CWH[Channel.DIRECTION.value, x, y].item()
-            tiles_list = factorion_rs.py_entity_tiles(x, y, d_val, ent.width, ent.height)
+            tiles_list = factorion_rs.py_entity_tiles(
+                x, y, d_val, ent.width, ent.height
+            )
             if tiles_list is not None:
                 for tx, ty in tiles_list:
                     if (tx, ty) != (x, y):
@@ -1681,8 +1644,12 @@ def _remove_entities(
                 group = {(x, y)}
             else:
                 d_val = world_CWH[Channel.DIRECTION.value, x, y].item()
-                tiles_list = factorion_rs.py_entity_tiles(x, y, d_val, ent.width, ent.height)
-                group = set(map(tuple, tiles_list)) if tiles_list is not None else {(x, y)}
+                tiles_list = factorion_rs.py_entity_tiles(
+                    x, y, d_val, ent.width, ent.height
+                )
+                group = (
+                    set(map(tuple, tiles_list)) if tiles_list is not None else {(x, y)}
+                )
             if group & protected_positions:
                 continue
             entity_groups.append(group)
@@ -1700,6 +1667,29 @@ def _remove_entities(
             world_CWH[Channel.MISC.value, x, y] = Misc.NONE.value
 
     return num_samples
+
+
+# Move-direction priority for the canonical MOVE_ONE_ITEM path (derisk
+# experiment to remove multiple-shortest-path ambiguity): North > East > South
+# > West. Keyed by (drow, dcol) so it is independent of the Direction enum's
+# names; row 0 is the top, so North == row-decreasing == (-1, 0).
+_MOVE_PRIORITY = {(-1, 0): 0, (0, 1): 1, (1, 0): 2, (0, -1): 3}
+
+
+def _canonical_path_key(path):
+    """Sort key selecting the single canonical belt path.
+
+    ``path`` is a list of ``(row, col, Direction)`` belt placements. The key is
+    the sequence of move-direction priorities (North>East>South>West) between
+    consecutive cells, so ``min(paths, key=_canonical_path_key)`` over the
+    equal-length shortest paths returns the lexicographically-smallest one — go
+    as far North as needed, then East, then South, then West, never
+    backtracking.
+    """
+    return [
+        _MOVE_PRIORITY[(x2 - x1, y2 - y1)]
+        for (x1, y1, _), (x2, y2, _) in zip(path, path[1:])
+    ]
 
 
 def build_factory(
@@ -1741,9 +1731,7 @@ def build_factory(
         torch.manual_seed(seed)
     total_entities: int = 0
     protected_positions: frozenset = frozenset()
-    world_CWH = torch.tensor(new_world(width=size, height=size)).permute(
-        2, 0, 1
-    )
+    world_CWH = torch.tensor(new_world(width=size, height=size)).permute(2, 0, 1)
     C, W, H = world_CWH.shape
     # No idea why, but there doing kind == LessonKind.MOVE_ONE_ITEM doesn't evaluate to true...
     if kind.value == LessonKind.MOVE_ONE_ITEM.value:
@@ -1762,12 +1750,8 @@ def build_factory(
 
             source_WH = divmod(pos1.item(), W)
             sink_WH = divmod(pos2.item(), W)
-            source_dir = random.choice(
-                [d for d in Direction if d != Direction.NONE]
-            )
-            sink_dir = random.choice(
-                [d for d in Direction if d != Direction.NONE]
-            )
+            source_dir = random.choice([d for d in Direction if d != Direction.NONE])
+            sink_dir = random.choice([d for d in Direction if d != Direction.NONE])
 
             if random_item:
                 item_value = random.choice(
@@ -1776,24 +1760,20 @@ def build_factory(
             else:
                 item_value = str2item("electronic_circuit").value
 
-            world_CWH[Channel.ENTITIES.value, source_WH[0], source_WH[1]] = (
-                str2ent("source").value
-            )
-            world_CWH[Channel.ENTITIES.value, sink_WH[0], sink_WH[1]] = (
-                str2ent("sink").value
-            )
+            world_CWH[Channel.ENTITIES.value, source_WH[0], source_WH[1]] = str2ent(
+                "source"
+            ).value
+            world_CWH[Channel.ENTITIES.value, sink_WH[0], sink_WH[1]] = str2ent(
+                "sink"
+            ).value
 
-            world_CWH[Channel.ITEMS.value, source_WH[0], source_WH[1]] = (
-                item_value
-            )
+            world_CWH[Channel.ITEMS.value, source_WH[0], source_WH[1]] = item_value
             world_CWH[Channel.ITEMS.value, sink_WH[0], sink_WH[1]] = item_value
 
             world_CWH[Channel.DIRECTION.value, source_WH[0], source_WH[1]] = (
                 source_dir.value
             )
-            world_CWH[Channel.DIRECTION.value, sink_WH[0], sink_WH[1]] = (
-                sink_dir.value
-            )
+            world_CWH[Channel.DIRECTION.value, sink_WH[0], sink_WH[1]] = sink_dir.value
             # print(world_CWH)
             # print(f"world so far: ")
             # print(world_CWH[0])
@@ -1808,14 +1788,22 @@ def build_factory(
             # print('filtered paths', len(paths))
 
             if len(paths) == 0:
-                world_CWH = torch.tensor(
-                    new_world(width=size, height=size)
-                ).permute(2, 0, 1)
+                world_CWH = torch.tensor(new_world(width=size, height=size)).permute(
+                    2, 0, 1
+                )
                 # Restart the loop until we get a source+sink that can be connected
                 continue
             else:
-                # Choose a valid path at random and add it to the map
-                chosen_path = random.choice(paths)
+                # DERISK EXPERIMENT: pick the single canonical path instead of a
+                # random one, so each (source, sink) has exactly ONE valid
+                # MOVE_ONE_ITEM completion and the direction target is
+                # unambiguous. Canonical = exhaust North, then East, then South,
+                # then West, never backtracking (see _canonical_path_key). If
+                # this makes loss_dir plummet, multiple-shortest-path ambiguity
+                # was the dir_acc ceiling. To restore path diversity later,
+                # revert to random.choice(paths) or move to a multi-target
+                # direction loss that rewards any valid path.
+                chosen_path = min(paths, key=_canonical_path_key)
                 total_entities = len(chosen_path)
                 for x, y, d in chosen_path:
                     world_CWH[Channel.ENTITIES.value, x, y] = str2ent(
@@ -1842,7 +1830,9 @@ def build_factory(
 
         while count > 0:
             count -= 1
-            world_CWH = torch.tensor(new_world(width=size, height=size)).permute(2, 0, 1)
+            world_CWH = torch.tensor(new_world(width=size, height=size)).permute(
+                2, 0, 1
+            )
             C, W, H = world_CWH.shape
 
             dirs = [d for d in Direction if d != Direction.NONE]
@@ -1853,8 +1843,12 @@ def build_factory(
             for _ in range(20):
                 sx = random.randint(0, W - 1)
                 sy = random.randint(0, H - 1)
-                tiles = factorion_rs.py_entity_tiles(sx, sy, splitter_dir.value, splitter_ent.width, splitter_ent.height)
-                if tiles is not None and all(0 <= tx < W and 0 <= ty < H for tx, ty in tiles):
+                tiles = factorion_rs.py_entity_tiles(
+                    sx, sy, splitter_dir.value, splitter_ent.width, splitter_ent.height
+                )
+                if tiles is not None and all(
+                    0 <= tx < W and 0 <= ty < H for tx, ty in tiles
+                ):
                     break
                 tiles = None
             if tiles is None:
@@ -1881,7 +1875,9 @@ def build_factory(
 
             # Pick 1 source and 2 sinks at random positions (avoiding splitter tiles and I/O cells)
             reserved = tile_set | set(all_io)
-            available = [(x, y) for x in range(W) for y in range(H) if (x, y) not in reserved]
+            available = [
+                (x, y) for x in range(W) for y in range(H) if (x, y) not in reserved
+            ]
             if len(available) < 3:
                 continue
 
@@ -1921,14 +1917,32 @@ def build_factory(
             # Also block the unused input cell AND the cell behind it to
             # prevent sideloading into the splitter's unused input.
             blocked_base = all_fixed
-            unused_input_buffer_0 = (input_cells[0][0] - d_delta[0], input_cells[0][1] - d_delta[1])
-            unused_input_buffer_1 = (input_cells[1][0] - d_delta[0], input_cells[1][1] - d_delta[1])
+            unused_input_buffer_0 = (
+                input_cells[0][0] - d_delta[0],
+                input_cells[0][1] - d_delta[1],
+            )
+            unused_input_buffer_1 = (
+                input_cells[1][0] - d_delta[0],
+                input_cells[1][1] - d_delta[1],
+            )
 
-            blocked1 = blocked_base | set(output_cells) | {sink1_input, sink2_input, input_cells[1], unused_input_buffer_1}
-            path1 = find_belt_path(W, H, source_output, input_cells[0], splitter_dir, blocked1)
+            blocked1 = (
+                blocked_base
+                | set(output_cells)
+                | {sink1_input, sink2_input, input_cells[1], unused_input_buffer_1}
+            )
+            path1 = find_belt_path(
+                W, H, source_output, input_cells[0], splitter_dir, blocked1
+            )
             if path1 is None:
-                blocked1 = blocked_base | set(output_cells) | {sink1_input, sink2_input, input_cells[0], unused_input_buffer_0}
-                path1 = find_belt_path(W, H, source_output, input_cells[1], splitter_dir, blocked1)
+                blocked1 = (
+                    blocked_base
+                    | set(output_cells)
+                    | {sink1_input, sink2_input, input_cells[0], unused_input_buffer_0}
+                )
+                path1 = find_belt_path(
+                    W, H, source_output, input_cells[1], splitter_dir, blocked1
+                )
                 if path1 is None:
                     continue
 
@@ -1956,15 +1970,44 @@ def build_factory(
             path2 = None
             path3 = None
             for out_a, out_b, sk_a, sk_a_dir, sk_b, sk_b_dir in [
-                (output_cells[0], output_cells[1], sink1_input, sink1_dir, sink2_input, sink2_dir),
-                (output_cells[0], output_cells[1], sink2_input, sink2_dir, sink1_input, sink1_dir),
+                (
+                    output_cells[0],
+                    output_cells[1],
+                    sink1_input,
+                    sink1_dir,
+                    sink2_input,
+                    sink2_dir,
+                ),
+                (
+                    output_cells[0],
+                    output_cells[1],
+                    sink2_input,
+                    sink2_dir,
+                    sink1_input,
+                    sink1_dir,
+                ),
             ]:
-                blocked2 = blocked_base | path1_cells | {sk_b, out_b} | set(input_cells) | unused_block | sink_buffers
+                blocked2 = (
+                    blocked_base
+                    | path1_cells
+                    | {sk_b, out_b}
+                    | set(input_cells)
+                    | unused_block
+                    | sink_buffers
+                )
                 p2 = find_belt_path(W, H, out_a, sk_a, sk_a_dir, blocked2)
                 if p2 is None:
                     continue
                 p2_cells = {(x, y) for x, y, _ in p2}
-                blocked3 = blocked_base | path1_cells | p2_cells | {out_a} | set(input_cells) | unused_block | sink_buffers
+                blocked3 = (
+                    blocked_base
+                    | path1_cells
+                    | p2_cells
+                    | {out_a}
+                    | set(input_cells)
+                    | unused_block
+                    | sink_buffers
+                )
                 p3 = find_belt_path(W, H, out_b, sk_b, sk_b_dir, blocked3)
                 if p3 is not None:
                     path2, path3 = p2, p3
@@ -1975,18 +2018,28 @@ def build_factory(
             path2_cells = {(x, y) for x, y, _ in path2}
 
             # Enforce max_entities
-            total_entities = len(path1) + len(path2) + len(path3) + 1  # +1 for splitter (2 tiles but 1 entity)
+            total_entities = (
+                len(path1) + len(path2) + len(path3) + 1
+            )  # +1 for splitter (2 tiles but 1 entity)
             if total_entities > max_entities:
                 continue
 
             # Place source and sinks
-            world_CWH[Channel.ENTITIES.value, source_pos[0], source_pos[1]] = str2ent("source").value
-            world_CWH[Channel.DIRECTION.value, source_pos[0], source_pos[1]] = source_dir.value
+            world_CWH[Channel.ENTITIES.value, source_pos[0], source_pos[1]] = str2ent(
+                "source"
+            ).value
+            world_CWH[Channel.DIRECTION.value, source_pos[0], source_pos[1]] = (
+                source_dir.value
+            )
             world_CWH[Channel.ITEMS.value, source_pos[0], source_pos[1]] = item_value
 
             for sink_pos, sink_dir in [(sink1_pos, sink1_dir), (sink2_pos, sink2_dir)]:
-                world_CWH[Channel.ENTITIES.value, sink_pos[0], sink_pos[1]] = str2ent("sink").value
-                world_CWH[Channel.DIRECTION.value, sink_pos[0], sink_pos[1]] = sink_dir.value
+                world_CWH[Channel.ENTITIES.value, sink_pos[0], sink_pos[1]] = str2ent(
+                    "sink"
+                ).value
+                world_CWH[Channel.DIRECTION.value, sink_pos[0], sink_pos[1]] = (
+                    sink_dir.value
+                )
                 world_CWH[Channel.ITEMS.value, sink_pos[0], sink_pos[1]] = item_value
 
             # Place splitter (all tiles)
@@ -1996,7 +2049,9 @@ def build_factory(
 
             # Place belt paths
             for x, y, d in path1 + path2 + path3:
-                world_CWH[Channel.ENTITIES.value, x, y] = str2ent("transport_belt").value
+                world_CWH[Channel.ENTITIES.value, x, y] = str2ent(
+                    "transport_belt"
+                ).value
                 world_CWH[Channel.DIRECTION.value, x, y] = d.value
 
             # Verify throughput > 0
@@ -2039,7 +2094,9 @@ def build_factory(
 
         while count > 0:
             count -= 1
-            world_CWH = torch.tensor(new_world(width=size, height=size)).permute(2, 0, 1)
+            world_CWH = torch.tensor(new_world(width=size, height=size)).permute(
+                2, 0, 1
+            )
             C, W, H = world_CWH.shape
 
             dirs = [d for d in Direction if d != Direction.NONE]
@@ -2050,8 +2107,12 @@ def build_factory(
             for _ in range(20):
                 sx = random.randint(0, W - 1)
                 sy = random.randint(0, H - 1)
-                tiles = factorion_rs.py_entity_tiles(sx, sy, splitter_dir.value, splitter_ent.width, splitter_ent.height)
-                if tiles is not None and all(0 <= tx < W and 0 <= ty < H for tx, ty in tiles):
+                tiles = factorion_rs.py_entity_tiles(
+                    sx, sy, splitter_dir.value, splitter_ent.width, splitter_ent.height
+                )
+                if tiles is not None and all(
+                    0 <= tx < W and 0 <= ty < H for tx, ty in tiles
+                ):
                     break
                 tiles = None
             if tiles is None:
@@ -2071,7 +2132,9 @@ def build_factory(
 
             # Pick 2 sources and 1 sink
             reserved = tile_set | set(all_io)
-            available = [(x, y) for x in range(W) for y in range(H) if (x, y) not in reserved]
+            available = [
+                (x, y) for x in range(W) for y in range(H) if (x, y) not in reserved
+            ]
             if len(available) < 3:
                 continue
 
@@ -2105,21 +2168,37 @@ def build_factory(
 
             # Path 1: source1 output → splitter input 0
             blocked_base = all_fixed
-            blocked1 = blocked_base | set(output_cells) | {source2_output, sink_input, input_cells[1]}
-            path1 = find_belt_path(W, H, source1_output, input_cells[0], splitter_dir, blocked1)
+            blocked1 = (
+                blocked_base
+                | set(output_cells)
+                | {source2_output, sink_input, input_cells[1]}
+            )
+            path1 = find_belt_path(
+                W, H, source1_output, input_cells[0], splitter_dir, blocked1
+            )
             if path1 is None:
-                blocked1 = blocked_base | set(output_cells) | {source2_output, sink_input, input_cells[0]}
-                path1 = find_belt_path(W, H, source1_output, input_cells[1], splitter_dir, blocked1)
+                blocked1 = (
+                    blocked_base
+                    | set(output_cells)
+                    | {source2_output, sink_input, input_cells[0]}
+                )
+                path1 = find_belt_path(
+                    W, H, source1_output, input_cells[1], splitter_dir, blocked1
+                )
                 if path1 is None:
                     continue
 
             path1_cells = {(x, y) for x, y, _ in path1}
             path1_end = path1[-1][:2]
-            remaining_input = input_cells[1] if path1_end == input_cells[0] else input_cells[0]
+            remaining_input = (
+                input_cells[1] if path1_end == input_cells[0] else input_cells[0]
+            )
 
             # Path 2: source2 output → remaining splitter input
             blocked2 = blocked_base | set(output_cells) | path1_cells | {sink_input}
-            path2 = find_belt_path(W, H, source2_output, remaining_input, splitter_dir, blocked2)
+            path2 = find_belt_path(
+                W, H, source2_output, remaining_input, splitter_dir, blocked2
+            )
             if path2 is None:
                 continue
 
@@ -2128,14 +2207,36 @@ def build_factory(
             # Path 3: splitter output → sink input (try both output cells).
             # Block the unused output cell AND the cell ahead of it to
             # prevent sideloading from the output path into the unused output.
-            unused_output_buffer_0 = (output_cells[0][0] + d_delta[0], output_cells[0][1] + d_delta[1])
-            unused_output_buffer_1 = (output_cells[1][0] + d_delta[0], output_cells[1][1] + d_delta[1])
+            unused_output_buffer_0 = (
+                output_cells[0][0] + d_delta[0],
+                output_cells[0][1] + d_delta[1],
+            )
+            unused_output_buffer_1 = (
+                output_cells[1][0] + d_delta[0],
+                output_cells[1][1] + d_delta[1],
+            )
 
-            blocked3 = blocked_base | path1_cells | path2_cells | set(input_cells) | {output_cells[1], unused_output_buffer_1}
-            path3 = find_belt_path(W, H, output_cells[0], sink_input, sink_dir, blocked3)
+            blocked3 = (
+                blocked_base
+                | path1_cells
+                | path2_cells
+                | set(input_cells)
+                | {output_cells[1], unused_output_buffer_1}
+            )
+            path3 = find_belt_path(
+                W, H, output_cells[0], sink_input, sink_dir, blocked3
+            )
             if path3 is None:
-                blocked3 = blocked_base | path1_cells | path2_cells | set(input_cells) | {output_cells[0], unused_output_buffer_0}
-                path3 = find_belt_path(W, H, output_cells[1], sink_input, sink_dir, blocked3)
+                blocked3 = (
+                    blocked_base
+                    | path1_cells
+                    | path2_cells
+                    | set(input_cells)
+                    | {output_cells[0], unused_output_buffer_0}
+                )
+                path3 = find_belt_path(
+                    W, H, output_cells[1], sink_input, sink_dir, blocked3
+                )
                 if path3 is None:
                     continue
 
@@ -2144,13 +2245,24 @@ def build_factory(
                 continue
 
             # Place sources and sink
-            for src_pos, src_dir in [(source1_pos, source1_dir), (source2_pos, source2_dir)]:
-                world_CWH[Channel.ENTITIES.value, src_pos[0], src_pos[1]] = str2ent("source").value
-                world_CWH[Channel.DIRECTION.value, src_pos[0], src_pos[1]] = src_dir.value
+            for src_pos, src_dir in [
+                (source1_pos, source1_dir),
+                (source2_pos, source2_dir),
+            ]:
+                world_CWH[Channel.ENTITIES.value, src_pos[0], src_pos[1]] = str2ent(
+                    "source"
+                ).value
+                world_CWH[Channel.DIRECTION.value, src_pos[0], src_pos[1]] = (
+                    src_dir.value
+                )
                 world_CWH[Channel.ITEMS.value, src_pos[0], src_pos[1]] = item_value
 
-            world_CWH[Channel.ENTITIES.value, sink_pos[0], sink_pos[1]] = str2ent("sink").value
-            world_CWH[Channel.DIRECTION.value, sink_pos[0], sink_pos[1]] = sink_dir.value
+            world_CWH[Channel.ENTITIES.value, sink_pos[0], sink_pos[1]] = str2ent(
+                "sink"
+            ).value
+            world_CWH[Channel.DIRECTION.value, sink_pos[0], sink_pos[1]] = (
+                sink_dir.value
+            )
             world_CWH[Channel.ITEMS.value, sink_pos[0], sink_pos[1]] = item_value
 
             # Place splitter
@@ -2160,7 +2272,9 @@ def build_factory(
 
             # Place belt paths
             for x, y, d in path1 + path2 + path3:
-                world_CWH[Channel.ENTITIES.value, x, y] = str2ent("transport_belt").value
+                world_CWH[Channel.ENTITIES.value, x, y] = str2ent(
+                    "transport_belt"
+                ).value
                 world_CWH[Channel.DIRECTION.value, x, y] = d.value
 
             # Verify throughput > 0
@@ -2241,9 +2355,7 @@ def build_factory(
             # Pick assembler anchor
             ax = random.randint(0, W - 3)
             ay = random.randint(0, H - 3)
-            asm_tiles = {
-                (ax + dx, ay + dy) for dx in range(3) for dy in range(3)
-            }
+            asm_tiles = {(ax + dx, ay + dy) for dx in range(3) for dy in range(3)}
 
             # Pick distinct input + output perimeter slots
             in_slot, out_slot = random.sample(perim_slots, 2)
@@ -2293,10 +2405,7 @@ def build_factory(
             # Pick source + sink positions outside everything reserved
             reserved = asm_tiles | set(key_cells) | all_perim
             available = [
-                (x, y)
-                for x in range(W)
-                for y in range(H)
-                if (x, y) not in reserved
+                (x, y) for x in range(W) for y in range(H) if (x, y) not in reserved
             ]
             if len(available) < 2:
                 continue
@@ -2325,11 +2434,14 @@ def build_factory(
 
             # Path 1: source_output → in_pickup. Last belt orients toward
             # the input inserter.
-            blocked1 = (
-                asm_tiles
-                | {in_inserter_pos, out_inserter_pos, source_pos, sink_pos,
-                   sink_input, out_drop}
-            )
+            blocked1 = asm_tiles | {
+                in_inserter_pos,
+                out_inserter_pos,
+                source_pos,
+                sink_pos,
+                sink_input,
+                out_drop,
+            }
             path1 = find_belt_path(
                 W, H, source_output, in_pickup, in_inserter_dir, blocked1
             )
@@ -2340,13 +2452,17 @@ def build_factory(
             # Path 2: out_drop → sink_input. Last belt orients toward sink.
             blocked2 = (
                 asm_tiles
-                | {in_inserter_pos, out_inserter_pos, source_pos, sink_pos,
-                   in_pickup, source_output}
+                | {
+                    in_inserter_pos,
+                    out_inserter_pos,
+                    source_pos,
+                    sink_pos,
+                    in_pickup,
+                    source_output,
+                }
                 | path1_cells
             )
-            path2 = find_belt_path(
-                W, H, out_drop, sink_input, sink_dir, blocked2
-            )
+            path2 = find_belt_path(W, H, out_drop, sink_input, sink_dir, blocked2)
             if path2 is None:
                 continue
 
@@ -2357,9 +2473,9 @@ def build_factory(
                 continue
 
             # Place source
-            world_CWH[Channel.ENTITIES.value, source_pos[0], source_pos[1]] = (
-                str2ent("source").value
-            )
+            world_CWH[Channel.ENTITIES.value, source_pos[0], source_pos[1]] = str2ent(
+                "source"
+            ).value
             world_CWH[Channel.DIRECTION.value, source_pos[0], source_pos[1]] = (
                 source_dir.value
             )
@@ -2368,22 +2484,18 @@ def build_factory(
             )
 
             # Place sink
-            world_CWH[Channel.ENTITIES.value, sink_pos[0], sink_pos[1]] = (
-                str2ent("sink").value
-            )
+            world_CWH[Channel.ENTITIES.value, sink_pos[0], sink_pos[1]] = str2ent(
+                "sink"
+            ).value
             world_CWH[Channel.DIRECTION.value, sink_pos[0], sink_pos[1]] = (
                 sink_dir.value
             )
-            world_CWH[Channel.ITEMS.value, sink_pos[0], sink_pos[1]] = (
-                output_item_value
-            )
+            world_CWH[Channel.ITEMS.value, sink_pos[0], sink_pos[1]] = output_item_value
 
             # Place assembler (3×3, all tiles tagged with the recipe item)
             for tx, ty in asm_tiles:
                 world_CWH[Channel.ENTITIES.value, tx, ty] = asm_ent.value
-                world_CWH[Channel.DIRECTION.value, tx, ty] = (
-                    Direction.NORTH.value
-                )
+                world_CWH[Channel.DIRECTION.value, tx, ty] = Direction.NORTH.value
                 world_CWH[Channel.ITEMS.value, tx, ty] = recipe_item_value
 
             # Place input + output inserters
@@ -2450,9 +2562,7 @@ def build_factory(
             )
             C, W, H = world_CWH.shape
 
-            flow_dir = random.choice(
-                [d for d in Direction if d != Direction.NONE]
-            )
+            flow_dir = random.choice([d for d in Direction if d != Direction.NONE])
             is_horizontal = flow_dir in (Direction.EAST, Direction.WEST)
             flow_span = W if is_horizontal else H
             perp_span = H if is_horizontal else W
@@ -2530,9 +2640,7 @@ def build_factory(
             if source_drop in (ug_up_pos, sink_pos):
                 continue
             sd_flow = source_drop[0] if is_horizontal else source_drop[1]
-            if not (
-                src_lo <= sd_flow <= src_hi or source_drop == ug_down_pos
-            ):
+            if not (src_lo <= sd_flow <= src_hi or source_drop == ug_down_pos):
                 continue
 
             # sink_input must be on sink side or land directly on UG_UP
@@ -2541,9 +2649,7 @@ def build_factory(
             if sink_input in (ug_down_pos, source_pos):
                 continue
             si_flow = sink_input[0] if is_horizontal else sink_input[1]
-            if not (
-                snk_lo <= si_flow <= snk_hi or sink_input == ug_up_pos
-            ):
+            if not (snk_lo <= si_flow <= snk_hi or sink_input == ug_up_pos):
                 continue
 
             flow_delta = DIR_TO_DELTA[flow_dir]
@@ -2557,7 +2663,11 @@ def build_factory(
                     ug_down_pos[1] - flow_delta[1],
                 )
                 blocked1 = wall_tiles | {
-                    source_pos, sink_pos, ug_down_pos, ug_up_pos, sink_input,
+                    source_pos,
+                    sink_pos,
+                    ug_down_pos,
+                    ug_up_pos,
+                    sink_input,
                 }
                 # Restrict path1 to source side: block all sink-side cells.
                 for fc in range(snk_lo, snk_hi + 1):
@@ -2591,33 +2701,31 @@ def build_factory(
                         blocked2.add(fp_to_xy(fc, pc))
                 if ug_up_drop in blocked2 or sink_input in blocked2:
                     continue
-                path2 = find_belt_path(
-                    W, H, ug_up_drop, sink_input, sink_dir, blocked2
-                )
+                path2 = find_belt_path(W, H, ug_up_drop, sink_input, sink_dir, blocked2)
                 if path2 is None:
                     continue
 
             # Place source/sink
-            world_CWH[Channel.ENTITIES.value, source_pos[0], source_pos[1]] = (
-                str2ent("source").value
-            )
+            world_CWH[Channel.ENTITIES.value, source_pos[0], source_pos[1]] = str2ent(
+                "source"
+            ).value
             world_CWH[Channel.DIRECTION.value, source_pos[0], source_pos[1]] = (
                 source_dir.value
             )
             world_CWH[Channel.ITEMS.value, source_pos[0], source_pos[1]] = item_value
 
-            world_CWH[Channel.ENTITIES.value, sink_pos[0], sink_pos[1]] = (
-                str2ent("sink").value
-            )
+            world_CWH[Channel.ENTITIES.value, sink_pos[0], sink_pos[1]] = str2ent(
+                "sink"
+            ).value
             world_CWH[Channel.DIRECTION.value, sink_pos[0], sink_pos[1]] = (
                 sink_dir.value
             )
             world_CWH[Channel.ITEMS.value, sink_pos[0], sink_pos[1]] = item_value
 
             # Place UG pair (always facing flow_dir)
-            world_CWH[Channel.ENTITIES.value, ug_down_pos[0], ug_down_pos[1]] = (
-                str2ent("underground_belt").value
-            )
+            world_CWH[Channel.ENTITIES.value, ug_down_pos[0], ug_down_pos[1]] = str2ent(
+                "underground_belt"
+            ).value
             world_CWH[Channel.DIRECTION.value, ug_down_pos[0], ug_down_pos[1]] = (
                 flow_dir.value
             )
@@ -2625,9 +2733,9 @@ def build_factory(
                 Misc.UNDERGROUND_DOWN.value
             )
 
-            world_CWH[Channel.ENTITIES.value, ug_up_pos[0], ug_up_pos[1]] = (
-                str2ent("underground_belt").value
-            )
+            world_CWH[Channel.ENTITIES.value, ug_up_pos[0], ug_up_pos[1]] = str2ent(
+                "underground_belt"
+            ).value
             world_CWH[Channel.DIRECTION.value, ug_up_pos[0], ug_up_pos[1]] = (
                 flow_dir.value
             )
@@ -2655,9 +2763,7 @@ def build_factory(
             # freely buildable on either side of the wall.
             world_CWH[Channel.FOOTPRINT.value, :, :] = Footprint.AVAILABLE.value
             for wx, wy in wall_tiles:
-                world_CWH[Channel.FOOTPRINT.value, wx, wy] = (
-                    Footprint.UNAVAILABLE.value
-                )
+                world_CWH[Channel.FOOTPRINT.value, wx, wy] = Footprint.UNAVAILABLE.value
 
             break
         if count == 0:
@@ -2731,9 +2837,7 @@ def build_factory(
             # Pick assembler anchor
             ax = random.randint(0, W - 3)
             ay = random.randint(0, H - 3)
-            asm_tiles = {
-                (ax + dx, ay + dy) for dx in range(3) for dy in range(3)
-            }
+            asm_tiles = {(ax + dx, ay + dy) for dx in range(3) for dy in range(3)}
 
             # Pick three distinct perimeter slots: 2 inputs + 1 output
             in_a_slot, in_b_slot, out_slot = random.sample(perim_slots, 3)
@@ -2754,8 +2858,12 @@ def build_factory(
             out_drop = (out_pos[0] + out_dd[0], out_pos[1] + out_dd[1])
 
             key_cells = [
-                in_a_pos, in_b_pos, out_pos,
-                in_a_pickup, in_b_pickup, out_drop,
+                in_a_pos,
+                in_b_pos,
+                out_pos,
+                in_a_pickup,
+                in_b_pickup,
+                out_drop,
             ]
             if any(not (0 <= c[0] < W and 0 <= c[1] < H) for c in key_cells):
                 continue
@@ -2775,10 +2883,7 @@ def build_factory(
             }
             reserved = asm_tiles | set(key_cells) | all_perim
             available = [
-                (x, y)
-                for x in range(W)
-                for y in range(H)
-                if (x, y) not in reserved
+                (x, y) for x in range(W) for y in range(H) if (x, y) not in reserved
             ]
             if len(available) < 3:
                 continue
@@ -2813,26 +2918,17 @@ def build_factory(
             )
 
             # Path A: source A → input-A pickup
-            blocked_a = (
-                fixed_cells
-                | {in_b_pickup, out_drop, src_b_out, sink_in}
-            )
-            path_a = find_belt_path(
-                W, H, src_a_out, in_a_pickup, in_a_dir, blocked_a
-            )
+            blocked_a = fixed_cells | {in_b_pickup, out_drop, src_b_out, sink_in}
+            path_a = find_belt_path(W, H, src_a_out, in_a_pickup, in_a_dir, blocked_a)
             if path_a is None:
                 continue
             path_a_cells = {(x, y) for x, y, _ in path_a}
 
             # Path B: source B → input-B pickup
             blocked_b = (
-                fixed_cells
-                | {in_a_pickup, out_drop, src_a_out, sink_in}
-                | path_a_cells
+                fixed_cells | {in_a_pickup, out_drop, src_a_out, sink_in} | path_a_cells
             )
-            path_b = find_belt_path(
-                W, H, src_b_out, in_b_pickup, in_b_dir, blocked_b
-            )
+            path_b = find_belt_path(W, H, src_b_out, in_b_pickup, in_b_dir, blocked_b)
             if path_b is None:
                 continue
             path_b_cells = {(x, y) for x, y, _ in path_b}
@@ -2844,9 +2940,7 @@ def build_factory(
                 | path_a_cells
                 | path_b_cells
             )
-            path_c = find_belt_path(
-                W, H, out_drop, sink_in, sink_dir, blocked_c
-            )
+            path_c = find_belt_path(W, H, out_drop, sink_in, sink_dir, blocked_c)
             if path_c is None:
                 continue
 
@@ -2856,43 +2950,35 @@ def build_factory(
                 continue
 
             # Place sources
-            world_CWH[Channel.ENTITIES.value, src_a_pos[0], src_a_pos[1]] = (
-                str2ent("source").value
-            )
+            world_CWH[Channel.ENTITIES.value, src_a_pos[0], src_a_pos[1]] = str2ent(
+                "source"
+            ).value
             world_CWH[Channel.DIRECTION.value, src_a_pos[0], src_a_pos[1]] = (
                 src_a_dir.value
             )
-            world_CWH[Channel.ITEMS.value, src_a_pos[0], src_a_pos[1]] = (
-                input_a_value
-            )
+            world_CWH[Channel.ITEMS.value, src_a_pos[0], src_a_pos[1]] = input_a_value
 
-            world_CWH[Channel.ENTITIES.value, src_b_pos[0], src_b_pos[1]] = (
-                str2ent("source").value
-            )
+            world_CWH[Channel.ENTITIES.value, src_b_pos[0], src_b_pos[1]] = str2ent(
+                "source"
+            ).value
             world_CWH[Channel.DIRECTION.value, src_b_pos[0], src_b_pos[1]] = (
                 src_b_dir.value
             )
-            world_CWH[Channel.ITEMS.value, src_b_pos[0], src_b_pos[1]] = (
-                input_b_value
-            )
+            world_CWH[Channel.ITEMS.value, src_b_pos[0], src_b_pos[1]] = input_b_value
 
             # Place sink
-            world_CWH[Channel.ENTITIES.value, sink_pos[0], sink_pos[1]] = (
-                str2ent("sink").value
-            )
+            world_CWH[Channel.ENTITIES.value, sink_pos[0], sink_pos[1]] = str2ent(
+                "sink"
+            ).value
             world_CWH[Channel.DIRECTION.value, sink_pos[0], sink_pos[1]] = (
                 sink_dir.value
             )
-            world_CWH[Channel.ITEMS.value, sink_pos[0], sink_pos[1]] = (
-                output_item_value
-            )
+            world_CWH[Channel.ITEMS.value, sink_pos[0], sink_pos[1]] = output_item_value
 
             # Place assembler (3×3, all tiles tagged with the recipe item)
             for tx, ty in asm_tiles:
                 world_CWH[Channel.ENTITIES.value, tx, ty] = asm_ent.value
-                world_CWH[Channel.DIRECTION.value, tx, ty] = (
-                    Direction.NORTH.value
-                )
+                world_CWH[Channel.DIRECTION.value, tx, ty] = Direction.NORTH.value
                 world_CWH[Channel.ITEMS.value, tx, ty] = recipe_item_value
 
             # Place 2 input inserters + 1 output inserter
@@ -2901,12 +2987,10 @@ def build_factory(
                 (in_b_pos, in_b_dir),
                 (out_pos, out_dir),
             ]:
-                world_CWH[
-                    Channel.ENTITIES.value, ipos[0], ipos[1]
-                ] = str2ent("inserter").value
-                world_CWH[
-                    Channel.DIRECTION.value, ipos[0], ipos[1]
-                ] = idir.value
+                world_CWH[Channel.ENTITIES.value, ipos[0], ipos[1]] = str2ent(
+                    "inserter"
+                ).value
+                world_CWH[Channel.DIRECTION.value, ipos[0], ipos[1]] = idir.value
 
             # Place belt paths
             for x, y, d in path_a + path_b + path_c:
@@ -2943,9 +3027,7 @@ def build_factory(
         # different one is tried. The throughput check rejects
         # blueprints that don't actually produce flow (malformed or
         # incompatible after augmentation).
-        bp_paths = sorted(glob.glob(os.path.join(
-            LESSON_BLUEPRINT_DIR, "*.txt"
-        )))
+        bp_paths = sorted(glob.glob(os.path.join(LESSON_BLUEPRINT_DIR, "*.txt")))
         if not bp_paths:
             raise Exception(
                 f"No blueprints in {LESSON_BLUEPRINT_DIR}; "
@@ -2983,10 +3065,10 @@ def build_factory(
             ox = random.randint(0, size - w_bp)
             oy = random.randint(0, size - h_bp)
 
-            world_CWH = torch.tensor(
-                new_world(width=size, height=size)
-            ).permute(2, 0, 1)
-            world_CWH[:, ox:ox + w_bp, oy:oy + h_bp] = decoded
+            world_CWH = torch.tensor(new_world(width=size, height=size)).permute(
+                2, 0, 1
+            )
+            world_CWH[:, ox : ox + w_bp, oy : oy + h_bp] = decoded
 
             # Extend belt chains backward from each source/sink into
             # any empties created by translation (or already present
@@ -3075,6 +3157,7 @@ def _bfs_shortest(grid_h, grid_w, start, end, blocked):
     equal-length parents for enumerating all shortest paths.
     Returns (None, None) if no path exists.
     """
+
     def in_bounds(cell):
         r, c = cell
         return 0 <= r < grid_h and 0 <= c < grid_w
@@ -3110,6 +3193,7 @@ def _bfs_shortest(grid_h, grid_w, start, end, blocked):
         return None, None
     return dist, parents
 
+
 def _path_to_belts(path, end_dir):
     """Convert a list of (x, y) cells into belt placements with directions."""
     belts: List[Tuple[int, int, Direction]] = []
@@ -3121,6 +3205,7 @@ def _path_to_belts(path, end_dir):
                 break
     belts.append((path[-1][0], path[-1][1], end_dir))
     return belts
+
 
 def find_belt_path(
     grid_h: int,
@@ -3150,6 +3235,7 @@ def find_belt_path(
 
     return _path_to_belts(path, end_dir)
 
+
 def find_belt_paths_with_source_sink_orient(
     entities: torch.Tensor,
     directions: torch.Tensor,
@@ -3161,14 +3247,8 @@ def find_belt_paths_with_source_sink_orient(
     Returns a list of paths, each being a list of (row, col, Direction)
     tuples. If no valid path exists, returns [].
     """
-    if (
-        entities.ndim != 2
-        or directions.ndim != 2
-        or entities.shape != directions.shape
-    ):
-        raise ValueError(
-            "entities and directions must be 2D tensors of the same shape"
-        )
+    if entities.ndim != 2 or directions.ndim != 2 or entities.shape != directions.shape:
+        raise ValueError("entities and directions must be 2D tensors of the same shape")
     H, W = entities.shape
 
     src_pos = (entities == source_value).nonzero(as_tuple=False)
@@ -3209,4 +3289,3 @@ def find_belt_paths_with_source_sink_orient(
 
     backtrack(end, [])
     return all_paths
-

--- a/factorion.py
+++ b/factorion.py
@@ -1669,29 +1669,6 @@ def _remove_entities(
     return num_samples
 
 
-# Move-direction priority for the canonical MOVE_ONE_ITEM path (derisk
-# experiment to remove multiple-shortest-path ambiguity): North > East > South
-# > West. Keyed by (drow, dcol) so it is independent of the Direction enum's
-# names; row 0 is the top, so North == row-decreasing == (-1, 0).
-_MOVE_PRIORITY = {(-1, 0): 0, (0, 1): 1, (1, 0): 2, (0, -1): 3}
-
-
-def _canonical_path_key(path):
-    """Sort key selecting the single canonical belt path.
-
-    ``path`` is a list of ``(row, col, Direction)`` belt placements. The key is
-    the sequence of move-direction priorities (North>East>South>West) between
-    consecutive cells, so ``min(paths, key=_canonical_path_key)`` over the
-    equal-length shortest paths returns the lexicographically-smallest one — go
-    as far North as needed, then East, then South, then West, never
-    backtracking.
-    """
-    return [
-        _MOVE_PRIORITY[(x2 - x1, y2 - y1)]
-        for (x1, y1, _), (x2, y2, _) in zip(path, path[1:])
-    ]
-
-
 def build_factory(
     size: int = 12,
     kind: LessonKind = LessonKind.MOVE_ONE_ITEM,
@@ -1794,16 +1771,8 @@ def build_factory(
                 # Restart the loop until we get a source+sink that can be connected
                 continue
             else:
-                # DERISK EXPERIMENT: pick the single canonical path instead of a
-                # random one, so each (source, sink) has exactly ONE valid
-                # MOVE_ONE_ITEM completion and the direction target is
-                # unambiguous. Canonical = exhaust North, then East, then South,
-                # then West, never backtracking (see _canonical_path_key). If
-                # this makes loss_dir plummet, multiple-shortest-path ambiguity
-                # was the dir_acc ceiling. To restore path diversity later,
-                # revert to random.choice(paths) or move to a multi-target
-                # direction loss that rewards any valid path.
-                chosen_path = min(paths, key=_canonical_path_key)
+                # Choose a valid path at random and add it to the map
+                chosen_path = random.choice(paths)
                 total_entities = len(chosen_path)
                 for x, y, d in chosen_path:
                     world_CWH[Channel.ENTITIES.value, x, y] = str2ent(

--- a/ppo.py
+++ b/ppo.py
@@ -161,10 +161,11 @@ class Args:
     deep_encoder: bool = False
     """Use the 6-conv-layer encoder (receptive field 13x13 >= the grid) instead
     of the shallow 3-layer one (RF 7x7). The shallow encoder can't see both
-    source and sink from a far tile, so the belt-direction head plateaus (~0.92
-    held-out) and greedy full-build caps ~0.64; the deep encoder + canonical
-    routing lifts greedy build to ~0.90. Must match the --start_from checkpoint's
-    architecture."""
+    source and sink from a far tile, so the belt-direction head plateaus and
+    greedy full-build caps ~0.64; the deep encoder lifts held-out greedy build to
+    ~0.85-0.90 (ablation: the deep RECEPTIVE FIELD is the driver — training on
+    diverse random routes works as well as / better than a canonical route).
+    Must match the --start_from checkpoint's architecture."""
     size: int = 12
     """The width and height of the factory"""
     summary_path: Optional[str] = None
@@ -1054,10 +1055,11 @@ class AgentCNN(nn.Module):
         if deep_encoder:
             # 6 conv layers (3x3) -> receptive field 13x13 >= the 11x11 grid, so
             # EVERY tile can see both source and sink. The shallow 3-layer encoder
-            # only reaches 7x7, which is why the belt-DIRECTION head plateaued at
-            # ~0.92 on held-out (a turn far from the sink can't see which way to
-            # route) and capped greedy full-build at ~0.64. Full RF + canonical
-            # routing lifts greedy build to ~0.90.
+            # only reaches 7x7, which is why the belt-DIRECTION head plateaued on
+            # held-out (a turn far from the sink can't see which way to route) and
+            # capped greedy full-build at ~0.64. The full receptive field lifts
+            # held-out greedy build to ~0.85-0.90 (ablation: the RF is the driver,
+            # not the route choice).
             hidden = [64, 96, 96, 96, 96]
             layers, c_in = [], self.channels
             for c_out in hidden:

--- a/ppo.py
+++ b/ppo.py
@@ -224,10 +224,12 @@ def _resolve_start_from(start_from, project, entity):
             os.environ["WANDB_DISABLED"] = prev_disabled
 
 
-def make_env(env_id, idx, capture_video, size, run_name):
+def make_env(env_id, idx, capture_video, size, run_name, reward_coeffs=None):
     def thunk():
         kwargs = {"render_mode": "rgb_array"} if capture_video else {}
         kwargs.update({"size": size, "max_steps": 2 * size, "idx": idx})
+        if reward_coeffs is not None:
+            kwargs["reward_coeffs"] = reward_coeffs
         # kwargs.update({'size': size, 'max_steps': 6})
         env = gym.make(env_id, **kwargs)
         if capture_video:
@@ -311,8 +313,13 @@ class FactorioEnv(gym.Env):
         render_mode: Optional[str] = None,
         idx: Optional[int] = None,
         options: Optional[dict] = None,
+        reward_coeffs: Optional[dict] = None,
     ):
         super().__init__()
+        # Runtime reward coefficients (from Args); fall back to Args class
+        # defaults per-key. Fixes the old `'args' not in locals()` hack that
+        # always used the class defaults and ignored --coeff-* flags (issue #135).
+        self._reward_coeffs = reward_coeffs or {}
         # Setup the renderer if requested
         if render_mode is not None:
             self.metadata = {"render_modes": [render_mode], "render_fps": 2}
@@ -698,15 +705,13 @@ class FactorioEnv(gym.Env):
         # ── Normalized weighted reward (throughput + validity only) ──
         reward_components = {
             "throughput": {
-                "coeff": Args.coeff_throughput
-                if "args" not in locals()
-                else args.coeff_throughput,
+                "coeff": self._reward_coeffs.get(
+                    "coeff_throughput", Args.coeff_throughput
+                ),
                 "value": throughput,
             },
             "validity": {
-                "coeff": Args.coeff_validity
-                if "args" not in locals()
-                else args.coeff_validity,
+                "coeff": self._reward_coeffs.get("coeff_validity", Args.coeff_validity),
                 "value": 0 if action_is_invalid else 1,
             },
         }
@@ -726,20 +731,14 @@ class FactorioEnv(gym.Env):
         dir_delta = curr_match[2] - self._prev_match[2]
         self._prev_match = curr_match
 
-        coeff_loc = (
-            Args.coeff_shaping_location
-            if "args" not in locals()
-            else args.coeff_shaping_location
+        coeff_loc = self._reward_coeffs.get(
+            "coeff_shaping_location", Args.coeff_shaping_location
         )
-        coeff_ent = (
-            Args.coeff_shaping_entity
-            if "args" not in locals()
-            else args.coeff_shaping_entity
+        coeff_ent = self._reward_coeffs.get(
+            "coeff_shaping_entity", Args.coeff_shaping_entity
         )
-        coeff_dir = (
-            Args.coeff_shaping_direction
-            if "args" not in locals()
-            else args.coeff_shaping_direction
+        coeff_dir = self._reward_coeffs.get(
+            "coeff_shaping_direction", Args.coeff_shaping_direction
         )
 
         pre_reward += coeff_loc * loc_delta
@@ -1267,9 +1266,18 @@ if __name__ == "__main__":
 
     print(f"Setting up envs with {args}")
     # env setup
+    reward_coeffs = {
+        "coeff_throughput": args.coeff_throughput,
+        "coeff_validity": args.coeff_validity,
+        "coeff_shaping_location": args.coeff_shaping_location,
+        "coeff_shaping_entity": args.coeff_shaping_entity,
+        "coeff_shaping_direction": args.coeff_shaping_direction,
+    }
     envs = gym.vector.SyncVectorEnv(
         [
-            make_env(args.env_id, i, args.capture_video, args.size, run_name)
+            make_env(
+                args.env_id, i, args.capture_video, args.size, run_name, reward_coeffs
+            )
             for i in range(args.num_envs)
         ],
     )
@@ -1720,7 +1728,7 @@ if __name__ == "__main__":
             num_render_envs = 5
             render_envs = gym.vector.SyncVectorEnv(
                 [
-                    make_env(args.env_id, i, False, args.size, run_name)
+                    make_env(args.env_id, i, False, args.size, run_name, reward_coeffs)
                     for i in range(num_render_envs)
                 ]
             )

--- a/ppo.py
+++ b/ppo.py
@@ -158,6 +158,59 @@ class Args:
     """the number of iterations (total_timesteps // batch_size)"""
 
 
+def _resolve_start_from(start_from, project, entity):
+    """Resolve --start_from to a local checkpoint path.
+
+    SFT and PPO may run on different machines, so the PPO box often won't have
+    the SFT box's local .pt. Resolution order (per spec):
+      1. existing local file -> use it directly;
+      2. else treat the string as a W&B run id -> download that run's newest
+         type="model" artifact and use its .pt;
+      3. else abort.
+    File-existence (not a try/except on torch.load) disambiguates path vs run id,
+    so a present-but-corrupt file raises a real error instead of being misread as
+    a run id.
+    """
+    if os.path.exists(start_from):
+        return start_from
+    # Not a local file -> try as a W&B run id. Clear disabled/offline flags so
+    # the API can fetch (restored in finally).
+    prev_mode = os.environ.pop("WANDB_MODE", None)
+    prev_disabled = os.environ.pop("WANDB_DISABLED", None)
+    try:
+        import wandb
+
+        api = wandb.Api()
+        if start_from.count("/") == 2:
+            run = api.run(start_from)
+        else:
+            run = api.run(f"{entity or api.default_entity}/{project}/{start_from}")
+        model_arts = [a for a in run.logged_artifacts() if a.type == "model"]
+        if not model_arts:
+            raise RuntimeError(f"W&B run {start_from} has no type=model artifact")
+        art = max(model_arts, key=lambda a: a.created_at)
+        local_dir = art.download(
+            root=str(
+                Path("/tmp/factorion-checkpoints") / run.id / art.name.replace(":", "_")
+            )
+        )
+        pts = sorted(Path(local_dir).glob("*.pt"))
+        if not pts:
+            raise RuntimeError(f"W&B artifact {art.name} contains no .pt file")
+        print(f"Resolved --start_from {start_from} -> {art.name} -> {pts[0]}")
+        return str(pts[0])
+    except Exception as e:
+        raise SystemExit(
+            f"--start_from '{start_from}' is neither a readable file nor a "
+            f"resolvable W&B run: {e}"
+        )
+    finally:
+        if prev_mode is not None:
+            os.environ["WANDB_MODE"] = prev_mode
+        if prev_disabled is not None:
+            os.environ["WANDB_DISABLED"] = prev_disabled
+
+
 def make_env(env_id, idx, capture_video, size, run_name):
     def thunk():
         kwargs = {"render_mode": "rgb_array"} if capture_video else {}
@@ -1221,10 +1274,13 @@ if __name__ == "__main__":
     )
 
     if args.start_from is not None:
+        resolved = _resolve_start_from(
+            args.start_from, args.wandb_project_name, args.wandb_entity
+        )
         if args.track:
             run.tags = run.tags + (f"start_from:{args.start_from}",)
-        print(f"Loading model weights from {args.start_from}")
-        agent.load_state_dict(torch.load(args.start_from))
+        print(f"Loading model weights from {resolved}")
+        agent.load_state_dict(torch.load(resolved, map_location="cpu"))
 
     agent.to(device)
 

--- a/ppo.py
+++ b/ppo.py
@@ -161,6 +161,10 @@ class Args:
     """Tags to apply to the wandb run."""
     start_curriculum_level: int = 1
     """Starting curriculum level (num_missing_entities). Useful when loading an SFT checkpoint that already handles easy levels."""
+    curriculum_advance_threshold: float = 0.95
+    """Advance the curriculum (num_missing_entities += 1) once the throughput moving
+    average exceeds this. Set >1.0 to pin the level so the agent perfects it to 1.0
+    instead of advancing at 0.95."""
 
     # to be filled in runtime
     batch_size: int = 0
@@ -1700,7 +1704,7 @@ if __name__ == "__main__":
             final_thputs_100ma = sum(end_of_episode_thputs) / len(end_of_episode_thputs)
             if len(end_of_episode_thputs) > int(moving_average_length * 0.9):
                 if (
-                    final_thputs_100ma > 0.95
+                    final_thputs_100ma > args.curriculum_advance_threshold
                     and iteration - iteration_of_last_increase > 10
                 ):
                     iteration_of_last_increase = iteration

--- a/ppo.py
+++ b/ppo.py
@@ -88,6 +88,14 @@ class Args:
     """the number of steps to run in each environment per policy rollout"""
     anneal_lr: bool = True
     """Toggle learning rate annealing for policy and value networks"""
+    lr_anneal_timesteps: int = 0
+    """If >0, anneal LR from learning_rate down to min_lr linearly over the first
+    this-many env steps, then HOLD at min_lr. Decouples the LR schedule from
+    total_timesteps so a long run uses the same early decay as a short one (fast
+    climb) and then keeps training at a small floor instead of freezing at 0.
+    0 = legacy behaviour (anneal to 0 over the whole run)."""
+    min_lr: float = 0.0
+    """LR floor held after lr_anneal_timesteps (only used when lr_anneal_timesteps > 0)."""
     gamma: float = 0.9857
     """the discount factor gamma"""
     gae_lambda: float = 0.8014
@@ -1378,8 +1386,17 @@ if __name__ == "__main__":
         # print(f"{iteration=}")
         # Annealing the rate if instructed to do so.
         if args.anneal_lr:
-            frac = 1.0 - (iteration - 1.0) / args.num_iterations
-            lrnow = frac * args.learning_rate
+            if args.lr_anneal_timesteps > 0:
+                # Fixed-horizon anneal: learning_rate -> min_lr over the first
+                # lr_anneal_timesteps env steps, then hold at min_lr. Decoupled
+                # from total_timesteps so the early decay (and climb) matches a
+                # short run and the long run keeps training at a small floor.
+                # global_step here is the count BEFORE this iteration's rollout.
+                frac = min(1.0, global_step / args.lr_anneal_timesteps)
+                lrnow = args.learning_rate + frac * (args.min_lr - args.learning_rate)
+            else:
+                frac = 1.0 - (iteration - 1.0) / args.num_iterations
+                lrnow = frac * args.learning_rate
             optimizer.param_groups[0]["lr"] = lrnow
 
         # Entropy coefficient annealing: linear from ent_coef_start to ent_coef_end

--- a/ppo.py
+++ b/ppo.py
@@ -1651,6 +1651,10 @@ if __name__ == "__main__":
         # ── Per-iteration logging ──────────────────────────────────────
         iter_metrics = {
             "global_step": global_step,
+            # 1 = critic-only warm-up (actor + encoder frozen); 0 = joint PPO
+            # (actor and critic training together). Lets you see on the W&B
+            # charts exactly when the actor unfreezes.
+            "charts/actor_frozen": int(warming_up),
             "losses/policy": pg_loss.item(),
             "losses/value": v_loss.item(),
             "losses/entropy": entropy_loss.item(),

--- a/ppo.py
+++ b/ppo.py
@@ -137,7 +137,7 @@ class Args:
     """Number of channels in the first layer of the CNN encoder"""
     chan2: int = 48
     """Number of channels in the second layer of the CNN encoder"""
-    chan3: int = 48
+    chan3: int = 64
     """Number of channels in the third layer of the CNN encoder"""
     flat_dim: int = 128
     """Output size of the fully connected layer after the encoder"""

--- a/ppo.py
+++ b/ppo.py
@@ -184,11 +184,13 @@ class Args:
     iterations (in addition to the end-of-run save). Lets you greedy-eval a run's
     real progress mid-flight and kill plateaued/degrading runs without losing the
     weights. 0 = only the end-of-run save."""
-    greedy_eval_seeds: int = 20
+    greedy_eval_seeds: int = 128
     """Number of fresh empty-factory seeds averaged for the greedy eval metric
-    (eval/greedy_empty_throughput). Each seed: start from a completely empty
-    factory, place entities GREEDILY (argmax) until throughput == 1.0 or
-    max_steps, then read the built factory's throughput. This is the honest,
+    (eval/greedy_empty_throughput). 128 keeps the per-iteration eval under ~2s on
+    CPU (20 was too noisy — flipped ~0.1 between iters; 600 would cost ~10-16s/iter).
+    Each seed: start from a completely empty factory, place entities GREEDILY
+    (argmax) until throughput == 1.0 or max_steps, then read the built factory's
+    throughput. This is the honest,
     deployable metric — the deterministic policy on fresh factories — unlike the
     sampled episode/throughput, which is inflated by sampling luck and trivial
     no-op episodes. (EOT is not used as a stop yet; see issue #137.)"""

--- a/ppo.py
+++ b/ppo.py
@@ -158,6 +158,13 @@ class Args:
     """Output size of the fully connected layer after the encoder"""
     tile_head_std: float = 0.06503
     """Initialization std for the tile selection conv head (smaller = more uniform initial exploration)"""
+    deep_encoder: bool = False
+    """Use the 6-conv-layer encoder (receptive field 13x13 >= the grid) instead
+    of the shallow 3-layer one (RF 7x7). The shallow encoder can't see both
+    source and sink from a far tile, so the belt-direction head plateaus (~0.92
+    held-out) and greedy full-build caps ~0.64; the deep encoder + canonical
+    routing lifts greedy build to ~0.90. Must match the --start_from checkpoint's
+    architecture."""
     size: int = 12
     """The width and height of the factory"""
     summary_path: Optional[str] = None
@@ -1018,7 +1025,14 @@ class FactorioEnv(gym.Env):
 
 class AgentCNN(nn.Module):
     def __init__(
-        self, envs, chan1=32, chan2=64, chan3=64, flat_dim=256, tile_head_std=0.01
+        self,
+        envs,
+        chan1=32,
+        chan2=64,
+        chan3=64,
+        flat_dim=256,
+        tile_head_std=0.01,
+        deep_encoder=False,
     ):
         super().__init__()
         base_env = envs.envs[0].unwrapped
@@ -1035,14 +1049,35 @@ class AgentCNN(nn.Module):
         self.num_misc = len(Misc)
         self.chan3 = chan3
 
-        self.encoder = nn.Sequential(
-            layer_init(nn.Conv2d(self.channels, chan1, kernel_size=3, padding=1)),
-            nn.ReLU(),
-            layer_init(nn.Conv2d(chan1, chan2, kernel_size=3, padding=1)),
-            nn.ReLU(),
-            layer_init(nn.Conv2d(chan2, chan3, kernel_size=3, padding=1)),
-            nn.ReLU(),
-        )
+        if deep_encoder:
+            # 6 conv layers (3x3) -> receptive field 13x13 >= the 11x11 grid, so
+            # EVERY tile can see both source and sink. The shallow 3-layer encoder
+            # only reaches 7x7, which is why the belt-DIRECTION head plateaued at
+            # ~0.92 on held-out (a turn far from the sink can't see which way to
+            # route) and capped greedy full-build at ~0.64. Full RF + canonical
+            # routing lifts greedy build to ~0.90.
+            hidden = [64, 96, 96, 96, 96]
+            layers, c_in = [], self.channels
+            for c_out in hidden:
+                layers += [
+                    layer_init(nn.Conv2d(c_in, c_out, kernel_size=3, padding=1)),
+                    nn.ReLU(),
+                ]
+                c_in = c_out
+            layers += [
+                layer_init(nn.Conv2d(c_in, chan3, kernel_size=3, padding=1)),
+                nn.ReLU(),
+            ]
+            self.encoder = nn.Sequential(*layers)
+        else:
+            self.encoder = nn.Sequential(
+                layer_init(nn.Conv2d(self.channels, chan1, kernel_size=3, padding=1)),
+                nn.ReLU(),
+                layer_init(nn.Conv2d(chan1, chan2, kernel_size=3, padding=1)),
+                nn.ReLU(),
+                layer_init(nn.Conv2d(chan2, chan3, kernel_size=3, padding=1)),
+                nn.ReLU(),
+            )
         num_params_encoder = sum(p.numel() for p in self.encoder.parameters())
         print(f"Encoder has {num_params_encoder} params")
 
@@ -1331,6 +1366,7 @@ if __name__ == "__main__":
         chan3=args.chan3,
         flat_dim=args.flat_dim,
         tile_head_std=args.tile_head_std,
+        deep_encoder=args.deep_encoder,
     )
 
     if args.start_from is not None:
@@ -1359,6 +1395,7 @@ if __name__ == "__main__":
             chan3=args.chan3,
             flat_dim=args.flat_dim,
             tile_head_std=args.tile_head_std,
+            deep_encoder=args.deep_encoder,
         )
         ref_agent.load_state_dict(torch.load(resolved, map_location="cpu"))
         ref_agent.to(device)

--- a/ppo.py
+++ b/ppo.py
@@ -66,9 +66,14 @@ class Args:
     capture_video: bool = False
     """whether to capture videos of the agent performances (check out `videos` folder)"""
     start_from: Optional[str] = None
-    """Path of a model from which to start the training (instead of from scratch)"""
+    """Local path OR W&B run id of a checkpoint to start from (e.g. an SFT actor)."""
     start_from_wandb: Optional[str] = None
     """wandb run id to continue from"""
+    critic_warmup: int = 0
+    """Number of initial PPO iterations to train ONLY the critic head (encoder +
+    actor heads frozen, value-loss only) before unfreezing for joint PPO. Lets a
+    random-init critic catch up to an SFT-pretrained actor without its gradients
+    corrupting the shared encoder. 0 = no warm-up."""
 
     # Algorithm specific arguments
     env_id: str = "factorion/FactorioEnv-v0"
@@ -1362,6 +1367,12 @@ if __name__ == "__main__":
     _next_eval_log_step = 256
     print(f"Starting {args.num_iterations} iterations")
     iteration_of_last_increase = 0
+    # Critic warm-up: params to FREEZE during the warm-up (everything except the
+    # critic head — i.e. the shared encoder + all actor heads). Toggled per
+    # iteration below.
+    actor_trunk_params = [
+        p for n, p in agent.named_parameters() if "critic_head" not in n
+    ]
     pbar = tqdm.trange(1, args.num_iterations + 1)
     for iteration in pbar:
         # print(f"{iteration=}")
@@ -1376,6 +1387,14 @@ if __name__ == "__main__":
         ent_coef = args.ent_coef_end + ent_frac * (
             args.ent_coef_start - args.ent_coef_end
         )
+
+        # Critic warm-up: freeze the encoder + actor heads while the critic
+        # catches up, then unfreeze for joint PPO. requires_grad_ is a no-op when
+        # already set, so this only flips (and triggers one recompile) at the
+        # warm-up -> joint transition.
+        warming_up = iteration <= args.critic_warmup
+        for p in actor_trunk_params:
+            p.requires_grad_(not warming_up)
 
         for step in range(0, args.num_steps):
             global_step += args.num_envs
@@ -1605,7 +1624,13 @@ if __name__ == "__main__":
                 entropy_loss = entropy_B.mean()
                 assert not torch.isnan(pg_loss), "pg_loss is NaN, probably a bug"
                 assert not torch.isnan(v_loss), "v_loss is NaN, probably a bug"
-                loss = pg_loss - ent_coef * entropy_loss + v_loss * args.vf_coef
+                if warming_up:
+                    # Critic-only warm-up: train the value head on the rollout
+                    # returns; actor + encoder are frozen so pg/entropy are
+                    # excluded (still computed above for logging).
+                    loss = v_loss * args.vf_coef
+                else:
+                    loss = pg_loss - ent_coef * entropy_loss + v_loss * args.vf_coef
 
                 optimizer.zero_grad(set_to_none=True)
                 assert not torch.isnan(loss), "Loss is NaN, probably a bug"

--- a/ppo.py
+++ b/ppo.py
@@ -44,6 +44,7 @@ for _ in range(moving_average_length):
     end_of_episode_thputs.append(0)
 min_belts_thoughputs = [deque(maxlen=100) for _ in range(10)]
 
+
 @dataclass
 class Args:
     exp_name: str = os.path.basename(__file__)[: -len(".py")]
@@ -160,43 +161,57 @@ class Args:
 def make_env(env_id, idx, capture_video, size, run_name):
     def thunk():
         kwargs = {"render_mode": "rgb_array"} if capture_video else {}
-        kwargs.update({'size': size, 'max_steps': 2*size, 'idx': idx})
+        kwargs.update({"size": size, "max_steps": 2 * size, "idx": idx})
         # kwargs.update({'size': size, 'max_steps': 6})
         env = gym.make(env_id, **kwargs)
         if capture_video:
-            env = gym.wrappers.RecordVideo(env, f"videos/{run_name}/env_{idx}", episode_trigger=lambda e: (e+1) % 10 == 0)
+            env = gym.wrappers.RecordVideo(
+                env,
+                f"videos/{run_name}/env_{idx}",
+                episode_trigger=lambda e: (e + 1) % 10 == 0,
+            )
             # env = gym.wrappers.RecordVideo(env, f"videos/{run_name}/env_{idx}", episode_trigger=lambda _: True)
         env = gym.wrappers.RecordEpisodeStatistics(env)
         return env
+
     return thunk
+
 
 def layer_init(layer, std=np.sqrt(2), bias_const=0.0):
     torch.nn.init.orthogonal_(layer.weight, std)
     torch.nn.init.constant_(layer.bias, bias_const)
     return layer
 
+
 mapping = {
     # transport belt
-    (1, 1): '↑',
-    (1, 2): '→',
-    (1, 3): '↓',
-    (1, 4): '←',
+    (1, 1): "↑",
+    (1, 2): "→",
+    (1, 3): "↓",
+    (1, 4): "←",
     # sink
-    (5, 1):  '📥',
-    (5, 2):  '📥',
-    (5, 3):  '📥',
-    (5, 4): '📥',
+    (5, 1): "📥",
+    (5, 2): "📥",
+    (5, 3): "📥",
+    (5, 4): "📥",
     # source
-    (6, 1):  '📤',
-    (6, 2):  '📤',
-    (6, 3):  '📤',
-    (6, 4): '📤',
+    (6, 1): "📤",
+    (6, 2): "📤",
+    (6, 3): "📤",
+    (6, 4): "📤",
 }
 
+
 def get_pretty_format(tensor, entity_dir_map):
-    assert isinstance(tensor, torch.Tensor), f"Input must be a torch tensor but is {tensor}"
-    assert tensor.ndim == 3 and tensor.shape[0] >= 2, f"Tensor must have shape (2+, W, H) but has shape {tensor.shape}"
-    assert tensor.shape[1] == tensor.shape[2], f"Expected world to be square, but is of shape {tensor.shape}"
+    assert isinstance(tensor, torch.Tensor), (
+        f"Input must be a torch tensor but is {tensor}"
+    )
+    assert tensor.ndim == 3 and tensor.shape[0] >= 2, (
+        f"Tensor must have shape (2+, W, H) but has shape {tensor.shape}"
+    )
+    assert tensor.shape[1] == tensor.shape[2], (
+        f"Expected world to be square, but is of shape {tensor.shape}"
+    )
     # assert torch.is_integral(tensor), "Tensor must contain integers"
 
     _, W, H = tensor.shape
@@ -212,9 +227,9 @@ def get_pretty_format(tensor, entity_dir_map):
             ent = int(entities[x, y])
             direc = int(directions[x, y])
             char = entity_dir_map.get((ent, direc), str(ent))
-            if char == '0':
-                char = '.'
-            if char in ('📤', '📥'):
+            if char == "0":
+                char = "."
+            if char in ("📤", "📥"):
                 line.append(f"{char:^2}")
             else:
                 line.append(f"{char:^3}")
@@ -261,17 +276,18 @@ class FactorioEnv(gym.Env):
             dtype=int,
         )
 
-
-        self.action_space = gym.spaces.Dict({
-            "xy": gym.spaces.Box(low=0, high=self.size, shape=(2,), dtype=int),
-            "entity": gym.spaces.Discrete(len(entities)),
-            "direction": gym.spaces.Discrete(len(Direction)),
-            "item": gym.spaces.Discrete(len(items)),
-            "misc": gym.spaces.Discrete(len(Misc))
-        })
+        self.action_space = gym.spaces.Dict(
+            {
+                "xy": gym.spaces.Box(low=0, high=self.size, shape=(2,), dtype=int),
+                "entity": gym.spaces.Discrete(len(entities)),
+                "direction": gym.spaces.Discrete(len(Direction)),
+                "item": gym.spaces.Discrete(len(items)),
+                "misc": gym.spaces.Discrete(len(Misc)),
+            }
+        )
         # Cache source/sink IDs (non-placeable prototypes)
-        self._source_id = str2ent('stack_inserter').value
-        self._sink_id = str2ent('bulk_inserter').value
+        self._source_id = str2ent("stack_inserter").value
+        self._sink_id = str2ent("bulk_inserter").value
         self._reset_options = options if options is not None else {}
 
         self.steps = 0
@@ -282,13 +298,13 @@ class FactorioEnv(gym.Env):
     def _get_info(self):
         return {
             # 'num_missing_entities': self.num_missing_entities,
-            'throughput': self._throughput,
-            'frac_reachable': self._frac_reachable,
-            'frac_hallucin': self._frac_hallucin,
-            'final_dir_reward': self._final_dir_reward,
-            'material_cost': self._material_cost,
-            'reward': self._reward,
-            'cum_reward': self._cum_reward,
+            "throughput": self._throughput,
+            "frac_reachable": self._frac_reachable,
+            "frac_hallucin": self._frac_hallucin,
+            "final_dir_reward": self._final_dir_reward,
+            "material_cost": self._material_cost,
+            "reward": self._reward,
+            "cum_reward": self._cum_reward,
         }
 
     def _compute_solution_match(self):
@@ -299,7 +315,7 @@ class FactorioEnv(gym.Env):
         orig_dir = self._solved_world_CWH[Channel.DIRECTION.value]
         curr_dir = self._world_CWH[Channel.DIRECTION.value]
 
-        mask = (orig_ent != 0)
+        mask = orig_ent != 0
         n = mask.sum().item()
         if n == 0:
             return 1.0, 1.0, 1.0
@@ -329,7 +345,9 @@ class FactorioEnv(gym.Env):
         self._terminated = False
         self._truncated = False
         self.max_entities = 2
-        self._num_missing_entities = self._reset_options['num_missing_entities'] # TODO also change max_steps in tandem
+        self._num_missing_entities = self._reset_options[
+            "num_missing_entities"
+        ]  # TODO also change max_steps in tandem
 
         self.actions = []
         # Lesson kind is settable per-reset. Default (omitted or None) is
@@ -344,14 +362,27 @@ class FactorioEnv(gym.Env):
         # itself for a given (size, kind, seed); for the random-kind
         # path we just sample a different kind, since they have very
         # different rejection rates on small grids.
-        kind_opt = self._reset_options.get('kind', None)
+        kind_opt = self._reset_options.get("kind", None)
         factory = None
         if kind_opt is None:
-            kinds_list = list(LessonKind)
+            # OVERFIT EXPERIMENT: pin RL to MOVE_ONE_ITEM only (matches the SFT
+            # pinning in generate_dataset). Re-enable the others / restore
+            # `kinds_list = list(LessonKind)` to train on the full mix.
+            kinds_list = [
+                LessonKind.MOVE_ONE_ITEM,
+                # LessonKind.SPLITTER_SPLIT,
+                # LessonKind.SPLITTER_MERGE,
+                # LessonKind.ASSEMBLE_1IN_1OUT,
+                # LessonKind.MOVE_VIA_UG_BELT,
+                # LessonKind.ASSEMBLE_2IN_1OUT,
+                # LessonKind.FROM_BLUEPRINT,
+            ]
             for _ in range(16):
                 kind = kinds_list[int(self.np_random.integers(0, len(kinds_list)))]
                 factory = build_factory(
-                    size=self.size, kind=kind, seed=self._seed,
+                    size=self.size,
+                    kind=kind,
+                    seed=self._seed,
                 )
                 if factory is not None:
                     break
@@ -363,12 +394,13 @@ class FactorioEnv(gym.Env):
         else:
             kind = kind_opt
             factory = build_factory(
-                size=self.size, kind=kind, seed=self._seed,
+                size=self.size,
+                kind=kind,
+                seed=self._seed,
             )
             if factory is None:
                 raise RuntimeError(
-                    f"build_factory returned None for kind={kind} "
-                    f"seed={self._seed}"
+                    f"build_factory returned None for kind={kind} seed={self._seed}"
                 )
         self._solved_world_CWH = factory.world_CWH
         self._world_CWH, min_entities_required = blank_entities(
@@ -389,10 +421,13 @@ class FactorioEnv(gym.Env):
         item_id = action["item"]
         misc = action["misc"]
 
-
         # (x, y), entity_id, direc = action
-        assert 0 <= x < self._world_CWH.shape[1], f"x={x} out of bounds [0, {self._world_CWH.shape[1]})"
-        assert 0 <= y < self._world_CWH.shape[2], f"y={y} out of bounds [0, {self._world_CWH.shape[2]})"
+        assert 0 <= x < self._world_CWH.shape[1], (
+            f"x={x} out of bounds [0, {self._world_CWH.shape[1]})"
+        )
+        assert 0 <= y < self._world_CWH.shape[2], (
+            f"y={y} out of bounds [0, {self._world_CWH.shape[2]})"
+        )
         source_id = self._source_id
         sink_id = self._sink_id
 
@@ -402,16 +437,16 @@ class FactorioEnv(gym.Env):
         self.actions.append(None)
         action_is_invalid = False
         invalid_reason = {
-            'placed_on_masked_tile': False,
-            'replaced_source_or_sink': False,
-            'placed_source_or_sink': False,
-            'place_asm_mach_wo_recipe': False,
-            'placement_wo_direction': False,
-            'direction_wo_entity': False,
-            'ug_belt_wo_up_or_down': False,
-            'placement_with_unneeded_misc': False,
-            'too_wide': False,
-            'too_tall': False,
+            "placed_on_masked_tile": False,
+            "replaced_source_or_sink": False,
+            "placed_source_or_sink": False,
+            "place_asm_mach_wo_recipe": False,
+            "placement_wo_direction": False,
+            "direction_wo_entity": False,
+            "ug_belt_wo_up_or_down": False,
+            "placement_with_unneeded_misc": False,
+            "too_wide": False,
+            "too_tall": False,
         }
 
         # Check that the action is actually valid
@@ -423,32 +458,42 @@ class FactorioEnv(gym.Env):
             action_is_invalid = True
         elif entity_id in (source_id, sink_id):
             # agent tried to place a source or sink
-            invalid_reason['placed_source_or_sink'] = True
+            invalid_reason["placed_source_or_sink"] = True
             action_is_invalid = True
-        elif entity_id == str2ent('assembling_machine_1').value and item_id == str2item('empty'):
+        elif entity_id == str2ent("assembling_machine_1").value and item_id == str2item(
+            "empty"
+        ):
             # Model is trying to place an assembling machine without a recipe
-            invalid_reason['place_asm_mach_wo_recipe'] = True
+            invalid_reason["place_asm_mach_wo_recipe"] = True
             action_is_invalid = True
             pass
-        elif entity_id not in (str2ent('empty').value, str2ent('assembling_machine_1').value) and direc == Direction.NONE.value:
+        elif (
+            entity_id
+            not in (str2ent("empty").value, str2ent("assembling_machine_1").value)
+            and direc == Direction.NONE.value
+        ):
             # Model is trying to put a thing without giving a direction
-            invalid_reason['placement_wo_direction'] = True
+            invalid_reason["placement_wo_direction"] = True
             action_is_invalid = True
             pass
-        elif entity_id == str2ent('empty').value and direc != Direction.NONE.value:
+        elif entity_id == str2ent("empty").value and direc != Direction.NONE.value:
             # Model is trying to put a thing without giving a direction
-            invalid_reason['direction_wo_entity'] = True
+            invalid_reason["direction_wo_entity"] = True
             action_is_invalid = True
             pass
-        elif (misc == Misc.NONE.value) and (entity_id == str2ent('underground_belt').value):
+        elif (misc == Misc.NONE.value) and (
+            entity_id == str2ent("underground_belt").value
+        ):
             # model is trying to place an underground belt without giving a down/up
-            invalid_reason['ug_belt_wo_up_or_down'] = True
+            invalid_reason["ug_belt_wo_up_or_down"] = True
             action_is_invalid = True
             pass
-        elif (misc != Misc.NONE.value) and (entity_id != str2ent('underground_belt').value):
+        elif (misc != Misc.NONE.value) and (
+            entity_id != str2ent("underground_belt").value
+        ):
             # model is trying to place a thing that doesn't need a Misc but
             # still giving it a Misc
-            invalid_reason['placement_with_unneeded_misc'] = True
+            invalid_reason["placement_with_unneeded_misc"] = True
             action_is_invalid = True
             pass
         else:
@@ -457,7 +502,9 @@ class FactorioEnv(gym.Env):
             # rotation correctly; the previous x+width/y+height bounds
             # checks were direction-agnostic and wrong for rotated splitters.
             proto = entities[entity_id]
-            tiles_list = factorion_rs.py_entity_tiles(x, y, direc, proto.width, proto.height)
+            tiles_list = factorion_rs.py_entity_tiles(
+                x, y, direc, proto.width, proto.height
+            )
             if tiles_list is None:
                 tiles_list = [(x, y)]
             tiles_list = [tuple(t) for t in tiles_list]
@@ -471,20 +518,21 @@ class FactorioEnv(gym.Env):
                 for tx, ty in tiles_list
             )
             if out_of_bounds:
-                invalid_reason['too_wide'] = True
+                invalid_reason["too_wide"] = True
                 action_is_invalid = True
             elif any(
                 self._world_CWH[Channel.FOOTPRINT.value, tx, ty]
-                    == Footprint.UNAVAILABLE.value
+                == Footprint.UNAVAILABLE.value
                 for tx, ty in tiles_list
             ):
-                invalid_reason['placed_on_masked_tile'] = True
+                invalid_reason["placed_on_masked_tile"] = True
                 action_is_invalid = True
             elif any(
-                int(self._world_CWH[Channel.ENTITIES.value, tx, ty]) in (source_id, sink_id)
+                int(self._world_CWH[Channel.ENTITIES.value, tx, ty])
+                in (source_id, sink_id)
                 for tx, ty in tiles_list
             ):
-                invalid_reason['replaced_source_or_sink'] = True
+                invalid_reason["replaced_source_or_sink"] = True
                 action_is_invalid = True
             else:
                 action_is_invalid = False
@@ -498,16 +546,18 @@ class FactorioEnv(gym.Env):
                 self._world_CWH[Channel.ITEMS.value, x, y] = item_id
                 self._world_CWH[Channel.MISC.value, x, y] = misc
                 self.actions[-1] = {
-                    'entity': entities[entity_id].name,
-                    'xy': (x, y),
-                    'direction': Direction(direc),
-                    'item': items[item_id].name,
-                    'misc': Misc(misc),
+                    "entity": entities[entity_id].name,
+                    "xy": (x, y),
+                    "direction": Direction(direc),
+                    "item": items[item_id].name,
+                    "misc": Misc(misc),
                 }
 
         self.invalid_actions += 1 if action_is_invalid else 0
 
-        throughput, num_unreachable = factorion_rs.simulate_throughput(self._world_CWH.permute(1, 2, 0).to(torch.int64).numpy())
+        throughput, num_unreachable = factorion_rs.simulate_throughput(
+            self._world_CWH.permute(1, 2, 0).to(torch.int64).numpy()
+        )
         # TODO don't always divide by 15
         throughput /= 15.0
 
@@ -517,7 +567,11 @@ class FactorioEnv(gym.Env):
         # NOTE: weird bug with num_unreachable calculations, not planning on
         # fixing any time super soon. really the calculation should be to
         # calculate frac_reachable directly, not go via frac_unreachable
-        frac_reachable = 0 if num_entities == 2 else max(0, 1.0 - (float(num_unreachable) / (num_entities - 2)))
+        frac_reachable = (
+            0
+            if num_entities == 2
+            else max(0, 1.0 - (float(num_unreachable) / (num_entities - 2)))
+        )
         frac_hallucin = 0
 
         # Give some small reward for having the belt be the right direction.
@@ -525,12 +579,14 @@ class FactorioEnv(gym.Env):
         # MOVE_ONE_ITEM case). Other lesson kinds (e.g. SPLITTER_SPLIT)
         # place multiple sinks or none, so this shaping term gets zeroed
         # instead of asserting.
-        sink_locs = torch.where(self._world_CWH[Channel.ENTITIES.value] == self._sink_id)
+        sink_locs = torch.where(
+            self._world_CWH[Channel.ENTITIES.value] == self._sink_id
+        )
         C, W, H = self._world_CWH.shape
         if len(sink_locs[0]) == 1:
             w_sink, h_sink = sink_locs[0][0], sink_locs[1][0]
-            w_belt = torch.clamp(w_sink, 1, W-2)
-            h_belt = torch.clamp(h_sink, 1, H-2)
+            w_belt = torch.clamp(w_sink, 1, W - 2)
+            h_belt = torch.clamp(h_sink, 1, H - 2)
             final_belt_dir = self._world_CWH[Channel.DIRECTION.value, w_belt, h_belt]
             sink_dir = self._world_CWH[Channel.DIRECTION.value, w_sink, h_sink]
             final_dir_reward = 1.0 if final_belt_dir == sink_dir else 0.0
@@ -538,9 +594,21 @@ class FactorioEnv(gym.Env):
             final_dir_reward = 0.0
 
         material_cost = (
-            1.0 * (self._world_CWH[Channel.DIRECTION.value] == str2ent('transport_belt').value).sum()
-            + 1.5 * (self._world_CWH[Channel.DIRECTION.value] == str2ent('underground_belt').value).sum()
-            + 2.0 * (self._world_CWH[Channel.DIRECTION.value] == str2ent('assembling_machine_1').value).sum()
+            1.0
+            * (
+                self._world_CWH[Channel.DIRECTION.value]
+                == str2ent("transport_belt").value
+            ).sum()
+            + 1.5
+            * (
+                self._world_CWH[Channel.DIRECTION.value]
+                == str2ent("underground_belt").value
+            ).sum()
+            + 2.0
+            * (
+                self._world_CWH[Channel.DIRECTION.value]
+                == str2ent("assembling_machine_1").value
+            ).sum()
         )
 
         # ── Diagnostic tile-match metrics (for logging, NOT used in reward) ──
@@ -549,11 +617,13 @@ class FactorioEnv(gym.Env):
         orig_dir = self._solved_world_CWH[Channel.DIRECTION.value]
         curr_dir = self._world_CWH[Channel.DIRECTION.value]
 
-        solution_nonempty = (orig_ent != 0)
-        current_nonempty = (curr_ent != 0)
+        solution_nonempty = orig_ent != 0
+        current_nonempty = curr_ent != 0
         num_solution_nonempty = solution_nonempty.sum().item()
         if num_solution_nonempty > 0:
-            tile_match_location = (solution_nonempty & current_nonempty).sum().item() / num_solution_nonempty
+            tile_match_location = (
+                solution_nonempty & current_nonempty
+            ).sum().item() / num_solution_nonempty
         else:
             tile_match_location = 1.0
         tile_match_entity = (curr_ent == orig_ent).float().mean().item()
@@ -561,20 +631,24 @@ class FactorioEnv(gym.Env):
 
         # ── Normalized weighted reward (throughput + validity only) ──
         reward_components = {
-            'throughput': {
-                'coeff': Args.coeff_throughput if 'args' not in locals() else args.coeff_throughput,
-                'value': throughput,
+            "throughput": {
+                "coeff": Args.coeff_throughput
+                if "args" not in locals()
+                else args.coeff_throughput,
+                "value": throughput,
             },
-            'validity': {
-                'coeff': Args.coeff_validity if 'args' not in locals() else args.coeff_validity,
-                'value': 0 if action_is_invalid else 1,
+            "validity": {
+                "coeff": Args.coeff_validity
+                if "args" not in locals()
+                else args.coeff_validity,
+                "value": 0 if action_is_invalid else 1,
             },
         }
         pre_reward = 0.0
         normalisation = 0.0
         for name, item in reward_components.items():
-            pre_reward += item['coeff'] * item['value']
-            normalisation += item['coeff']
+            pre_reward += item["coeff"] * item["value"]
+            normalisation += item["coeff"]
 
         pre_reward /= normalisation
 
@@ -586,9 +660,21 @@ class FactorioEnv(gym.Env):
         dir_delta = curr_match[2] - self._prev_match[2]
         self._prev_match = curr_match
 
-        coeff_loc = Args.coeff_shaping_location if 'args' not in locals() else args.coeff_shaping_location
-        coeff_ent = Args.coeff_shaping_entity if 'args' not in locals() else args.coeff_shaping_entity
-        coeff_dir = Args.coeff_shaping_direction if 'args' not in locals() else args.coeff_shaping_direction
+        coeff_loc = (
+            Args.coeff_shaping_location
+            if "args" not in locals()
+            else args.coeff_shaping_location
+        )
+        coeff_ent = (
+            Args.coeff_shaping_entity
+            if "args" not in locals()
+            else args.coeff_shaping_entity
+        )
+        coeff_dir = (
+            Args.coeff_shaping_direction
+            if "args" not in locals()
+            else args.coeff_shaping_direction
+        )
 
         pre_reward += coeff_loc * loc_delta
         pre_reward += coeff_ent * ent_delta
@@ -618,33 +704,37 @@ class FactorioEnv(gym.Env):
         observation = self._get_obs()
         info = self._get_info()
         if terminated or truncated:
-            info.update({ 'steps_taken': self.steps })
+            info.update({"steps_taken": self.steps})
 
-        num_placed_entities = len([a for a in self.actions if a is not None and a['entity'] != 'empty'])
+        num_placed_entities = len(
+            [a for a in self.actions if a is not None and a["entity"] != "empty"]
+        )
 
-        info.update({
-            'throughput': throughput,
-            'frac_reachable': frac_reachable,
-            'frac_hallucin': frac_hallucin,
-            'final_dir_reward': final_dir_reward,
-            'material_cost': material_cost,
-            'completion_bonus': self.max_steps - self.steps,
-            'min_entities_required': self.min_entities_required,
-            'num_entities': num_entities,
-            'num_placed_entities': num_placed_entities,
-            'frac_invalid_actions': self.invalid_actions / self.max_steps,
-            'max_entities': self.max_entities,
-            'invalid_reason': invalid_reason,
-            'tile_match_location': tile_match_location,
-            'tile_match_entity': tile_match_entity,
-            'tile_match_direction': tile_match_direction,
-            'shaping_location_match': curr_match[0],
-            'shaping_entity_match': curr_match[1],
-            'shaping_direction_match': curr_match[2],
-            'shaping_location_delta': loc_delta,
-            'shaping_entity_delta': ent_delta,
-            'shaping_direction_delta': dir_delta,
-        })
+        info.update(
+            {
+                "throughput": throughput,
+                "frac_reachable": frac_reachable,
+                "frac_hallucin": frac_hallucin,
+                "final_dir_reward": final_dir_reward,
+                "material_cost": material_cost,
+                "completion_bonus": self.max_steps - self.steps,
+                "min_entities_required": self.min_entities_required,
+                "num_entities": num_entities,
+                "num_placed_entities": num_placed_entities,
+                "frac_invalid_actions": self.invalid_actions / self.max_steps,
+                "max_entities": self.max_entities,
+                "invalid_reason": invalid_reason,
+                "tile_match_location": tile_match_location,
+                "tile_match_entity": tile_match_entity,
+                "tile_match_direction": tile_match_direction,
+                "shaping_location_match": curr_match[0],
+                "shaping_entity_match": curr_match[1],
+                "shaping_direction_match": curr_match[2],
+                "shaping_location_delta": loc_delta,
+                "shaping_entity_delta": ent_delta,
+                "shaping_direction_delta": dir_delta,
+            }
+        )
 
         self._cum_reward += reward
         self.steps += 1
@@ -657,10 +747,10 @@ class FactorioEnv(gym.Env):
         Returns an RGB uint8 array compatible with Gymnasium video wrappers.
         """
         # ------------------- constants -------------------
-        ICON_DIR       = Path("factorio-icons")   # where all *.png live
-        CELL_PX        = 64                       # tile size in pixels
-        MINI_PX        = 18                       # size for arrow + recipe icon
-        GRID_COLOR     = (0, 0, 0)                # black grid lines
+        ICON_DIR = Path("factorio-icons")  # where all *.png live
+        CELL_PX = 64  # tile size in pixels
+        MINI_PX = 18  # size for arrow + recipe icon
+        GRID_COLOR = (0, 0, 0)  # black grid lines
 
         # ---------------- lazy one-time setup ------------
         if not hasattr(self, "_render_cache"):
@@ -671,7 +761,13 @@ class FactorioEnv(gym.Env):
             for ent_id, ent in entities.items():
                 p = ICON_DIR / f"{ent.name}.png"
                 if p.exists():
-                    img = Image.open(p).convert("RGBA").resize(((CELL_PX // 10) * 8, (CELL_PX // 10) * 8), Image.BICUBIC)
+                    img = (
+                        Image.open(p)
+                        .convert("RGBA")
+                        .resize(
+                            ((CELL_PX // 10) * 8, (CELL_PX // 10) * 8), Image.BICUBIC
+                        )
+                    )
                     self._render_cache["entity"][ent_id] = img
 
             # item (recipe) icons (resized to MINI_PX)
@@ -680,7 +776,11 @@ class FactorioEnv(gym.Env):
                     continue
                 p = ICON_DIR / f"{itm.name}.png"
                 if p.exists():
-                    img = Image.open(p).convert("RGBA").resize((MINI_PX, MINI_PX), Image.BICUBIC)
+                    img = (
+                        Image.open(p)
+                        .convert("RGBA")
+                        .resize((MINI_PX, MINI_PX), Image.BICUBIC)
+                    )
                     self._render_cache["item"][itm_id] = img
 
             # tiny triangular arrow, rotated for each cardinal direction
@@ -691,41 +791,51 @@ class FactorioEnv(gym.Env):
             shaft_x0 = (MINI_PX - shaft_w) // 2
             draw.rectangle(
                 [shaft_x0, MINI_PX // 3, shaft_x0 + shaft_w, MINI_PX - 1],
-                fill=(0, 0, 0, 255)
+                fill=(0, 0, 0, 255),
             )
             # head: triangle at the top
             draw.polygon(
                 [
-                    (MINI_PX // 2, 0),           # tip
-                    (shaft_x0 + shaft_w*4, MINI_PX // 3),
-                    (shaft_x0 - shaft_w*4, MINI_PX // 3),
+                    (MINI_PX // 2, 0),  # tip
+                    (shaft_x0 + shaft_w * 4, MINI_PX // 3),
+                    (shaft_x0 - shaft_w * 4, MINI_PX // 3),
                 ],
-                fill=(0, 0, 0, 255)
+                fill=(0, 0, 0, 255),
             )
             # cache rotations for each cardinal direction
             self._render_cache["arrow"][Direction.NORTH.value] = base
-            self._render_cache["arrow"][Direction.EAST.value]  = base.rotate(-90, expand=True)
-            self._render_cache["arrow"][Direction.SOUTH.value] = base.rotate(180, expand=True)
-            self._render_cache["arrow"][Direction.WEST.value]  = base.rotate(90,  expand=True)
+            self._render_cache["arrow"][Direction.EAST.value] = base.rotate(
+                -90, expand=True
+            )
+            self._render_cache["arrow"][Direction.SOUTH.value] = base.rotate(
+                180, expand=True
+            )
+            self._render_cache["arrow"][Direction.WEST.value] = base.rotate(
+                90, expand=True
+            )
 
             # default font for fallback label
             self._render_cache["font"] = ImageFont.load_default()
 
         cache = self._render_cache
-        ENT, DIR, ITEM = Channel.ENTITIES.value, Channel.DIRECTION.value, Channel.ITEMS.value
+        ENT, DIR, ITEM = (
+            Channel.ENTITIES.value,
+            Channel.DIRECTION.value,
+            Channel.ITEMS.value,
+        )
 
         # ---------------- canvas -------------------------
-        HUD_PX = 32*4                                     # height of stats strip
+        HUD_PX = 32 * 4  # height of stats strip
         canvas_w = canvas_h = self.size * CELL_PX
         canvas = Image.new("RGB", (canvas_w, canvas_h + HUD_PX), (255, 255, 255))
-        draw   = ImageDraw.Draw(canvas)
+        draw = ImageDraw.Draw(canvas)
 
-        ent_layer  = self._world_CWH[ENT].cpu().numpy()
-        dir_layer  = self._world_CWH[DIR].cpu().numpy()
+        ent_layer = self._world_CWH[ENT].cpu().numpy()
+        dir_layer = self._world_CWH[DIR].cpu().numpy()
         item_layer = self._world_CWH[ITEM].cpu().numpy()
 
-        for gx in range(self.size):          # grid row
-            for gy in range(self.size):      # grid col
+        for gx in range(self.size):  # grid row
+            for gy in range(self.size):  # grid col
                 x0, y0 = gx * CELL_PX, gy * CELL_PX
                 x1, y1 = x0 + CELL_PX, y0 + CELL_PX
                 draw.rectangle([x0, y0, x1, y1], outline=GRID_COLOR, width=1)
@@ -733,21 +843,26 @@ class FactorioEnv(gym.Env):
                 ent_id = int(ent_layer[gx, gy])
                 sprite = cache["entity"].get(ent_id)
                 if sprite is not None:
-                    canvas.paste(sprite, (x0 + CELL_PX//10, y0 + CELL_PX//10), sprite)
+                    canvas.paste(
+                        sprite, (x0 + CELL_PX // 10, y0 + CELL_PX // 10), sprite
+                    )
                 else:
                     # fallback: draw first letter
                     letter = entities[ent_id].name[0].upper()
-                    font   = cache["font"]
-                    canvas_w, canvas_h   = font.getbbox(letter)[2:]
+                    font = cache["font"]
+                    canvas_w, canvas_h = font.getbbox(letter)[2:]
                     draw.text(
-                        (x0 + (CELL_PX - canvas_w) // 2, y0 + (CELL_PX - canvas_h) // 2),
+                        (
+                            x0 + (CELL_PX - canvas_w) // 2,
+                            y0 + (CELL_PX - canvas_h) // 2,
+                        ),
                         letter,
                         fill=(0, 0, 0),
                         font=font,
                     )
                 # Draw the xy-coords onto the cell
                 text = f"{gx},{gy}"
-                font   = cache["font"]
+                font = cache["font"]
                 draw.text(
                     (x0 + (CELL_PX // 10) * 8, y0 + CELL_PX // 10),
                     text,
@@ -756,13 +871,13 @@ class FactorioEnv(gym.Env):
                 )
 
                 itm_id = int(item_layer[gx, gy])
-                mini   = cache["item"].get(itm_id)
+                mini = cache["item"].get(itm_id)
                 if mini is not None:
                     off = CELL_PX - MINI_PX - 2
                     canvas.paste(mini, (x0 + off, y0 + off), mini)
 
                 dir_id = Direction(dir_layer[gx, gy]).value
-                arrow  = cache["arrow"].get(dir_id)
+                arrow = cache["arrow"].get(dir_id)
                 if arrow is not None:
                     canvas.paste(arrow, (x0 + 2, y0 + 2), arrow)
 
@@ -786,7 +901,9 @@ class FactorioEnv(gym.Env):
         bbox = font.getbbox(lines[0])
         txt_h = bbox[3] - bbox[1]
 
-        draw.rectangle([(0, canvas_h), (canvas_w, canvas_h + HUD_PX)], fill=(230, 230, 230))
+        draw.rectangle(
+            [(0, canvas_h), (canvas_w, canvas_h + HUD_PX)], fill=(230, 230, 230)
+        )
         for i, line in enumerate(lines):
             draw.text(
                 (4, 4 + canvas_h + i * txt_h * 1.25),
@@ -799,7 +916,9 @@ class FactorioEnv(gym.Env):
 
 
 class AgentCNN(nn.Module):
-    def __init__(self, envs, chan1=32, chan2=64, chan3=64, flat_dim=256, tile_head_std=0.01):
+    def __init__(
+        self, envs, chan1=32, chan2=64, chan3=64, flat_dim=256, tile_head_std=0.01
+    ):
         super().__init__()
         base_env = envs.envs[0].unwrapped
         self.width = base_env.size
@@ -830,8 +949,7 @@ class AgentCNN(nn.Module):
 
         # Project encoded state to value
         self.critic_head = nn.Sequential(
-            nn.Flatten(),
-            layer_init(nn.Linear(flat_dim, 1), std=1.0)
+            nn.Flatten(), layer_init(nn.Linear(flat_dim, 1), std=1.0)
         )
 
         # Binary end-of-turn head. Predicts whether the factory is complete
@@ -849,7 +967,9 @@ class AgentCNN(nn.Module):
         )
 
         # Tile selection: 1x1 conv producing one logit per spatial position
-        self.tile_logits = layer_init(nn.Conv2d(chan3, 1, kernel_size=1), std=tile_head_std)
+        self.tile_logits = layer_init(
+            nn.Conv2d(chan3, 1, kernel_size=1), std=tile_head_std
+        )
 
         # Per-tile entity/direction/item/misc heads (conditioned on selected
         # tile features). The env's step() requires all four to be set
@@ -904,12 +1024,12 @@ class AgentCNN(nn.Module):
         B = encoded_BCWH.shape[0]
 
         # --- Tile selection: joint (x, y) via 1x1 conv ---
-        tile_logits_B1WH = self.tile_logits(encoded_BCWH)      # (B, 1, W, H)
-        tile_logits_BN = tile_logits_B1WH.reshape(B, -1)       # (B, W*H)
+        tile_logits_B1WH = self.tile_logits(encoded_BCWH)  # (B, 1, W, H)
+        tile_logits_BN = tile_logits_B1WH.reshape(B, -1)  # (B, W*H)
         dist_tile = Categorical(logits=tile_logits_BN)
 
         if action is None:
-            tile_idx_B = dist_tile.sample()                     # (B,)
+            tile_idx_B = dist_tile.sample()  # (B,)
         else:
             # Reconstruct tile index from stored (x, y)
             tile_idx_B = action[:, 0] * self.height + action[:, 1]
@@ -945,18 +1065,18 @@ class AgentCNN(nn.Module):
 
         # --- Log probs and entropy ---
         logp_B = (
-            dist_tile.log_prob(tile_idx_B) +
-            dist_e.log_prob(ent_B) +
-            dist_d.log_prob(dir_B) +
-            dist_i.log_prob(item_B) +
-            dist_m.log_prob(misc_B)
+            dist_tile.log_prob(tile_idx_B)
+            + dist_e.log_prob(ent_B)
+            + dist_d.log_prob(dir_B)
+            + dist_i.log_prob(item_B)
+            + dist_m.log_prob(misc_B)
         )
         entropy_B = (
-            dist_tile.entropy() +
-            dist_e.entropy() +
-            dist_d.entropy() +
-            dist_i.entropy() +
-            dist_m.entropy()
+            dist_tile.entropy()
+            + dist_e.entropy()
+            + dist_d.entropy()
+            + dist_i.entropy()
+            + dist_m.entropy()
         )
 
         action_out = {
@@ -969,6 +1089,7 @@ class AgentCNN(nn.Module):
         self.time_for_get_action_and_value = time.time() - t0
         return action_out, logp_B, entropy_B, value_B
 
+
 if __name__ == "__main__":
     print("Starting...")
     start_time = time.time()
@@ -978,15 +1099,20 @@ if __name__ == "__main__":
     args.num_iterations = args.total_timesteps // args.batch_size
     # 16 * 256 * (50000/(16*256))
     num_gsteps = args.num_envs * args.num_steps * args.num_iterations
-    print(f"batch_size: {args.batch_size}, minibatch_size: {args.minibatch_size}, num_iterations: {args.num_iterations}, num_gsteps: {num_gsteps}")
+    print(
+        f"batch_size: {args.batch_size}, minibatch_size: {args.minibatch_size}, num_iterations: {args.num_iterations}, num_gsteps: {num_gsteps}"
+    )
 
-    iso8601 = datetime.now().replace(microsecond=0).isoformat(sep='T')
+    iso8601 = datetime.now().replace(microsecond=0).isoformat(sep="T")
     run_name = f"{iso8601} seed{args.seed}"
     run = None
     if args.track:
         import wandb
+
         if args.start_from_wandb is not None and args.start_from is None:
-            raise Exception(f"args.start_from_wandb is not None ({args.start_from_wandb}) and args.start_from is None")
+            raise Exception(
+                f"args.start_from_wandb is not None ({args.start_from_wandb}) and args.start_from is None"
+            )
 
         run = wandb.init(
             project=args.wandb_project_name,
@@ -1005,7 +1131,7 @@ if __name__ == "__main__":
             f"num_iterations:{args.num_iterations}",
             f"seed:{args.seed}",
             f"size:{args.size}",
-            f"timesteps:{args.total_timesteps//1000}K",
+            f"timesteps:{args.total_timesteps // 1000}K",
             f"chan1:{args.chan1}",
             f"chan2:{args.chan2}",
             f"chan3:{args.chan3}",
@@ -1014,16 +1140,36 @@ if __name__ == "__main__":
 
         # Define metric axes and summary aggregation
         wandb.define_metric("*", step_metric="global_step")
-        for m in ["throughput", "reward", "length", "invalid_frac",
-                   "num_entities", "entity_efficiency", "frac_reachable"]:
+        for m in [
+            "throughput",
+            "reward",
+            "length",
+            "invalid_frac",
+            "num_entities",
+            "entity_efficiency",
+            "frac_reachable",
+        ]:
             wandb.define_metric(f"episode/{m}", summary="last")
-        for m in ["tile_location", "tile_entity", "tile_direction",
-                   "delta_location", "delta_entity", "delta_direction"]:
+        for m in [
+            "tile_location",
+            "tile_entity",
+            "tile_direction",
+            "delta_location",
+            "delta_entity",
+            "delta_direction",
+        ]:
             wandb.define_metric(f"shaping/{m}", summary="last")
         wandb.define_metric("curriculum/score", summary="max")
         wandb.define_metric("curriculum/level", summary="max")
         wandb.define_metric("curriculum/throughput_avg", summary="last")
-        for m in ["policy", "value", "entropy", "approx_kl", "clipfrac", "explained_var"]:
+        for m in [
+            "policy",
+            "value",
+            "entropy",
+            "approx_kl",
+            "clipfrac",
+            "explained_var",
+        ]:
             wandb.define_metric(f"losses/{m}", summary="last")
         for m in ["lr", "ent_coef", "grad_norm"]:
             wandb.define_metric(f"optim/{m}", summary="last")
@@ -1043,7 +1189,11 @@ if __name__ == "__main__":
     torch.backends.cudnn.deterministic = args.torch_deterministic
     torch.use_deterministic_algorithms(args.torch_deterministic)
 
-    device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else ("mps" if torch.backends.mps.is_available() and args.metal else "cpu"))
+    device = torch.device(
+        "cuda"
+        if torch.cuda.is_available() and args.cuda
+        else ("mps" if torch.backends.mps.is_available() and args.metal else "cpu")
+    )
     if device.type == "mps":
         # metal doesn't like anything but f32
         torch.set_default_dtype(torch.float32)
@@ -1052,10 +1202,15 @@ if __name__ == "__main__":
     print(f"Setting up envs with {args}")
     # env setup
     envs = gym.vector.SyncVectorEnv(
-        [make_env(args.env_id, i, args.capture_video, args.size, run_name) for i in range(args.num_envs)],
+        [
+            make_env(args.env_id, i, args.capture_video, args.size, run_name)
+            for i in range(args.num_envs)
+        ],
     )
 
-    print(f"Creating agent with {args.chan1=}, {args.chan2=}, {args.chan3=}, {args.flat_dim=}, {args.tile_head_std=} ")
+    print(
+        f"Creating agent with {args.chan1=}, {args.chan2=}, {args.chan3=}, {args.flat_dim=}, {args.tile_head_std=} "
+    )
     agent = AgentCNN(
         envs,
         chan1=args.chan1,
@@ -1076,17 +1231,33 @@ if __name__ == "__main__":
     print("Compiling agent with torch.compile()")
     agent = torch.compile(agent)
 
-    optimizer = optim.Adam(agent.parameters(), lr=args.learning_rate, eps=args.adam_epsilon)
+    optimizer = optim.Adam(
+        agent.parameters(), lr=args.learning_rate, eps=args.adam_epsilon
+    )
 
     print("Allocating storage space")
     # ALGO Logic: Storage setup
-    obs_SECWH = torch.zeros((args.num_steps, args.num_envs) + envs.single_observation_space.shape, dtype=torch.float32, device=device)
+    obs_SECWH = torch.zeros(
+        (args.num_steps, args.num_envs) + envs.single_observation_space.shape,
+        dtype=torch.float32,
+        device=device,
+    )
     ACTION_SPACE_SHAPE = (6,)
-    actions_SEA = torch.zeros((args.num_steps, args.num_envs) + ACTION_SPACE_SHAPE, dtype=int, device=device)
-    logprobs_SE = torch.zeros((args.num_steps, args.num_envs), dtype=torch.float32, device=device)
-    rewards_SE = torch.zeros((args.num_steps, args.num_envs), dtype=torch.float32, device=device)
-    dones_SE = torch.zeros((args.num_steps, args.num_envs), dtype=torch.float32, device=device)
-    values_SE = torch.zeros((args.num_steps, args.num_envs), dtype=torch.float32, device=device)
+    actions_SEA = torch.zeros(
+        (args.num_steps, args.num_envs) + ACTION_SPACE_SHAPE, dtype=int, device=device
+    )
+    logprobs_SE = torch.zeros(
+        (args.num_steps, args.num_envs), dtype=torch.float32, device=device
+    )
+    rewards_SE = torch.zeros(
+        (args.num_steps, args.num_envs), dtype=torch.float32, device=device
+    )
+    dones_SE = torch.zeros(
+        (args.num_steps, args.num_envs), dtype=torch.float32, device=device
+    )
+    values_SE = torch.zeros(
+        (args.num_steps, args.num_envs), dtype=torch.float32, device=device
+    )
 
     # TRY NOT TO MODIFY: start the game
     global_step = 0
@@ -1094,10 +1265,14 @@ if __name__ == "__main__":
     next_obs_ECWH, _ = envs.reset(
         seed=args.seed,
         options={
-            'num_missing_entities': int(torch.randint(0, max_missing_entities+1, (1,))[0]),
-        }
+            "num_missing_entities": int(
+                torch.randint(0, max_missing_entities + 1, (1,))[0]
+            ),
+        },
     )
-    next_obs_ECWH = torch.as_tensor(np.array(next_obs_ECWH), dtype=torch.float32, device=device)
+    next_obs_ECWH = torch.as_tensor(
+        np.array(next_obs_ECWH), dtype=torch.float32, device=device
+    )
     next_done = torch.zeros(args.num_envs, dtype=torch.float32, device=device)
     final_thputs_100ma = sum(end_of_episode_thputs) / len(end_of_episode_thputs)
     unclipped_grad_norm = np.nan
@@ -1105,11 +1280,14 @@ if __name__ == "__main__":
 
     # Log initial eval metrics at step 0 (before any training)
     if args.track:
-        wandb.log({
-            "curriculum/level": max_missing_entities,
-            "curriculum/score": (max_missing_entities - 1) + final_thputs_100ma,
-            "curriculum/throughput_avg": final_thputs_100ma,
-        }, step=0)
+        wandb.log(
+            {
+                "curriculum/level": max_missing_entities,
+                "curriculum/score": (max_missing_entities - 1) + final_thputs_100ma,
+                "curriculum/throughput_avg": final_thputs_100ma,
+            },
+            step=0,
+        )
 
     # Accumulate episode-level metrics during rollout, log means once per iteration
     _episode_metrics: dict[str, list[float]] = {}
@@ -1139,12 +1317,16 @@ if __name__ == "__main__":
 
         # Entropy coefficient annealing: linear from ent_coef_start to ent_coef_end
         ent_frac = 1.0 - (iteration - 1.0) / args.num_iterations
-        ent_coef = args.ent_coef_end + ent_frac * (args.ent_coef_start - args.ent_coef_end)
+        ent_coef = args.ent_coef_end + ent_frac * (
+            args.ent_coef_start - args.ent_coef_end
+        )
 
         for step in range(0, args.num_steps):
             global_step += args.num_envs
-            if (step+1) % 10 == 0 or step + 1 == args.num_steps:
-                pbar.set_description(f"taking step {step+1: 4}/{args.num_steps}; gstep:{global_step: 6}; score:{(max_missing_entities - 1) + final_thputs_100ma:.2f} (lvl:{max_missing_entities} thput:{final_thputs_100ma:.2f})")
+            if (step + 1) % 10 == 0 or step + 1 == args.num_steps:
+                pbar.set_description(
+                    f"taking step {step + 1: 4}/{args.num_steps}; gstep:{global_step: 6}; score:{(max_missing_entities - 1) + final_thputs_100ma:.2f} (lvl:{max_missing_entities} thput:{final_thputs_100ma:.2f})"
+                )
             obs_SECWH[step] = next_obs_ECWH
             dones_SE[step] = next_done
 
@@ -1152,7 +1334,9 @@ if __name__ == "__main__":
             with torch.no_grad():
                 # TODO update for new action logic
                 # D for dictionary
-                action_ED, logprobs_E, _entropy_E, value_E = agent.get_action_and_value(next_obs_ECWH)
+                action_ED, logprobs_E, _entropy_E, value_E = agent.get_action_and_value(
+                    next_obs_ECWH
+                )
                 values_SE[step] = value_E
                 # Flatten action
                 # (xy_B2, direc_B1, entities_B1) = action_ED
@@ -1173,20 +1357,33 @@ if __name__ == "__main__":
 
             action_ED_numpy = {k: v.cpu().numpy() for k, v in action_ED.items()}
             # TRY NOT TO MODIFY: execute the game and log data.
-            next_obs_ECWH, reward, terminations, truncations, infos = envs.step(action_ED_numpy)
+            next_obs_ECWH, reward, terminations, truncations, infos = envs.step(
+                action_ED_numpy
+            )
             next_done = np.logical_or(terminations, truncations)
-            rewards_SE[step] = torch.as_tensor(np.array(reward), dtype=torch.float32, device=device)
+            rewards_SE[step] = torch.as_tensor(
+                np.array(reward), dtype=torch.float32, device=device
+            )
 
             # Reset only the done environments with updated num_missing_entities
             done_indices = np.where(next_done)[0]
             for idx in done_indices:
-                obs, _ = envs.envs[idx].reset(seed=args.seed + idx, options={
-                    'num_missing_entities': int(torch.randint(0, max_missing_entities+1, (1,))[0])
-                })
+                obs, _ = envs.envs[idx].reset(
+                    seed=args.seed + idx,
+                    options={
+                        "num_missing_entities": int(
+                            torch.randint(0, max_missing_entities + 1, (1,))[0]
+                        )
+                    },
+                )
                 next_obs_ECWH[idx] = obs
 
-            next_obs_ECWH = torch.as_tensor(np.array(next_obs_ECWH), dtype=torch.float32, device=device)
-            next_done = torch.as_tensor(np.array(next_done), dtype=torch.float32, device=device)
+            next_obs_ECWH = torch.as_tensor(
+                np.array(next_obs_ECWH), dtype=torch.float32, device=device
+            )
+            next_done = torch.as_tensor(
+                np.array(next_done), dtype=torch.float32, device=device
+            )
 
             if "episode" in infos:
                 # The "_episode" mask indicates which environments finished this step
@@ -1210,25 +1407,44 @@ if __name__ == "__main__":
 
                     end_of_episode_thputs.append(end_of_episode_thput)
 
-                    _record_episode({
-                        "episode/throughput": float(end_of_episode_thput),
-                        "episode/reward": float(episode_return),
-                        "episode/length": float(episode_len),
-                        "episode/invalid_frac": float(infos['frac_invalid_actions'][i]),
-                        "episode/num_entities": float(infos['num_entities'][i]),
-                        "episode/entity_efficiency": float(infos['min_entities_required'][i]) / float(infos['num_entities'][i]),
-                        "episode/frac_reachable": float(final_frac_reachable),
-                        "shaping/tile_location": float(infos['tile_match_location'][i]),
-                        "shaping/tile_entity": float(infos['tile_match_entity'][i]),
-                        "shaping/tile_direction": float(infos['tile_match_direction'][i]),
-                        "shaping/delta_location": float(infos['shaping_location_delta'][i]),
-                        "shaping/delta_entity": float(infos['shaping_entity_delta'][i]),
-                        "shaping/delta_direction": float(infos['shaping_direction_delta'][i]),
-                    })
+                    _record_episode(
+                        {
+                            "episode/throughput": float(end_of_episode_thput),
+                            "episode/reward": float(episode_return),
+                            "episode/length": float(episode_len),
+                            "episode/invalid_frac": float(
+                                infos["frac_invalid_actions"][i]
+                            ),
+                            "episode/num_entities": float(infos["num_entities"][i]),
+                            "episode/entity_efficiency": float(
+                                infos["min_entities_required"][i]
+                            )
+                            / float(infos["num_entities"][i]),
+                            "episode/frac_reachable": float(final_frac_reachable),
+                            "shaping/tile_location": float(
+                                infos["tile_match_location"][i]
+                            ),
+                            "shaping/tile_entity": float(infos["tile_match_entity"][i]),
+                            "shaping/tile_direction": float(
+                                infos["tile_match_direction"][i]
+                            ),
+                            "shaping/delta_location": float(
+                                infos["shaping_location_delta"][i]
+                            ),
+                            "shaping/delta_entity": float(
+                                infos["shaping_entity_delta"][i]
+                            ),
+                            "shaping/delta_direction": float(
+                                infos["shaping_direction_delta"][i]
+                            ),
+                        }
+                    )
 
             # Log eval metrics every 256 global steps during rollout
             if args.track and global_step >= _next_eval_log_step:
-                final_thputs_100ma = sum(end_of_episode_thputs) / len(end_of_episode_thputs)
+                final_thputs_100ma = sum(end_of_episode_thputs) / len(
+                    end_of_episode_thputs
+                )
                 eval_metrics = {
                     "curriculum/level": max_missing_entities,
                     "curriculum/score": (max_missing_entities - 1) + final_thputs_100ma,
@@ -1250,8 +1466,14 @@ if __name__ == "__main__":
                 else:
                     nextnonterminal = 1.0 - dones_SE[t + 1]
                     nextvalues = values_SE[t + 1]
-                delta = rewards_SE[t] + args.gamma * nextvalues * nextnonterminal - values_SE[t]
-                lastgaelam = delta + args.gamma * args.gae_lambda * nextnonterminal * lastgaelam
+                delta = (
+                    rewards_SE[t]
+                    + args.gamma * nextvalues * nextnonterminal
+                    - values_SE[t]
+                )
+                lastgaelam = (
+                    delta + args.gamma * args.gae_lambda * nextnonterminal * lastgaelam
+                )
                 advantages_SE[t] = lastgaelam
             returns_SE = advantages_SE + values_SE
 
@@ -1270,15 +1492,16 @@ if __name__ == "__main__":
         idxs_B = np.arange(args.batch_size)
         clipfracs = []
         for epoch in range(args.update_epochs):
-            pbar.set_description(f"optimiser epoch {epoch+1}/{args.update_epochs}; grad norm:{unclipped_grad_norm:5.2f}; kl:{approx_kl:5.3f}; score:{(max_missing_entities - 1) + final_thputs_100ma:.2f}")
+            pbar.set_description(
+                f"optimiser epoch {epoch + 1}/{args.update_epochs}; grad norm:{unclipped_grad_norm:5.2f}; kl:{approx_kl:5.3f}; score:{(max_missing_entities - 1) + final_thputs_100ma:.2f}"
+            )
             np.random.shuffle(idxs_B)
             for start in range(0, args.batch_size, args.minibatch_size):
                 end = start + args.minibatch_size
                 idxs = idxs_B[start:end]
 
-                _action_BA, newlogprobs_B, entropy_B, newvalue_B = agent.get_action_and_value(
-                    obs_B[idxs],
-                    actions_B.long()[idxs]
+                _action_BA, newlogprobs_B, entropy_B, newvalue_B = (
+                    agent.get_action_and_value(obs_B[idxs], actions_B.long()[idxs])
                 )
                 newlogprobs_B = newlogprobs_B.reshape(-1)
                 logratio_B = newlogprobs_B - logprobs_B[idxs].reshape(-1)
@@ -1288,16 +1511,24 @@ if __name__ == "__main__":
                     # calculate approx_kl http://joschu.net/blog/kl-approx.html
                     old_approx_kl = (-logratio_B).mean()
                     approx_kl = ((ratio_B - 1) - logratio_B).mean()
-                    clipfracs += [((ratio_B - 1.0).abs() > args.clip_coef).float().mean().item()]
+                    clipfracs += [
+                        ((ratio_B - 1.0).abs() > args.clip_coef).float().mean().item()
+                    ]
 
-                assert not torch.isnan(advantages_B).any(), f"Some advantages are NaN: {advantages_B=}"
+                assert not torch.isnan(advantages_B).any(), (
+                    f"Some advantages are NaN: {advantages_B=}"
+                )
                 advantages_mB = advantages_B[idxs]
                 if args.norm_adv:
-                    advantages_mB = (advantages_mB - advantages_mB.mean()) / (advantages_mB.std() + 1e-8)
+                    advantages_mB = (advantages_mB - advantages_mB.mean()) / (
+                        advantages_mB.std() + 1e-8
+                    )
 
                 # Policy loss
                 pg_loss1 = -advantages_mB * ratio_B
-                pg_loss2 = -advantages_mB * torch.clamp(ratio_B, 1 - args.clip_coef, 1 + args.clip_coef)
+                pg_loss2 = -advantages_mB * torch.clamp(
+                    ratio_B, 1 - args.clip_coef, 1 + args.clip_coef
+                )
                 pg_loss = torch.max(pg_loss1, pg_loss2).mean()
 
                 # Value loss
@@ -1323,7 +1554,9 @@ if __name__ == "__main__":
                 optimizer.zero_grad(set_to_none=True)
                 assert not torch.isnan(loss), "Loss is NaN, probably a bug"
                 loss.backward()
-                unclipped_grad_norm = nn.utils.clip_grad_norm_(agent.parameters(), args.max_grad_norm)
+                unclipped_grad_norm = nn.utils.clip_grad_norm_(
+                    agent.parameters(), args.max_grad_norm
+                )
                 optimizer.step()
 
             if args.target_kl is not None and approx_kl > args.target_kl:
@@ -1356,28 +1589,42 @@ if __name__ == "__main__":
         if len(end_of_episode_thputs) > 0:
             final_thputs_100ma = sum(end_of_episode_thputs) / len(end_of_episode_thputs)
             if len(end_of_episode_thputs) > int(moving_average_length * 0.9):
-                if final_thputs_100ma > 0.95 and iteration - iteration_of_last_increase > 10:
+                if (
+                    final_thputs_100ma > 0.95
+                    and iteration - iteration_of_last_increase > 10
+                ):
                     iteration_of_last_increase = iteration
                     end_of_episode_thputs.clear()
                     for _ in range(moving_average_length):
                         end_of_episode_thputs.append(0)
-                    max_missing_entities = min(max_missing_entities + 1, args.size*2)
+                    max_missing_entities = min(max_missing_entities + 1, args.size * 2)
                     print(f"\nNow working with {max_missing_entities=}")
             # Recompute after potential level-up so we use the reset buffer
             final_thputs_100ma = sum(end_of_episode_thputs) / len(end_of_episode_thputs)
             iter_metrics["curriculum/level"] = max_missing_entities
-            iter_metrics["curriculum/score"] = (max_missing_entities - 1) + final_thputs_100ma
+            iter_metrics["curriculum/score"] = (
+                max_missing_entities - 1
+            ) + final_thputs_100ma
             iter_metrics["curriculum/throughput_avg"] = final_thputs_100ma
 
         # Single wandb.log() call per iteration
         if args.track:
             wandb.log(iter_metrics, step=global_step)
 
-        if args.capture_video and ((iteration-1) % 50 == 0 or iteration + 1 == args.num_iterations):
+        if args.capture_video and (
+            (iteration - 1) % 50 == 0 or iteration + 1 == args.num_iterations
+        ):
             print(f"Recording agent progress at {iteration}")
             num_render_envs = 5
-            render_envs = gym.vector.SyncVectorEnv([make_env(args.env_id, i, False, args.size, run_name) for i in range(num_render_envs)])
-            next_obs_ECWH_render, _ = render_envs.reset(seed=args.seed, options={'num_missing_entities': max_missing_entities})
+            render_envs = gym.vector.SyncVectorEnv(
+                [
+                    make_env(args.env_id, i, False, args.size, run_name)
+                    for i in range(num_render_envs)
+                ]
+            )
+            next_obs_ECWH_render, _ = render_envs.reset(
+                seed=args.seed, options={"num_missing_entities": max_missing_entities}
+            )
 
             temp_dirs = [tempfile.mkdtemp() for _ in range(num_render_envs)]
             frame_counts = [0] * num_render_envs
@@ -1386,39 +1633,65 @@ if __name__ == "__main__":
                 # Save initial frames
                 for env_idx, img in enumerate(render_envs.render()):
                     image = Image.fromarray(img, mode="RGB")
-                    frame_path = os.path.join(temp_dirs[env_idx], f'frame_{frame_counts[env_idx]:06d}.png')
+                    frame_path = os.path.join(
+                        temp_dirs[env_idx], f"frame_{frame_counts[env_idx]:06d}.png"
+                    )
                     image.save(frame_path, format="png", optimize=True)
                     frame_counts[env_idx] += 1
 
                 # Run simulation and save frames
                 for i in range(1, 10):
                     with torch.no_grad():
-                        action_ED_render, _logprobs_E, _entropy_E, _value_E = agent.get_action_and_value(torch.Tensor(next_obs_ECWH_render).to(device))
-                        action_ED_numpy = {k: v.cpu().numpy() for k, v in action_ED_render.items()}
-                        next_obs_ECWH_render, _reward, terminations_render, truncations_render, _infos = render_envs.step(action_ED_numpy)
+                        action_ED_render, _logprobs_E, _entropy_E, _value_E = (
+                            agent.get_action_and_value(
+                                torch.Tensor(next_obs_ECWH_render).to(device)
+                            )
+                        )
+                        action_ED_numpy = {
+                            k: v.cpu().numpy() for k, v in action_ED_render.items()
+                        }
+                        (
+                            next_obs_ECWH_render,
+                            _reward,
+                            terminations_render,
+                            truncations_render,
+                            _infos,
+                        ) = render_envs.step(action_ED_numpy)
 
                     for env_idx, img in enumerate(render_envs.render()):
                         image = Image.fromarray(img, mode="RGB")
-                        frame_path = os.path.join(temp_dirs[env_idx], f'frame_{frame_counts[env_idx]:06d}.png')
+                        frame_path = os.path.join(
+                            temp_dirs[env_idx], f"frame_{frame_counts[env_idx]:06d}.png"
+                        )
                         image.save(frame_path, format="png", optimize=True)
                         frame_counts[env_idx] += 1
 
                 # Create videos for each environment
-                iso8601 = datetime.now().replace(microsecond=0).isoformat(sep='T').replace(":", "-")
-                Path('videos').mkdir(parents=True, exist_ok=True)
+                iso8601 = (
+                    datetime.now()
+                    .replace(microsecond=0)
+                    .isoformat(sep="T")
+                    .replace(":", "-")
+                )
+                Path("videos").mkdir(parents=True, exist_ok=True)
 
                 for env_idx in range(num_render_envs):
-                    output_path = f'videos/world_inits/{iso8601}_size{args.size}_missing{max_missing_entities}_iter{iteration:06}_env{env_idx}.mp4'
+                    output_path = f"videos/world_inits/{iso8601}_size{args.size}_missing{max_missing_entities}_iter{iteration:06}_env{env_idx}.mp4"
 
                     ffmpeg_cmd = [
-                        'ffmpeg',
-                        '-y',
-                        '-framerate', '2',
-                        '-i', os.path.join(temp_dirs[env_idx], 'frame_%06d.png'),
-                        '-c:v', 'libx264',
-                        '-pix_fmt', 'yuv420p',
-                        '-crf', '23',
-                        output_path
+                        "ffmpeg",
+                        "-y",
+                        "-framerate",
+                        "2",
+                        "-i",
+                        os.path.join(temp_dirs[env_idx], "frame_%06d.png"),
+                        "-c:v",
+                        "libx264",
+                        "-pix_fmt",
+                        "yuv420p",
+                        "-crf",
+                        "23",
+                        output_path,
                     ]
 
                     try:
@@ -1431,25 +1704,37 @@ if __name__ == "__main__":
                 for temp_dir in temp_dirs:
                     shutil.rmtree(temp_dir, ignore_errors=True)
                 render_envs.close()
-    final_thput = 0 if len(end_of_episode_thputs) == 0 else sum(end_of_episode_thputs) / len(end_of_episode_thputs)
+    final_thput = (
+        0
+        if len(end_of_episode_thputs) == 0
+        else sum(end_of_episode_thputs) / len(end_of_episode_thputs)
+    )
     # curriculum_score: monotonically increasing with agent capability.
     # Advancing a curriculum level is always worth more than any throughput
     # gain within a level (since throughput is in [0, 1]).
     curriculum_score = (max_missing_entities - 1) + final_thput
+
     def format_duration(seconds: float) -> str:
         total_seconds = int(round(seconds))
         hours = total_seconds // 3600
         minutes = (total_seconds % 3600) // 60
         secs = total_seconds % 60
         return f"{hours:02d}h{minutes:02d}m{secs:02d}s"
+
     runtime = time.time() - start_time
     if args.track:
-        run.tags = run.tags + (f"score:{curriculum_score:.2f}", f"thput:{final_thput*100:.0f}", f"duration:{format_duration(runtime)}")
+        run.tags = run.tags + (
+            f"score:{curriculum_score:.2f}",
+            f"thput:{final_thput * 100:.0f}",
+            f"duration:{format_duration(runtime)}",
+        )
     envs.close()
-    if runtime > 60 * 5: # 5 minutes
+    if runtime > 60 * 5:  # 5 minutes
         # avg_throughput = 0 if len(final_throughputs) == 0 else float(sum(final_throughputs) / len(final_throughputs))
         # Save the model to a file
-        run_name_dir_safe = run_name.replace('/', '-').replace(':', '-').replace(' ', '_')
+        run_name_dir_safe = (
+            run_name.replace("/", "-").replace(":", "-").replace(" ", "_")
+        )
         agent_name = f"agent-{run_name_dir_safe}"
         print(f"Saving model to artifacts/{agent_name}.pt")
         os.makedirs("artifacts", exist_ok=True)
@@ -1459,7 +1744,7 @@ if __name__ == "__main__":
             artifact.add_file(f"artifacts/{agent_name}.pt")
             wandb.log_artifact(artifact)
     else:
-        print(f'Not saving because: {time.time() - start_time:.2f} <= {60 * 5}')
+        print(f"Not saving because: {time.time() - start_time:.2f} <= {60 * 5}")
 
     # Write summary JSON (used by CI to post results to PR)
     summary = {
@@ -1476,10 +1761,10 @@ if __name__ == "__main__":
         "grid_size": args.size,
         "wandb_url": run.url if args.track and run else None,
     }
-    summary_path = args.summary_path or os.path.join(os.path.dirname(os.path.abspath(__file__)), "summary.json")
+    summary_path = args.summary_path or os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "summary.json"
+    )
     os.makedirs(os.path.dirname(os.path.abspath(summary_path)), exist_ok=True)
     with open(summary_path, "w") as f:
         json.dump(summary, f, indent=2)
     print(f"Summary written to {summary_path}")
-
-

--- a/ppo.py
+++ b/ppo.py
@@ -137,6 +137,13 @@ class Args:
     """delta reward shaping: reward for correct directions (solution-nonempty tiles only)"""
     max_grad_norm: float = 1.979
     """the maximum norm for the gradient clipping"""
+    kl_anchor_coef: float = 0.0
+    """RLHF-style anchor: penalise KL(current policy || frozen SFT reference) in
+    the actor loss (Schulman k3 estimator over rollout actions). >0 keeps the
+    finetuned policy near the SFT init so PPO can't drift it off the good basin
+    (the demonstrated SFT->PPO degradation: full-build 0.67 -> ~0.2 as the policy
+    over-places and stops completing). Requires --start_from. 0 = disabled (no
+    reference net built, zero overhead)."""
     target_kl: Optional[float] = None
     """the target KL divergence threshold"""
     adam_epsilon: float = 6.866e-06
@@ -165,6 +172,31 @@ class Args:
     """Advance the curriculum (num_missing_entities += 1) once the throughput moving
     average exceeds this. Set >1.0 to pin the level so the agent perfects it to 1.0
     instead of advancing at 0.95."""
+    checkpoint_every: int = 0
+    """If >0, save the agent state_dict to artifacts/<run>-iterNNNN.pt every N
+    iterations (in addition to the end-of-run save). Lets you greedy-eval a run's
+    real progress mid-flight and kill plateaued/degrading runs without losing the
+    weights. 0 = only the end-of-run save."""
+    greedy_eval_seeds: int = 20
+    """Number of fresh empty-factory seeds averaged for the greedy eval metric
+    (eval/greedy_empty_throughput). Each seed: start from a completely empty
+    factory, place entities GREEDILY (argmax) until throughput == 1.0 or
+    max_steps, then read the built factory's throughput. This is the honest,
+    deployable metric — the deterministic policy on fresh factories — unlike the
+    sampled episode/throughput, which is inflated by sampling luck and trivial
+    no-op episodes. (EOT is not used as a stop yet; see issue #137.)"""
+    greedy_eval_every: int = 1
+    """Run the greedy empty-factory eval every N iterations (1 = every iter).
+    Logged as eval/greedy_empty_throughput."""
+    min_curriculum_level: int = 0
+    """Lower bound on num_missing_entities per episode. Each reset draws
+    num_missing ~ randint(min_curriculum_level, max_missing_entities + 1). The
+    default 0 includes already-complete (no-op) factories. Set equal to
+    start_curriculum_level to train a FIXED difficulty — e.g.
+    --min-curriculum-level 22 --start-curriculum-level 22 trains full-blank only,
+    which is ON-distribution for an SFT flow-order policy (it builds from the
+    source outward) and avoids the OOD partial-fill valley + the no-op episodes
+    that flood the metric and pull the policy off the SFT basin."""
 
     # to be filled in runtime
     batch_size: int = 0
@@ -1231,6 +1263,9 @@ if __name__ == "__main__":
         wandb.define_metric("curriculum/score", summary="max")
         wandb.define_metric("curriculum/level", summary="max")
         wandb.define_metric("curriculum/throughput_avg", summary="last")
+        wandb.define_metric("eval/greedy_empty_throughput", summary="max")
+        wandb.define_metric("eval/stop_frac_completed", summary="max")
+        wandb.define_metric("eval/mean_stop_step", summary="last")
         for m in [
             "policy",
             "value",
@@ -1309,8 +1344,99 @@ if __name__ == "__main__":
 
     agent.to(device)
 
+    # ── Frozen SFT reference for the KL anchor (RLHF-style anti-drift) ──
+    # Built from the SAME weights the actor starts at; never updated. Used only
+    # to penalise KL(current || reference) so PPO can't drift the policy off the
+    # SFT basin. Gated on kl_anchor_coef so there's zero overhead when disabled.
+    ref_agent = None
+    if args.kl_anchor_coef > 0.0:
+        if args.start_from is None:
+            raise ValueError("--kl-anchor-coef > 0 requires --start_from (a reference)")
+        ref_agent = AgentCNN(
+            envs,
+            chan1=args.chan1,
+            chan2=args.chan2,
+            chan3=args.chan3,
+            flat_dim=args.flat_dim,
+            tile_head_std=args.tile_head_std,
+        )
+        ref_agent.load_state_dict(torch.load(resolved, map_location="cpu"))
+        ref_agent.to(device)
+        ref_agent.eval()
+        for p in ref_agent.parameters():
+            p.requires_grad_(False)
+        print(f"KL anchor enabled (coef={args.kl_anchor_coef}) against frozen SFT ref")
+
     print("Compiling agent with torch.compile()")
     agent = torch.compile(agent)
+
+    # ── Greedy empty-factory eval ────────────────────────────────────
+    # A dedicated single env (kept separate from the training vec-env so eval
+    # never disturbs rollout/curriculum state). Each call: start from a fully
+    # empty factory and place entities GREEDILY (argmax of every head) until the
+    # factory works (throughput == 1.0 → env terminates) OR we run out of steps
+    # (max_steps), then read the built factory's throughput; average over
+    # greedy_eval_seeds fresh seeds. This is the deployable metric — the
+    # deterministic policy on fresh factories.
+    #
+    # NB: EOT is deliberately NOT used as a stop here yet — the EOT head is
+    # trained in SFT but frozen+unused in PPO, so gating on it would just measure
+    # stale SFT calibration. Wiring EOT into PPO (train it + use it to stop) is
+    # tracked in issue #137; once that lands this eval should stop on EOT.
+    eval_env = make_env(
+        args.env_id, 10_000, False, args.size, run_name, reward_coeffs
+    )()
+    eval_full_blank = args.size * 2
+
+    @torch.no_grad()
+    def eval_greedy_empty(n_seeds: int) -> dict:
+        """Greedy empty-factory rollout: sample argmax until throughput==1.0 or
+        max_steps. Returns mean throughput, the fraction of seeds that fully
+        built (stop_frac_completed), and the mean number of placements before
+        stopping (mean_stop_step)."""
+        m = getattr(agent, "_orig_mod", agent)  # uncompiled module (shared weights)
+        was_training = m.training
+        m.eval()
+        thputs, stop_steps, completed = [], [], 0
+        cap = eval_env.unwrapped.max_steps + 1
+        for s in range(n_seeds):
+            obs, _ = eval_env.reset(
+                seed=1_000_000 + s,
+                options={"num_missing_entities": eval_full_blank},
+            )
+            last_thput = 0.0  # empty factory has zero throughput
+            placed, did_complete = 0, False
+            for _ in range(cap):
+                x = torch.as_tensor(np.array([obs]), dtype=torch.float32, device=device)
+                enc = m.encoder(x)
+                tile_idx = int(m.tile_logits(enc).reshape(1, -1).argmax(1)[0])
+                xi, yi = tile_idx // m.height, tile_idx % m.height
+                feat = enc[:, :, xi, yi]
+                action = {
+                    "xy": np.array([xi, yi]),
+                    "entity": int(m.ent_head(feat).argmax(1)[0]),
+                    "direction": int(m.dir_head(feat).argmax(1)[0]),
+                    "item": int(m.item_head(feat).argmax(1)[0]),
+                    "misc": int(m.misc_head(feat).argmax(1)[0]),
+                }
+                obs, _r, term, trunc, info = eval_env.step(action)
+                placed += 1
+                last_thput = float(info.get("throughput", last_thput))
+                if term:  # throughput reached 1.0
+                    did_complete = True
+                    break
+                if trunc:  # ran out of steps
+                    break
+            thputs.append(last_thput)
+            stop_steps.append(placed)
+            completed += int(did_complete)
+        if was_training:
+            m.train()
+        return {
+            "eval/greedy_empty_throughput": float(np.mean(thputs)),
+            "eval/stop_frac_completed": completed / float(n_seeds),
+            "eval/mean_stop_step": float(np.mean(stop_steps)),
+        }
 
     optimizer = optim.Adam(
         agent.parameters(), lr=args.learning_rate, eps=args.adam_epsilon
@@ -1330,6 +1456,10 @@ if __name__ == "__main__":
     logprobs_SE = torch.zeros(
         (args.num_steps, args.num_envs), dtype=torch.float32, device=device
     )
+    # Reference (frozen SFT) log-prob of each rollout action, for the KL anchor.
+    ref_logprobs_SE = torch.zeros(
+        (args.num_steps, args.num_envs), dtype=torch.float32, device=device
+    )
     rewards_SE = torch.zeros(
         (args.num_steps, args.num_envs), dtype=torch.float32, device=device
     )
@@ -1347,7 +1477,11 @@ if __name__ == "__main__":
         seed=args.seed,
         options={
             "num_missing_entities": int(
-                torch.randint(0, max_missing_entities + 1, (1,))[0]
+                torch.randint(
+                    min(args.min_curriculum_level, max_missing_entities),
+                    max_missing_entities + 1,
+                    (1,),
+                )[0]
             ),
         },
     )
@@ -1366,6 +1500,8 @@ if __name__ == "__main__":
                 "curriculum/level": max_missing_entities,
                 "curriculum/score": (max_missing_entities - 1) + final_thputs_100ma,
                 "curriculum/throughput_avg": final_thputs_100ma,
+                # Greedy empty-factory eval of the (SFT) init, before any RL.
+                **eval_greedy_empty(args.greedy_eval_seeds),
             },
             step=0,
         )
@@ -1459,6 +1595,14 @@ if __name__ == "__main__":
             actions_SEA[step] = action_EA
             logprobs_SE[step] = logprobs_E
 
+            # KL anchor: log-prob of this same action under the frozen SFT ref.
+            if ref_agent is not None:
+                with torch.no_grad():
+                    _, ref_logprobs_E, _, _ = ref_agent.get_action_and_value(
+                        next_obs_ECWH, action_EA
+                    )
+                ref_logprobs_SE[step] = ref_logprobs_E
+
             action_ED_numpy = {k: v.cpu().numpy() for k, v in action_ED.items()}
             # TRY NOT TO MODIFY: execute the game and log data.
             next_obs_ECWH, reward, terminations, truncations, infos = envs.step(
@@ -1476,7 +1620,11 @@ if __name__ == "__main__":
                     seed=args.seed + idx,
                     options={
                         "num_missing_entities": int(
-                            torch.randint(0, max_missing_entities + 1, (1,))[0]
+                            torch.randint(
+                                min(args.min_curriculum_level, max_missing_entities),
+                                max_missing_entities + 1,
+                                (1,),
+                            )[0]
                         )
                     },
                 )
@@ -1584,6 +1732,7 @@ if __name__ == "__main__":
         # flatten the batch
         obs_B = obs_SECWH.reshape((-1,) + envs.single_observation_space.shape)
         logprobs_B = logprobs_SE.reshape(-1)
+        ref_logprobs_B = ref_logprobs_SE.reshape(-1)
         # NOTE: maybe have to convert back to tuple of batches
         actions_B = actions_SEA.reshape((-1,) + ACTION_SPACE_SHAPE)
         advantages_B = advantages_SE.reshape(-1)
@@ -1651,6 +1800,16 @@ if __name__ == "__main__":
                     v_loss = 0.5 * ((newvalue - returns_B[idxs]) ** 2).mean()
 
                 entropy_loss = entropy_B.mean()
+
+                # KL anchor to the frozen SFT reference (Schulman k3 estimator,
+                # always >= 0). logr = ref - current over the rollout actions;
+                # k3 = exp(logr) - 1 - logr estimates KL(current || ref). Adding
+                # it to the actor loss pulls the policy back toward SFT.
+                kl_anchor = torch.zeros((), device=device)
+                if ref_agent is not None:
+                    logr_ref = ref_logprobs_B[idxs].reshape(-1) - newlogprobs_B
+                    kl_anchor = (logr_ref.exp() - 1 - logr_ref).mean()
+
                 assert not torch.isnan(pg_loss), "pg_loss is NaN, probably a bug"
                 assert not torch.isnan(v_loss), "v_loss is NaN, probably a bug"
                 if warming_up:
@@ -1659,7 +1818,12 @@ if __name__ == "__main__":
                     # excluded (still computed above for logging).
                     loss = v_loss * args.vf_coef
                 else:
-                    loss = pg_loss - ent_coef * entropy_loss + v_loss * args.vf_coef
+                    loss = (
+                        pg_loss
+                        - ent_coef * entropy_loss
+                        + v_loss * args.vf_coef
+                        + args.kl_anchor_coef * kl_anchor
+                    )
 
                 optimizer.zero_grad(set_to_none=True)
                 assert not torch.isnan(loss), "Loss is NaN, probably a bug"
@@ -1688,6 +1852,7 @@ if __name__ == "__main__":
             "losses/value": v_loss.item(),
             "losses/entropy": entropy_loss.item(),
             "losses/approx_kl": approx_kl.item(),
+            "losses/kl_anchor": float(kl_anchor.detach()),
             "losses/clipfrac": np.mean(clipfracs),
             "losses/explained_var": explained_var,
             "optim/lr": optimizer.param_groups[0]["lr"],
@@ -1698,6 +1863,11 @@ if __name__ == "__main__":
 
         # Flush episode means (empty dict if no episodes ended this iteration)
         iter_metrics.update(_flush_episode_means())
+
+        # Greedy empty-factory eval — the honest, deployable metric + stop-reason
+        # breakdown (eot / completed / cap) so you can watch EOT calibration.
+        if args.greedy_eval_every > 0 and iteration % args.greedy_eval_every == 0:
+            iter_metrics.update(eval_greedy_empty(args.greedy_eval_seeds))
 
         # Curriculum metrics — moving averages preserved exactly as before
         if len(end_of_episode_thputs) > 0:
@@ -1724,6 +1894,16 @@ if __name__ == "__main__":
         # Single wandb.log() call per iteration
         if args.track:
             wandb.log(iter_metrics, step=global_step)
+
+        # Periodic checkpoint so progress can be greedy-evaluated mid-run.
+        if args.checkpoint_every > 0 and iteration % args.checkpoint_every == 0:
+            os.makedirs("artifacts", exist_ok=True)
+            run_name_dir_safe = (
+                run_name.replace("/", "-").replace(":", "-").replace(" ", "_")
+            )
+            ckpt_path = f"artifacts/{run_name_dir_safe}-iter{iteration:04d}.pt"
+            torch.save(agent.state_dict(), ckpt_path)
+            print(f"[checkpoint] saved {ckpt_path}")
 
         if args.capture_video and (
             (iteration - 1) % 50 == 0 or iteration + 1 == args.num_iterations

--- a/scripts/ci/ppo_train.sh
+++ b/scripts/ci/ppo_train.sh
@@ -32,6 +32,8 @@ START_CURRICULUM_LEVEL="${START_CURRICULUM_LEVEL:-22}"
 ENT_COEF="${ENT_COEF:-0}"
 LEARNING_RATE="${LEARNING_RATE:-5e-5}"
 TARGET_KL="${TARGET_KL:-0.02}"
+LR_ANNEAL_TIMESTEPS="${LR_ANNEAL_TIMESTEPS:-500000}"
+MIN_LR="${MIN_LR:-1e-5}"
 SEED="${SEED:-1}"
 WATCHDOG_SECONDS="${WATCHDOG_SECONDS:-7200}"
 WANDB_PROJECT="${WANDB_PROJECT:-factorion}"
@@ -51,6 +53,8 @@ echo "  start_curric_level:  ${START_CURRICULUM_LEVEL}"
 echo "  ent_coef:            ${ENT_COEF}"
 echo "  learning_rate:       ${LEARNING_RATE}"
 echo "  target_kl:           ${TARGET_KL}"
+echo "  lr_anneal_timesteps: ${LR_ANNEAL_TIMESTEPS}"
+echo "  min_lr:              ${MIN_LR}"
 echo "  seed:                ${SEED}"
 echo "  watchdog:            ${WATCHDOG_SECONDS}s"
 echo "  W&B project:         ${WANDB_PROJECT}"
@@ -106,6 +110,8 @@ python ppo.py \
     --ent-coef-end "$ENT_COEF" \
     --learning-rate "$LEARNING_RATE" \
     --target-kl "$TARGET_KL" \
+    --lr-anneal-timesteps "$LR_ANNEAL_TIMESTEPS" \
+    --min-lr "$MIN_LR" \
     --total-timesteps "$TOTAL_TIMESTEPS" \
     --track \
     --wandb-project-name "$WANDB_PROJECT" \

--- a/scripts/ci/ppo_train.sh
+++ b/scripts/ci/ppo_train.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# ppo_train.sh — Runs a PPO (RL) training run on RunPod GPU, continuing from an
+# SFT checkpoint. Builds the Rust extension, loads the actor (+ critic) via
+# --start-from (a W&B run id OR a local .pt path), runs PPO with a critic
+# warm-up, and logs to W&B. Pre-installed deps + Rust toolchain are expected in
+# the Docker image (beyarkay/factorion-ci-gpu:latest); code should already be at
+# /workspace/factorion/.
+#
+# Required env vars:
+#   WANDB_API_KEY          - W&B API key (logging + artifact download for --start-from)
+#   WANDB_PROJECT          - W&B project name (e.g. factorion)
+#   START_FROM             - SFT checkpoint: a W&B run id OR a local .pt path
+#
+# Optional env vars:
+#   TOTAL_TIMESTEPS        - PPO total timesteps (default: 500000)
+#   SIZE                   - grid size; MUST match the SFT checkpoint (default: 11)
+#   CRITIC_WARMUP          - critic-only warm-up iterations (default: 10)
+#   START_CURRICULUM_LEVEL - num_missing_entities cap; ~2*size blanks the whole
+#                            MOVE_ONE_ITEM factory each episode (default: 22)
+#   SEED                   - random seed (default: 1)
+#   WATCHDOG_SECONDS       - self-terminate watchdog timeout (default: 7200 = 2h)
+#   PR_NUMBER, COMMIT_SHA  - tagging
+#   RUNPOD_POD_ID, RUNPOD_API_KEY - for the self-terminate watchdog
+
+set -euo pipefail
+
+: "${START_FROM:?START_FROM (a W&B run id or a .pt path) is required}"
+TOTAL_TIMESTEPS="${TOTAL_TIMESTEPS:-500000}"
+SIZE="${SIZE:-11}"
+CRITIC_WARMUP="${CRITIC_WARMUP:-10}"
+START_CURRICULUM_LEVEL="${START_CURRICULUM_LEVEL:-22}"
+SEED="${SEED:-1}"
+WATCHDOG_SECONDS="${WATCHDOG_SECONDS:-7200}"
+WANDB_PROJECT="${WANDB_PROJECT:-factorion}"
+PR_NUMBER="${PR_NUMBER:-unknown}"
+COMMIT_SHA="${COMMIT_SHA:-unknown}"
+
+echo "============================================"
+echo "  Factorion PPO Train (RL from SFT)"
+echo "============================================"
+echo "  GPU:                 $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo 'unknown')"
+echo "  CUDA:                $(nvcc --version 2>/dev/null | tail -1 || echo 'unknown')"
+echo "  start_from:          ${START_FROM}"
+echo "  total_timesteps:     ${TOTAL_TIMESTEPS}"
+echo "  size:                ${SIZE}"
+echo "  critic_warmup:       ${CRITIC_WARMUP}"
+echo "  start_curric_level:  ${START_CURRICULUM_LEVEL}"
+echo "  seed:                ${SEED}"
+echo "  watchdog:            ${WATCHDOG_SECONDS}s"
+echo "  W&B project:         ${WANDB_PROJECT}"
+echo "  PR:                  ${PR_NUMBER}"
+echo "  Commit:              ${COMMIT_SHA}"
+echo "============================================"
+
+# ── Safety net: self-terminate after WATCHDOG_SECONDS if cleanup fails ─
+if [ -n "${RUNPOD_POD_ID:-}" ] && [ -n "${RUNPOD_API_KEY:-}" ]; then
+    echo ">>> Starting self-terminate watchdog (${WATCHDOG_SECONDS}s timeout)..."
+    nohup bash -c "
+      sleep ${WATCHDOG_SECONDS}
+      curl -s 'https://api.runpod.io/graphql?api_key=${RUNPOD_API_KEY}' \
+        -H 'Content-Type: application/json' \
+        -d '{\"query\": \"mutation { podTerminate(input: {podId: \\\"${RUNPOD_POD_ID}\\\"}) }\"}'
+    " &>/dev/null &
+else
+    echo ">>> Watchdog skipped (RUNPOD_POD_ID or RUNPOD_API_KEY not set)"
+fi
+
+cd /workspace/factorion
+
+# ── Ensure Rust is on PATH ────────────────────────────────────────
+export PATH="/root/.cargo/bin:${PATH}"
+
+# ── CuBLAS deterministic mode ────────────────────────────────────
+export CUBLAS_WORKSPACE_CONFIG=:4096:8
+
+# ── Build Rust extension ─────────────────────────────────────────
+if [ -f factorion_rs/Cargo.toml ]; then
+    echo ""
+    echo ">>> Building factorion_rs from source..."
+    (cd factorion_rs && maturin build --release --out dist && pip install dist/*.whl)
+else
+    echo ">>> WARNING: factorion_rs not available."
+fi
+
+# ── Configure W&B (also used to download the --start-from artifact) ──
+export WANDB_API_KEY
+
+# ── Run PPO ──────────────────────────────────────────────────────
+echo ""
+echo ">>> Starting PPO (${TOTAL_TIMESTEPS} timesteps, from ${START_FROM})..."
+
+python ppo.py \
+    --seed "$SEED" \
+    --env-id factorion/FactorioEnv-v0 \
+    --size "$SIZE" \
+    --start-from "$START_FROM" \
+    --critic-warmup "$CRITIC_WARMUP" \
+    --start-curriculum-level "$START_CURRICULUM_LEVEL" \
+    --total-timesteps "$TOTAL_TIMESTEPS" \
+    --track \
+    --wandb-project-name "$WANDB_PROJECT" \
+    --tags ci ppo-train "pr:${PR_NUMBER}" "sha:${COMMIT_SHA}" "from:${START_FROM}" \
+    --summary-path /workspace/factorion/ppo_summary.json
+
+echo ""
+echo "============================================"
+echo "  PPO training completed successfully"
+echo "============================================"
+
+# ── Generate summary markdown (fetched by runpod-teardown) ───────
+SUMMARY_JSON="/workspace/factorion/ppo_summary.json"
+SUMMARY_MD="/workspace/summary.md"
+
+if [ -f "$SUMMARY_JSON" ]; then
+    GPU_NAME=$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo 'unknown')
+    python3 -c "
+import json
+s = json.load(open('$SUMMARY_JSON'))
+gpu = '''$GPU_NAME'''
+pr = '''$PR_NUMBER'''
+sha = '''$COMMIT_SHA'''
+start_from = '''$START_FROM'''
+wandb_url = s.get('wandb_url') or 'N/A'
+wandb_link = f'[View on W&B]({wandb_url})' if wandb_url != 'N/A' else 'N/A'
+print(f'''## PPO Train Results (RL from SFT)
+
+| Metric | Value |
+|--------|-------|
+| **Moving-avg throughput** | {s['moving_avg_throughput']:.4f} |
+| **Curriculum score** | {s['curriculum_score']:.4f} |
+| **Max missing entities** | {s['max_missing_entities']} |
+| **Total timesteps** | {s['total_timesteps']:,} |
+| **Global step** | {s['global_step']:,} |
+| **Runtime** | {s['runtime_human']} |
+| **Steps/sec** | {s['sps']:,} |
+| **Grid size** | {s['grid_size']}x{s['grid_size']} |
+| **Started from** | {start_from} |
+| **GPU** | {gpu} |
+
+{wandb_link}
+
+<sub>Commit {sha[:8]} · PR #{pr}</sub>''')
+" > "$SUMMARY_MD"
+    echo ">>> Summary written to $SUMMARY_MD"
+else
+    echo ">>> WARNING: ppo_summary.json not found, skipping summary"
+fi

--- a/scripts/ci/ppo_train.sh
+++ b/scripts/ci/ppo_train.sh
@@ -29,6 +29,9 @@ TOTAL_TIMESTEPS="${TOTAL_TIMESTEPS:-500000}"
 SIZE="${SIZE:-11}"
 CRITIC_WARMUP="${CRITIC_WARMUP:-10}"
 START_CURRICULUM_LEVEL="${START_CURRICULUM_LEVEL:-22}"
+ENT_COEF="${ENT_COEF:-0}"
+LEARNING_RATE="${LEARNING_RATE:-5e-5}"
+TARGET_KL="${TARGET_KL:-0.02}"
 SEED="${SEED:-1}"
 WATCHDOG_SECONDS="${WATCHDOG_SECONDS:-7200}"
 WANDB_PROJECT="${WANDB_PROJECT:-factorion}"
@@ -45,6 +48,9 @@ echo "  total_timesteps:     ${TOTAL_TIMESTEPS}"
 echo "  size:                ${SIZE}"
 echo "  critic_warmup:       ${CRITIC_WARMUP}"
 echo "  start_curric_level:  ${START_CURRICULUM_LEVEL}"
+echo "  ent_coef:            ${ENT_COEF}"
+echo "  learning_rate:       ${LEARNING_RATE}"
+echo "  target_kl:           ${TARGET_KL}"
 echo "  seed:                ${SEED}"
 echo "  watchdog:            ${WATCHDOG_SECONDS}s"
 echo "  W&B project:         ${WANDB_PROJECT}"
@@ -96,6 +102,10 @@ python ppo.py \
     --start-from "$START_FROM" \
     --critic-warmup "$CRITIC_WARMUP" \
     --start-curriculum-level "$START_CURRICULUM_LEVEL" \
+    --ent-coef-start "$ENT_COEF" \
+    --ent-coef-end "$ENT_COEF" \
+    --learning-rate "$LEARNING_RATE" \
+    --target-kl "$TARGET_KL" \
     --total-timesteps "$TOTAL_TIMESTEPS" \
     --track \
     --wandb-project-name "$WANDB_PROJECT" \

--- a/scripts/ci/sft_smoke_test.sh
+++ b/scripts/ci/sft_smoke_test.sh
@@ -80,7 +80,7 @@ echo ">>> Starting SFT smoke test (${NUM_SAMPLES} samples, ${EPOCHS} epochs)..."
 
 python sft.py \
     --seed 1 \
-    --size 17 \
+    --size 11 \
     --num-samples "$NUM_SAMPLES" \
     --epochs "$EPOCHS" \
     --track \

--- a/scripts/ci/sft_smoke_test.sh
+++ b/scripts/ci/sft_smoke_test.sh
@@ -80,7 +80,7 @@ echo ">>> Starting SFT smoke test (${NUM_SAMPLES} samples, ${EPOCHS} epochs)..."
 
 python sft.py \
     --seed 1 \
-    --size 5 \
+    --size 17 \
     --num-samples "$NUM_SAMPLES" \
     --epochs "$EPOCHS" \
     --track \

--- a/scripts/ci/sft_smoke_test.sh
+++ b/scripts/ci/sft_smoke_test.sh
@@ -80,7 +80,7 @@ echo ">>> Starting SFT smoke test (${NUM_SAMPLES} samples, ${EPOCHS} epochs)..."
 
 python sft.py \
     --seed 1 \
-    --size 11 \
+    --size 5 \
     --num-samples "$NUM_SAMPLES" \
     --epochs "$EPOCHS" \
     --track \

--- a/sft.py
+++ b/sft.py
@@ -29,14 +29,74 @@ from torch.utils.data import DataLoader, TensorDataset
 sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
 import factorion_rs  # noqa: E402
 from factorion import (  # noqa: E402
+    DIR_TO_DELTA,
     Channel,
+    Direction,
     LessonKind,
     blank_entities,
     build_factory,
     entities,
+    str2ent,
 )
 
 from ppo import AgentCNN, FactorioEnv, make_env  # noqa: E402
+
+
+def _flow_order(solved_CWH, anchor_locs):
+    """Order anchor tiles in canonical source->sink flow order.
+
+    Each placeable tile's DIRECTION channel points downstream (to the cell
+    items flow into). Starting from the cell(s) each source points into, we
+    BFS along these successor links and record a flow depth; anchors are then
+    returned sorted by ``(reached, depth, raster)`` so the expert demo places
+    tiles start-to-finish along the belt instead of in a random order.
+
+    Why: a random placement order makes the *same* partial state map to
+    *different* next-targets across samples — irreducible label noise that
+    caps per-head accuracy (esp. direction) below 1.0. A canonical flow order
+    makes the next placement a deterministic function of the current state,
+    which the model can fit, and which the literature (Vinyals "Order
+    Matters"; GraphRNN's BFS ordering; PolyGen) shows is far more learnable
+    than an arbitrary linearization.
+
+    Anchors not reachable from a source (e.g. malformed factories, or
+    non-belt lessons whose anchor cell isn't the flow-entry tile) are appended
+    afterwards in raster order, so no placement is ever dropped.
+    """
+    from collections import deque
+
+    ent = solved_CWH[Channel.ENTITIES.value]
+    dch = solved_CWH[Channel.DIRECTION.value]
+    anchor_set = {tuple(loc) for loc in anchor_locs}
+    src_val = str2ent("source").value
+    none_val = Direction.NONE.value
+
+    def successor(x, y):
+        d = int(dch[x, y])
+        if d == none_val:
+            return None
+        dx, dy = DIR_TO_DELTA[Direction(d)]
+        return (x + dx, y + dy)
+
+    depth: dict[tuple[int, int], int] = {}
+    q: deque[tuple[int, int]] = deque()
+    for sx, sy in (ent == src_val).nonzero(as_tuple=False).tolist():
+        nxt = successor(sx, sy)
+        if nxt in anchor_set and nxt not in depth:
+            depth[nxt] = 0
+            q.append(nxt)
+    while q:
+        cur = q.popleft()
+        nxt = successor(*cur)
+        if nxt in anchor_set and nxt not in depth:
+            depth[nxt] = depth[cur] + 1
+            q.append(nxt)
+
+    def sort_key(loc):
+        t = tuple(loc)
+        return (0 if t in depth else 1, depth.get(t, 0), t)
+
+    return sorted(anchor_locs, key=sort_key)
 
 
 def extract_expert_actions(solved_CWH, task_CWH):
@@ -102,8 +162,12 @@ def extract_expert_actions(solved_CWH, task_CWH):
 
     diff_locs = [loc for loc in diff_locs if tuple(loc) not in secondary_tiles]
 
-    # Shuffle for diversity
-    random.shuffle(diff_locs)
+    # Place tiles in canonical source->sink flow order rather than a random
+    # shuffle. Random order injects label noise (same partial state -> many
+    # possible "next" targets), capping per-head accuracy below 1.0; flow
+    # order makes the next placement a deterministic function of the state.
+    # See _flow_order for the full rationale + citations.
+    diff_locs = _flow_order(solved_CWH, diff_locs)
 
     state = task_CWH.clone()
     pairs = []

--- a/sft.py
+++ b/sft.py
@@ -172,13 +172,21 @@ def extract_expert_actions(solved_CWH, task_CWH):
     state = task_CWH.clone()
     pairs = []
 
-    # Build per-step valid_mask = all remaining anchor tiles. We pop as we go.
-    remaining_locs = [tuple(loc) for loc in diff_locs]
-
     for step, (x, y) in enumerate(diff_locs):
+        # Tile target = the flow FRONTIER (the single next tile in source->sink
+        # order), not every remaining tile. Because diff_locs is now flow-
+        # ordered, (x, y) is exactly the cell that extends the already-placed
+        # prefix. Single-hot supervision teaches the tile head to commit to
+        # building in order, so the greedy rollout lays a connected chain
+        # instead of wandering to a mid-path tile the direction head never
+        # trained on (the multi-label "all remaining" mask was a workaround for
+        # the old random order, which no longer applies).
+        #
+        # NB: correct for single-chain lessons (MOVE_ONE_ITEM). A branchy lesson
+        # (e.g. SPLITTER_*) has several valid frontier cells at once and would
+        # need a frontier *set* here to avoid re-introducing order noise.
         valid_mask = torch.zeros(W * H)
-        for rx, ry in remaining_locs[step:]:
-            valid_mask[rx * H + ry] = 1.0
+        valid_mask[x * H + y] = 1.0
 
         obs = state.clone()
         tile_idx = x * H + y
@@ -788,7 +796,6 @@ def train_sft(args: SFTArgs):
     # off on terminal (eot=1) samples and (b) aggregate per-LessonKind in
     # the val loop without re-running the forward pass.
     ce_loss_none = nn.CrossEntropyLoss(reduction="none")
-    bce_loss_none = nn.BCEWithLogitsLoss(reduction="none")
     # pos_weight balances the eot head against the placement-step
     # imbalance. Each lesson emits ~max_level placement pairs (eot=0) and
     # exactly 1 terminal pair (eot=1); without pos_weight the head
@@ -918,11 +925,13 @@ def train_sft(args: SFTArgs):
             eot_logits = agent.eot_head(encoded).squeeze(-1)
             loss_eot = bce_eot(eot_logits, batch_eot)
 
-            # Tile logits — use BCE with multi-label mask so ALL valid
-            # tiles are rewarded, not just the randomly-chosen one. Reduce
-            # to per-sample, mask off terminal samples, then average.
+            # Tile head — softmax CE over all cells toward the single flow
+            # FRONTIER tile. (Was multi-label BCE over every remaining tile,
+            # which suited the old random order; under canonical flow order the
+            # next tile is unique, and single-positive BCE over W*H cells is
+            # ~(W*H-1):1 imbalanced and collapses the head — so use CE instead.)
             tile_logits = agent.tile_logits(encoded).reshape(B, -1)
-            loss_tile_per = bce_loss_none(tile_logits, batch_mask).mean(dim=1)
+            loss_tile_per = ce_loss_none(tile_logits, batch_tile)
             loss_tile = (loss_tile_per * placement_mask).sum() / n_place
 
             # Extract features at target tile for entity/direction/item/misc heads
@@ -1078,14 +1087,10 @@ def train_sft(args: SFTArgs):
                 loss_eot_per = bce_eot_none(eot_logits, batch_eot)
 
                 tile_logits = agent.tile_logits(encoded).reshape(B, -1)
-                # Per-sample losses: needed so we can sum them within each
-                # LessonKind and so terminal samples can be masked out of
-                # placement losses. mean over the tile axis matches the
-                # scale of bce_loss(reduction="mean"), keeping
-                # val/loss_tile comparable to train/loss_tile.
-                loss_tile_per = (
-                    bce_loss_none(tile_logits, batch_mask).mean(dim=1) * placement_mask
-                )
+                # Softmax CE toward the single flow frontier tile (see the
+                # train loop). Per-sample so terminal samples can be masked out
+                # of the placement loss and summed within each LessonKind.
+                loss_tile_per = ce_loss_none(tile_logits, batch_tile) * placement_mask
 
                 x_B = batch_tile // agent.height
                 y_B = batch_tile % agent.height

--- a/sft.py
+++ b/sft.py
@@ -43,27 +43,35 @@ from ppo import AgentCNN, FactorioEnv, make_env  # noqa: E402
 
 
 def _flow_order(solved_CWH, anchor_locs):
-    """Order anchor tiles in canonical source->sink flow order.
+    """Order anchor tiles by walking the flow graph, tie-broken top-down then
+    left-right.
 
     Each placeable tile's DIRECTION channel points downstream (to the cell
-    items flow into). Starting from the cell(s) each source points into, we
-    BFS along these successor links and record a flow depth; anchors are then
-    returned sorted by ``(reached, depth, raster)`` so the expert demo places
-    tiles start-to-finish along the belt instead of in a random order.
+    items flow into), so the layout is a graph rooted at the source(s). A tile
+    becomes *placeable* once the tile feeding into it (its flow predecessor) is
+    already placed; among all currently-placeable tiles we always take the one
+    that is top-most then left-most (raster ``(row, col)`` order). Every
+    intermediate state is therefore a connected prefix of the finished layout —
+    exactly what the policy sees when it builds in order — and the next
+    placement is a deterministic function of the state.
 
     Why: a random placement order makes the *same* partial state map to
     *different* next-targets across samples — irreducible label noise that
-    caps per-head accuracy (esp. direction) below 1.0. A canonical flow order
-    makes the next placement a deterministic function of the current state,
-    which the model can fit, and which the literature (Vinyals "Order
-    Matters"; GraphRNN's BFS ordering; PolyGen) shows is far more learnable
-    than an arbitrary linearization.
+    caps per-head accuracy (esp. direction) below 1.0. This canonical order
+    removes that noise, and the literature (Vinyals "Order Matters"; GraphRNN's
+    BFS ordering; PolyGen) shows a fixed structure-respecting order is far more
+    learnable than an arbitrary linearization.
 
-    Anchors not reachable from a source (e.g. malformed factories, or
-    non-belt lessons whose anchor cell isn't the flow-entry tile) are appended
-    afterwards in raster order, so no placement is ever dropped.
+    For a single belt chain (MOVE_ONE_ITEM) the frontier is always one tile, so
+    this is just source->sink order; the raster tiebreak only bites when
+    several tiles are placeable at once (multiple sources, disconnected
+    components, or a branch). Anchors never reached from a source (malformed
+    layouts, or multi-output entities like splitters whose extra outputs the
+    single DIRECTION pointer doesn't follow) are appended afterwards in raster
+    order so nothing is dropped — those multi-output lessons still need richer
+    handling here before being re-enabled.
     """
-    from collections import deque
+    import heapq
 
     ent = solved_CWH[Channel.ENTITIES.value]
     dch = solved_CWH[Channel.DIRECTION.value]
@@ -78,25 +86,41 @@ def _flow_order(solved_CWH, anchor_locs):
         dx, dy = DIR_TO_DELTA[Direction(d)]
         return (x + dx, y + dy)
 
-    depth: dict[tuple[int, int], int] = {}
-    q: deque[tuple[int, int]] = deque()
-    for sx, sy in (ent == src_val).nonzero(as_tuple=False).tolist():
-        nxt = successor(sx, sy)
-        if nxt in anchor_set and nxt not in depth:
-            depth[nxt] = 0
-            q.append(nxt)
-    while q:
-        cur = q.popleft()
-        nxt = successor(*cur)
-        if nxt in anchor_set and nxt not in depth:
-            depth[nxt] = depth[cur] + 1
-            q.append(nxt)
+    # Flow predecessor of each anchor = the source/anchor cell pointing into it,
+    # found by inverting `successor` over the sources and anchors.
+    pred: dict[tuple[int, int], tuple[int, int]] = {}
+    sources = [tuple(s) for s in (ent == src_val).nonzero(as_tuple=False).tolist()]
+    for cx, cy in sources + list(anchor_set):
+        nxt = successor(cx, cy)
+        if nxt in anchor_set:
+            pred[nxt] = (cx, cy)
 
-    def sort_key(loc):
-        t = tuple(loc)
-        return (0 if t in depth else 1, depth.get(t, 0), t)
+    # Frontier = anchors whose predecessor is already placed. Seed it with the
+    # anchors fed directly by a source (predecessor isn't itself a blanked
+    # anchor). The min-heap pops in (row, col) order = top-down then left-right.
+    placed: set[tuple[int, int]] = set()
+    frontier: list[tuple[int, int]] = []
+    for a in anchor_set:
+        p = pred.get(a)
+        if p is None or p not in anchor_set:
+            heapq.heappush(frontier, a)
 
-    return sorted(anchor_locs, key=sort_key)
+    order: list[list[int]] = []
+    while frontier:
+        a = heapq.heappop(frontier)
+        if a in placed:
+            continue
+        placed.add(a)
+        order.append(list(a))
+        nxt = successor(*a)
+        if nxt in anchor_set and nxt not in placed and pred.get(nxt) == a:
+            heapq.heappush(frontier, nxt)
+
+    # Anything unreachable from a source -> raster order, so nothing is dropped.
+    for a in sorted(anchor_set):
+        if a not in placed:
+            order.append(list(a))
+    return order
 
 
 def extract_expert_actions(solved_CWH, task_CWH):

--- a/sft.py
+++ b/sft.py
@@ -109,17 +109,24 @@ def extract_expert_actions(solved_CWH, task_CWH):
     without misc=DOWN/UP, or an assembling_machine_1 without an item
     (= recipe).
 
-    The valid_tile_mask is a flat binary tensor marking ALL tiles that still
-    need entities at this step — not just the one chosen. This allows
-    multi-label tile loss to avoid penalizing the model for predicting a
-    valid-but-different tile.
+    The valid_tile_mask is single-hot on the FRONTIER tile — the single next
+    cell in canonical source->sink flow order. The tile head is trained with
+    softmax cross-entropy toward that cell so the policy learns to build the
+    chain start-to-finish. (Historically this mask marked ALL remaining tiles
+    and the tile loss was multi-label BCE — a workaround for the old *random*
+    placement order, where the demo's "next" tile was an arbitrary pick and
+    penalizing the model for choosing a valid-but-different one was unfair.
+    Canonical order makes the next tile unique, so that workaround is no longer
+    needed. NB: branchy lessons, e.g. SPLITTER_*, have several valid frontier
+    cells at once and would need a frontier *set* here before being re-enabled.)
 
     Multi-tile entities (e.g. splitters) emit a single pair at the anchor
     tile, not one per occupied cell — placing the anchor fills the whole
     footprint at execution time.
 
-    Actions are applied sequentially in random order, so intermediate states
-    reflect realistic observations the agent would see.
+    Actions are applied sequentially in canonical source->sink flow order
+    (see _flow_order), so each intermediate state is a clean prefix of the
+    completed path — exactly what the policy will see when it builds in order.
 
     `eot` (end-of-turn) is 0 for every placement step (the factory still
     has entities to place) and 1 for a single terminal pair appended at

--- a/sft.py
+++ b/sft.py
@@ -284,8 +284,9 @@ def _artifact_name(args: "SFTArgs") -> str:
 def generate_dataset(args: SFTArgs):
     """Generate SFT dataset from expert demonstrations.
 
-    Samples uniformly across every value of `LessonKind` (auto-discovered),
-    so adding a new lesson kind to the enum is automatically picked up.
+    Samples across the lesson kinds listed in `kinds` below. NOTE: for the
+    current overfit experiment this is pinned to MOVE_ONE_ITEM only; restore
+    `kinds = list(LessonKind)` for full-mix training.
     Per-kind sample/lesson counts are printed to stdout for visibility.
 
     Also returns a per-pair lesson_seed tensor so callers can split
@@ -294,7 +295,20 @@ def generate_dataset(args: SFTArgs):
     factories across the split).
     """
     max_level = args.max_level if args.max_level > 0 else args.size * args.size
-    kinds = list(LessonKind)
+    # OVERFIT EXPERIMENT: focus exclusively on MOVE_ONE_ITEM (the simplest
+    # lesson) to verify the SFT pipeline can actually drive
+    # val/MOVE_ONE_ITEM/throughput up given enough compute. The other lessons
+    # are deliberately commented out — re-enable them (or restore
+    # `kinds = list(LessonKind)`) to go back to full-mix training.
+    kinds = [
+        LessonKind.MOVE_ONE_ITEM,
+        # LessonKind.SPLITTER_SPLIT,
+        # LessonKind.SPLITTER_MERGE,
+        # LessonKind.ASSEMBLE_1IN_1OUT,
+        # LessonKind.MOVE_VIA_UG_BELT,
+        # LessonKind.ASSEMBLE_2IN_1OUT,
+        # LessonKind.FROM_BLUEPRINT,
+    ]
 
     all_obs = []
     all_tile_idx = []

--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -53,7 +53,16 @@ class TestExtractExpertActions:
         # agent is responsible for each. Skip terminal pairs (eot=1) which
         # carry sentinel placement targets, not real placements.
         state = task.clone()
-        for obs, tile_idx, entity_id, direction_id, item_id, misc_id, valid_mask, eot in pairs:
+        for (
+            obs,
+            tile_idx,
+            entity_id,
+            direction_id,
+            item_id,
+            misc_id,
+            valid_mask,
+            eot,
+        ) in pairs:
             if eot == 1:
                 continue
             H = state.shape[2]
@@ -137,8 +146,12 @@ class TestExtractExpertActions:
         for _, _, entity_id, direction_id, _, _, _, eot in pairs:
             if eot == 1:
                 continue
-            assert entity_id != str2ent("empty").value, "Expert actions shouldn't place empty"
-            assert direction_id != Direction.NONE.value, "Expert belt actions need a direction"
+            assert entity_id != str2ent("empty").value, (
+                "Expert actions shouldn't place empty"
+            )
+            assert direction_id != Direction.NONE.value, (
+                "Expert belt actions need a direction"
+            )
 
     def test_ug_belt_action_carries_misc(self):
         """A MOVE_VIA_UG_BELT lesson with the UG pair blanked must produce
@@ -146,19 +159,26 @@ class TestExtractExpertActions:
         not NONE. Without this the env rejects every UG placement at step
         time (ug_belt_wo_up_or_down)."""
         from helpers import Misc
+
         ug_id = str2ent("underground_belt").value
         found_down = found_up = False
         for seed in range(50):
             try:
-                factory = build_factory(size=8, kind=LessonKind.MOVE_VIA_UG_BELT, seed=seed)
+                factory = build_factory(
+                    size=8, kind=LessonKind.MOVE_VIA_UG_BELT, seed=seed
+                )
                 assert factory is not None
                 solved, _ = blank_entities(factory, num_missing_entities=0)
-                factory = build_factory(size=8, kind=LessonKind.MOVE_VIA_UG_BELT, seed=seed)
+                factory = build_factory(
+                    size=8, kind=LessonKind.MOVE_VIA_UG_BELT, seed=seed
+                )
                 assert factory is not None
                 task, _ = blank_entities(factory, num_missing_entities=2)
             except Exception:
                 continue
-            for _, _, ent_id, _, _, misc_id, _, eot in extract_expert_actions(solved, task):
+            for _, _, ent_id, _, _, misc_id, _, eot in extract_expert_actions(
+                solved, task
+            ):
                 if eot == 1:
                     continue
                 if ent_id == ug_id:
@@ -183,7 +203,9 @@ class TestExtractExpertActions:
         for seed in [1, 7, 42, 99]:
             for level in [1, 4, 8, 16]:
                 try:
-                    factory = build_factory(size=8, kind=LessonKind.MOVE_ONE_ITEM, seed=seed)
+                    factory = build_factory(
+                        size=8, kind=LessonKind.MOVE_ONE_ITEM, seed=seed
+                    )
                     assert factory is not None
                     task, _ = blank_entities(factory, num_missing_entities=level)
                 except Exception:
@@ -201,7 +223,9 @@ class TestGenerateDataset:
     def test_generates_correct_count(self):
         """Dataset should have the requested number of samples."""
         args = SFTArgs(seed=1, size=5, num_samples=100, max_level=2)
-        obs, tiles, ents, dirs, items_t, miscs_t, masks, eots, seeds, kinds = generate_dataset(args)
+        obs, tiles, ents, dirs, items_t, miscs_t, masks, eots, seeds, kinds = (
+            generate_dataset(args)
+        )
         assert len(obs) == 100
         assert len(tiles) == 100
         assert len(ents) == 100
@@ -238,6 +262,7 @@ class TestGenerateDataset:
         assert len(set(seeds.tolist())) >= 2
         # And at least one seed appears more than once (level=2 → ~2 pairs).
         from collections import Counter
+
         counts = Counter(seeds.tolist())
         assert any(c > 1 for c in counts.values()), (
             "expected at least one lesson to produce >1 pair sharing a seed"
@@ -287,13 +312,17 @@ class TestGenerateDataset:
         asm_pair_count = 0
         for seed in range(60):
             factory = build_factory(
-                size=10, kind=LessonKind.ASSEMBLE_1IN_1OUT, seed=seed,
+                size=10,
+                kind=LessonKind.ASSEMBLE_1IN_1OUT,
+                seed=seed,
             )
             if factory is None:
                 continue
             solved = factory.world_CWH
             task, _ = blank_entities(factory, num_missing_entities=20)
-            for _, _, ent_id, _, item_id, _, _, eot in extract_expert_actions(solved, task):
+            for _, _, ent_id, _, item_id, _, _, eot in extract_expert_actions(
+                solved, task
+            ):
                 if eot == 1:
                     continue
                 if ent_id == asm_id:
@@ -324,6 +353,11 @@ class TestGenerateDataset:
             f"Expected >=2 distinct non-empty item types, got {sorted(unique_items)}"
         )
 
+    @pytest.mark.skip(
+        reason="MOVE_ONE_ITEM-only overfit experiment: generate_dataset is "
+        "pinned to a single kind, so multi-kind assertions don't hold. "
+        "Revert when `kinds = list(LessonKind)` is restored in sft.py."
+    )
     def test_kinds_returned_per_pair(self):
         """generate_dataset must return a per-pair kind tensor with the
         same length as the rest. Values must be valid LessonKind enum
@@ -341,6 +375,11 @@ class TestGenerateDataset:
             f"expected >=2 distinct kinds, got {sorted(set(kinds.tolist()))}"
         )
 
+    @pytest.mark.skip(
+        reason="MOVE_ONE_ITEM-only overfit experiment: generate_dataset is "
+        "pinned to a single kind, so the dataset no longer spans multiple "
+        "kinds. Revert when `kinds = list(LessonKind)` is restored in sft.py."
+    )
     def test_samples_span_multiple_kinds(self, capsys):
         """Dataset should draw from more than one LessonKind.
 
@@ -354,8 +393,11 @@ class TestGenerateDataset:
         generate_dataset(args)
         out = capsys.readouterr().out
         productive = [
-            line for line in out.splitlines()
-            if "samples=" in line and "samples=     0" not in line and "samples=    0" not in line
+            line
+            for line in out.splitlines()
+            if "samples=" in line
+            and "samples=     0" not in line
+            and "samples=    0" not in line
         ]
         assert len(productive) >= 2, (
             f"Expected >=2 productive kinds in breakdown, got:\n{out}"
@@ -430,7 +472,9 @@ class TestSFTLossConvergence:
     def test_loss_decreases_on_small_dataset(self, registered_env):
         """SFT loss should decrease when training on a small expert dataset."""
         args = SFTArgs(seed=42, size=5, num_samples=200, max_level=2)
-        obs, tiles, ents, dirs, items_t, miscs_t, masks, _eots, _, _ = generate_dataset(args)
+        obs, tiles, ents, dirs, items_t, miscs_t, masks, _eots, _, _ = generate_dataset(
+            args
+        )
 
         envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, 5, "test")])
         agent = AgentCNN(envs, chan1=16, chan2=16, chan3=16, flat_dim=64)
@@ -501,6 +545,7 @@ class TestTrainSFTEndToEnd:
         assert os.path.exists(summary), "Summary JSON should be saved"
 
         import json
+
         with open(summary) as f:
             s = json.load(f)
         assert "best_val_acc" in s
@@ -538,13 +583,24 @@ class TestRunRolloutEval:
         agent = AgentCNN(envs, chan1=16, chan2=16, chan3=16, flat_dim=64)
         envs.close()
 
-        args = SFTArgs(seed=1, size=size, num_samples=50, max_level=2 * size,
-                       chan1=16, chan2=16, chan3=16, flat_dim=64)
+        args = SFTArgs(
+            seed=1,
+            size=size,
+            num_samples=50,
+            max_level=2 * size,
+            chan1=16,
+            chan2=16,
+            chan3=16,
+            flat_dim=64,
+        )
         val_seeds_to_kind = self._build_val_seeds_to_kind(size=size, num_kinds=4)
         assert len(val_seeds_to_kind) >= 1, "Sanity: at least one valid lesson"
 
         overall, per_kind, per_kind_n = run_rollout_eval(
-            agent, args, val_seeds_to_kind, device=torch.device("cpu"),
+            agent,
+            args,
+            val_seeds_to_kind,
+            device=torch.device("cpu"),
             max_seeds=len(val_seeds_to_kind),
         )
 
@@ -564,13 +620,24 @@ class TestRunRolloutEval:
         agent = AgentCNN(envs, chan1=16, chan2=16, chan3=16, flat_dim=64)
         envs.close()
 
-        args = SFTArgs(seed=1, size=size, num_samples=50, max_level=2 * size,
-                       chan1=16, chan2=16, chan3=16, flat_dim=64)
+        args = SFTArgs(
+            seed=1,
+            size=size,
+            num_samples=50,
+            max_level=2 * size,
+            chan1=16,
+            chan2=16,
+            chan3=16,
+            flat_dim=64,
+        )
         val_seeds_to_kind = self._build_val_seeds_to_kind(size=size, num_kinds=6)
         assert len(val_seeds_to_kind) >= 3
 
         _overall, _per_kind, per_kind_n = run_rollout_eval(
-            agent, args, val_seeds_to_kind, device=torch.device("cpu"),
+            agent,
+            args,
+            val_seeds_to_kind,
+            device=torch.device("cpu"),
             max_seeds=2,
         )
         assert sum(per_kind_n.values()) == 2
@@ -583,10 +650,21 @@ class TestRunRolloutEval:
         agent = AgentCNN(envs, chan1=16, chan2=16, chan3=16, flat_dim=64)
         envs.close()
 
-        args = SFTArgs(seed=1, size=size, num_samples=50, max_level=2 * size,
-                       chan1=16, chan2=16, chan3=16, flat_dim=64)
+        args = SFTArgs(
+            seed=1,
+            size=size,
+            num_samples=50,
+            max_level=2 * size,
+            chan1=16,
+            chan2=16,
+            chan3=16,
+            flat_dim=64,
+        )
         overall, per_kind, per_kind_n = run_rollout_eval(
-            agent, args, {}, device=torch.device("cpu"),
+            agent,
+            args,
+            {},
+            device=torch.device("cpu"),
         )
         assert overall == 0.0
         assert sum(per_kind_n.values()) == 0
@@ -641,7 +719,9 @@ class TestEotHead:
         x = torch.zeros((B, C, W, H), dtype=torch.float32)
         enc = agent.encoder(x)
         logits = agent.eot_head(enc).squeeze(-1)
-        assert logits.shape == (B,), f"eot_head output should be (B,), got {logits.shape}"
+        assert logits.shape == (B,), (
+            f"eot_head output should be (B,), got {logits.shape}"
+        )
 
     def test_eot_prob_and_should_stop_shapes(self, registered_env):
         """`eot_prob` returns a [0,1] tensor of shape (B,); `eot_should_stop`
@@ -652,7 +732,9 @@ class TestEotHead:
         envs.close()
 
         B = 3
-        x = torch.zeros((B, agent.channels, agent.width, agent.height), dtype=torch.float32)
+        x = torch.zeros(
+            (B, agent.channels, agent.width, agent.height), dtype=torch.float32
+        )
         probs = agent.eot_prob(x)
         assert probs.shape == (B,)
         assert (probs >= 0).all() and (probs <= 1).all()
@@ -699,10 +781,14 @@ class TestEotHead:
         neg_logits = []
         with torch.no_grad():
             for seed in range(10_000, 10_040):
-                factory = build_factory(size=5, kind=LessonKind.MOVE_ONE_ITEM, seed=seed)
+                factory = build_factory(
+                    size=5, kind=LessonKind.MOVE_ONE_ITEM, seed=seed
+                )
                 assert factory is not None
                 solved, _ = blank_entities(factory, num_missing_entities=0)
-                factory = build_factory(size=5, kind=LessonKind.MOVE_ONE_ITEM, seed=seed)
+                factory = build_factory(
+                    size=5, kind=LessonKind.MOVE_ONE_ITEM, seed=seed
+                )
                 assert factory is not None
                 task, _ = blank_entities(factory, num_missing_entities=3)
                 enc_pos = agent.encoder(solved.unsqueeze(0).float().to(device))
@@ -751,23 +837,29 @@ class TestArtifactNameHelpers:
     format so accidentally renaming a hyperparam doesn't silently
     fragment the artifact namespace."""
 
-    @pytest.mark.parametrize("n,expected", [
-        (500, "500"),
-        (1_000, "1k"),
-        (50_000, "50k"),
-        (200_000, "200k"),
-        (1_000_000, "1m"),
-        (2_500_000, "2.5m"),
-    ])
+    @pytest.mark.parametrize(
+        "n,expected",
+        [
+            (500, "500"),
+            (1_000, "1k"),
+            (50_000, "50k"),
+            (200_000, "200k"),
+            (1_000_000, "1m"),
+            (2_500_000, "2.5m"),
+        ],
+    )
     def test_humanize_count(self, n, expected):
         assert _humanize_count(n) == expected
 
-    @pytest.mark.parametrize("lr,expected", [
-        (1e-3, "1e-3"),
-        (3e-4, "3e-4"),
-        (1e-4, "1e-4"),
-        (5e-4, "5e-4"),
-    ])
+    @pytest.mark.parametrize(
+        "lr,expected",
+        [
+            (1e-3, "1e-3"),
+            (3e-4, "3e-4"),
+            (1e-4, "1e-4"),
+            (5e-4, "5e-4"),
+        ],
+    )
     def test_humanize_lr_round(self, lr, expected):
         """Mantissas that are clean integers don't get a decimal point."""
         assert _humanize_lr(lr) == expected
@@ -783,8 +875,14 @@ class TestArtifactNameHelpers:
 
     def test_artifact_name_larger_run(self):
         args = SFTArgs(
-            size=16, num_samples=200_000, epochs=50, batch_size=1024, lr=3e-4,
-            chan1=48, chan2=48, chan3=48,
+            size=16,
+            num_samples=200_000,
+            epochs=50,
+            batch_size=1024,
+            lr=3e-4,
+            chan1=48,
+            chan2=48,
+            chan3=48,
         )
         assert _artifact_name(args) == "sft-s16-n200k-e50-bs1024-lr3e-4-c48"
 

--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -15,6 +15,7 @@ os.environ["WANDB_DISABLED"] = "true"
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from helpers import (
+    DIR_TO_DELTA,
     Channel,
     Direction,
     LessonKind,
@@ -25,6 +26,7 @@ from helpers import (
 from sft import (
     SFTArgs,
     _artifact_name,
+    _flow_order,
     _humanize_count,
     _humanize_lr,
     build_lr_schedule,
@@ -34,6 +36,58 @@ from sft import (
     train_sft,
 )
 from ppo import FactorioEnv, AgentCNN, make_env
+
+
+class TestFlowOrder:
+    def _down(self):
+        """The Direction whose delta is (+1, 0) — increasing row = top-down."""
+        return next(
+            d for d in Direction if d != Direction.NONE and DIR_TO_DELTA[d] == (1, 0)
+        )
+
+    def test_single_chain_is_source_to_sink(self):
+        """A MOVE_ONE_ITEM demo places belts as one connected source->sink
+        chain: the first tile extends the source, each next tile extends the
+        previous one."""
+        factory = build_factory(size=8, kind=LessonKind.MOVE_ONE_ITEM, seed=7)
+        assert factory is not None
+        solved = factory.world_CWH
+        task, _ = blank_entities(factory, num_missing_entities=64)
+        pairs = extract_expert_actions(solved, task)
+        H = solved.shape[2]
+        order = [(p[1] // H, p[1] % H) for p in pairs if p[7] == 0]
+        ent = solved[Channel.ENTITIES.value]
+        dch = solved[Channel.DIRECTION.value]
+        sx, sy = (ent == str2ent("source").value).nonzero()[0].tolist()
+        dx, dy = DIR_TO_DELTA[Direction(int(dch[sx, sy]))]
+        assert order[0] == (sx + dx, sy + dy), "first tile must extend the source"
+        for (x, y), nxt in zip(order, order[1:]):
+            ddx, ddy = DIR_TO_DELTA[Direction(int(dch[x, y]))]
+            assert (x + ddx, y + ddy) == nxt, "each tile must extend the previous"
+
+    def test_branch_breaks_ties_top_down_left_right(self):
+        """When several tiles are simultaneously placeable, _flow_order takes
+        the top-most then left-most one (raster order)."""
+        nchan = max(c.value for c in Channel) + 1
+        H = W = 4
+        world = torch.zeros((nchan, W, H))
+        down = self._down().value
+        src = str2ent("source").value
+        belt = str2ent("transport_belt").value
+        e, dr = Channel.ENTITIES.value, Channel.DIRECTION.value
+        # two parallel downward chains rooted at sources in cols 0 and 2
+        for col in (0, 2):
+            world[e, 0, col] = src
+            world[dr, 0, col] = down
+            for row in (1, 2):
+                world[e, row, col] = belt
+                world[dr, row, col] = down
+        anchors = [[2, 2], [1, 2], [2, 0], [1, 0]]  # scrambled input order
+        order = [tuple(o) for o in _flow_order(world, anchors)]
+        # frontier at each step, top-down then left-right:
+        #   {(1,0),(1,2)} -> (1,0); {(1,2),(2,0)} -> (1,2);
+        #   {(2,0),(2,2)} -> (2,0); {(2,2)} -> (2,2)
+        assert order == [(1, 0), (1, 2), (2, 0), (2, 2)]
 
 
 class TestExtractExpertActions:


### PR DESCRIPTION
## What

Pin SFT dataset generation to **`MOVE_ONE_ITEM` only** so we can test — in the Karpathy sense — that the SFT pipeline can actually drive **`val/MOVE_ONE_ITEM/throughput`** up given ample compute. If throughput won't rise on the single simplest lesson, the problem is upstream of the lesson mix, not in the data diversity.

This is an **experiment scaffold, not destined for `main` as-is.** One-line revert: restore `kinds = list(LessonKind)` in `generate_dataset`.

## Changes

- `sft.py`: `generate_dataset` samples only `MOVE_ONE_ITEM` (other kinds commented out, not deleted).
- `tests/test_sft.py`: skip the two tests that assert the dataset spans ≥2 `LessonKind`s (they don't hold while pinned to one kind). Reason string points back here.

## Why this is a fair test (not memorize-3-layouts)

`build_factory` defaults to `random_item=True` and `max_entities=inf`, so each `MOVE_ONE_ITEM` lesson randomizes source/sink position, both directions, the item (full item set), and the path shape. Held-out val factories are genuinely unseen configs — so a rising `val/MOVE_ONE_ITEM/throughput` means real generalization on this lesson.

## Running the tracked RunPod job

RunPod is **label-gated** (not auto on PR open). Add the **`sft-smoketest`** label to trigger `scripts/ci/sft_smoke_test.sh`, which runs one tracked job:
`sft.py --size 11 --num-samples 300000 --epochs 30 --track` (logs to W&B `factorion`, 4h watchdog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
