### PR TITLE
Drive wandb _step from samples_seen so existing panels follow it

### DIFF
--- a/sft.py
+++ b/sft.py
@@ -759,20 +759,6 @@ def train_sft(args: SFTArgs):
                 seeds_by_kind.get(k.name, set())
             )
 
-        # Default the x-axis to "optimisation pressure applied" rather than
-        # epoch index. Logging once per epoch makes wandb's implicit _step
-        # epoch-aligned, so two runs with the same epoch count but different
-        # num_samples look identical on the x-axis despite one applying far
-        # more gradient updates. samples_seen (cumulative training pairs the
-        # model was updated on) scales with both epochs AND num_samples — and,
-        # unlike global_step, stays comparable across batch_size changes — so
-        # we make it the default x-axis for every metric. global_step (raw
-        # optimiser updates) and epoch are still logged for anyone who wants
-        # to switch the panel x-axis in the UI.
-        wandb.define_metric("train/samples_seen")
-        wandb.define_metric("train/global_step")
-        wandb.define_metric("*", step_metric="train/samples_seen")
-
     best_val_acc = 0.0
     val_loss = 0.0
     val_tile_acc = 0.0
@@ -1208,6 +1194,20 @@ def train_sft(args: SFTArgs):
             print(f"  per-kind val_acc: {kind_summary}")
 
         if args.track and run is not None:
+            # Drive wandb's underlying _step with samples_seen (cumulative
+            # training pairs the model has been updated on) instead of
+            # letting it auto-increment once per epoch. This is what makes
+            # the x-axis measure "optimisation pressure applied": two runs
+            # with the same epoch count but different num_samples now spread
+            # across proportionally different x-ranges. Crucially, _step is
+            # the axis EVERY default panel plots against — including ones
+            # already pinned to "Step" in an existing workspace — so this
+            # fixes panels (e.g. val/<kind>/throughput) that define_metric's
+            # step_metric alone could not retarget. samples_seen rather than
+            # global_step because it stays comparable across batch_size
+            # changes; both are still logged as metrics so either can be
+            # picked as a custom x-axis in the UI. (_step must increase
+            # monotonically — samples_seen does, by construction.)
             run.log(
                 {
                     "train/loss": train_loss,
@@ -1242,7 +1242,8 @@ def train_sft(args: SFTArgs):
                     if grad_norm_count > 0
                     else float("nan"),
                     **per_kind_metrics,
-                }
+                },
+                step=samples_seen,
             )
 
         if val_acc >= best_val_acc:


### PR DESCRIPTION
Follow-up fix to #132 (already merged). The reported symptom: `val/MOVE_ONE_ITEM/throughput` still showed only ~30 steps on the x-axis.

## Why #132 didn't work

#132 set `wandb.define_metric("*", step_metric="train/samples_seen")`. But `step_metric` only changes the **default x-axis for freshly auto-generated panels in a clean workspace**. It does **not**:

- change wandb's underlying `_step` (which is what most panels actually plot against), nor
- retarget panels that **already exist** in a workspace pinned to the "Step" axis (from earlier runs).

So carried-over panels like `val/<kind>/throughput` kept plotting against the epoch-aligned `_step` (~30 ticks).

## The fix

Pass `step=samples_seen` to `run.log()`, so wandb's `_step` **is** cumulative training pairs seen. Every default panel plots against `_step` — including already-pinned ones — so they all now measure "optimisation pressure applied" with no per-panel UI changes. Two runs with equal epochs but different `num_samples` now spread across proportionally different x-ranges.

- `samples_seen` rather than `global_step` for the step because it stays comparable across `batch_size` changes; both (plus `epoch`) are still logged as metrics, selectable as custom x-axes.
- `_step` must increase monotonically — `samples_seen` does by construction.
- Dropped the now-redundant `define_metric` block from #132.

## Verification

Decoded an offline tracked run's `.wandb` history:

| metric | epoch 1 | epoch 2 | epoch 3 |
|---|---|---|---|
| `_step` (Step axis) | **269** | **538** | **807** |
| `train/samples_seen` | 269 | 538 | 807 |
| `train/global_step` | 9 | 18 | 27 |
| `train/epoch` | 1 | 2 | 3 |
| `val/MOVE_ONE_ITEM/throughput` | — | logged @538 | logged @807 |

`_step` is driven by samples_seen (269→807), not 0→2, and the problem metric lands at sample-based steps. In a real 300k×30 run the Step axis runs to ~8.1M.

- `ruff check sft.py` → clean
- `pytest tests/test_sft.py` → 45 passed, 41 skipped

## Note

Applies to **new** runs. Historical runs already wrote `_step` as epoch index, so they keep their old axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)