### PR TITLE
Add PPO Train (manual) RunPod workflow

### DIFF
--- a/.github/workflows/ppo-train.yml
+++ b/.github/workflows/ppo-train.yml
@@ -1,0 +1,173 @@
+name: PPO Train (manual)
+
+# Kick off a real PPO (RL) training run from any branch (no PR required),
+# continuing from an SFT checkpoint, using the ppo_train.sh in-pod pipeline.
+# The pod-side watchdog and the GH Actions job timeout are both derived from
+# total_timesteps so longer runs get more headroom automatically.
+
+on:
+  workflow_dispatch:
+    inputs:
+      start_from:
+        description: "SFT checkpoint to continue from: a W&B run id OR a local .pt path"
+        required: true
+        type: string
+      total_timesteps:
+        description: "PPO total timesteps"
+        required: true
+        default: "500000"
+        type: string
+      size:
+        description: "Grid size (must match the SFT checkpoint)"
+        required: false
+        default: "11"
+        type: string
+      critic_warmup:
+        description: "Critic-only warm-up iterations before joint PPO"
+        required: false
+        default: "10"
+        type: string
+      start_curriculum_level:
+        description: "num_missing_entities cap (~2*size blanks the whole factory)"
+        required: false
+        default: "22"
+        type: string
+      ent_coef:
+        description: "Entropy bonus (constant; sets both start & end). 0 = no entropy bonus, right for finetuning an SFT policy"
+        required: false
+        default: "0"
+        type: string
+      learning_rate:
+        description: "Peak LR. Small (e.g. 5e-5) for stable SFT finetuning"
+        required: false
+        default: "5e-5"
+        type: string
+      target_kl:
+        description: "KL early-stop threshold per rollout (trust region). e.g. 0.02"
+        required: false
+        default: "0.02"
+        type: string
+      seed:
+        description: "Random seed"
+        required: false
+        default: "1"
+        type: string
+      ref:
+        description: "Git ref to run (branch / SHA / tag)"
+        required: false
+        default: "main"
+        type: string
+      gpu_type:
+        description: "RunPod GPU type"
+        required: false
+        default: "NVIDIA A100 80GB PCIe"
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  WANDB_CI_PROJECT: factorion
+  PYTHON_VERSION: "3.11"
+
+jobs:
+  # ──────────────────────────────────────────────
+  # Job 0: Compute time budget from total_timesteps
+  # ──────────────────────────────────────────────
+  calc-budget:
+    runs-on: ubuntu-latest
+    outputs:
+      job_timeout: ${{ steps.calc.outputs.job_timeout }}
+      watchdog_seconds: ${{ steps.calc.outputs.watchdog_seconds }}
+    steps:
+      - name: Compute budget
+        id: calc
+        env:
+          TOTAL_TIMESTEPS: ${{ inputs.total_timesteps }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import os
+          t = int(os.environ["TOTAL_TIMESTEPS"])
+          # Conservative A100 PPO rate (~200 env-steps/sec incl. the Rust
+          # throughput sim + curriculum eval), with a 2x safety margin so the
+          # watchdog never kills a legitimate run early. Calibratable.
+          base_seconds = t / 200
+          watchdog = int(base_seconds * 2 + 900)
+          watchdog = max(watchdog, 1800)          # floor: 30 min
+          job_minutes = int(watchdog / 60) + 30   # + pod create/teardown
+          job_minutes = min(job_minutes, 360)     # hosted-runner 6h cap
+          print(f"watchdog_seconds={watchdog}")
+          print(f"job_timeout={job_minutes}")
+          PY
+          echo "Budget:"
+          cat "$GITHUB_OUTPUT"
+
+  # ──────────────────────────────────────────────
+  # Job 1: PPO training on RunPod GPU
+  # ──────────────────────────────────────────────
+  ppo-train:
+    needs: [calc-budget]
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ fromJSON(needs.calc-budget.outputs.job_timeout) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          ref: ${{ inputs.ref }}
+
+      - name: Setup RunPod
+        id: runpod
+        uses: ./.github/actions/runpod-setup
+        with:
+          runpod_api_key: ${{ secrets.RUNPOD_API_KEY }}
+          ssh_private_key: ${{ secrets.RUNPOD_SSH_PRIVATE_KEY }}
+          gpu_type: ${{ inputs.gpu_type }}
+          name_prefix: ci-ppo-train
+
+      - name: Run PPO training on GPU
+        env:
+          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+          RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
+        run: |
+          SSH_HOST="${{ steps.runpod.outputs.ssh_host }}"
+          SSH_PORT="${{ steps.runpod.outputs.ssh_port }}"
+          POD_ID="${{ steps.runpod.outputs.pod_id }}"
+          REF="${{ inputs.ref }}"
+          WATCHDOG_SECONDS="${{ needs.calc-budget.outputs.watchdog_seconds }}"
+
+          scp -i ~/.ssh/runpod_ci -P "$SSH_PORT" \
+            scripts/ci/ppo_train.sh \
+            root@"$SSH_HOST":/workspace/ppo_train.sh
+
+          ssh -i ~/.ssh/runpod_ci -p "$SSH_PORT" root@"$SSH_HOST" \
+            WANDB_API_KEY="$WANDB_API_KEY" \
+            WANDB_PROJECT="${{ env.WANDB_CI_PROJECT }}" \
+            START_FROM="${{ inputs.start_from }}" \
+            TOTAL_TIMESTEPS="${{ inputs.total_timesteps }}" \
+            SIZE="${{ inputs.size }}" \
+            CRITIC_WARMUP="${{ inputs.critic_warmup }}" \
+            START_CURRICULUM_LEVEL="${{ inputs.start_curriculum_level }}" \
+            ENT_COEF="${{ inputs.ent_coef }}" \
+            LEARNING_RATE="${{ inputs.learning_rate }}" \
+            TARGET_KL="${{ inputs.target_kl }}" \
+            SEED="${{ inputs.seed }}" \
+            WATCHDOG_SECONDS="$WATCHDOG_SECONDS" \
+            PR_NUMBER="manual-${REF}" \
+            COMMIT_SHA="$GITHUB_SHA" \
+            RUNPOD_API_KEY="$RUNPOD_API_KEY" \
+            RUNPOD_POD_ID="$POD_ID" \
+            bash /workspace/ppo_train.sh
+
+      - name: Teardown RunPod
+        if: always()
+        uses: ./.github/actions/runpod-teardown
+        with:
+          runpod_api_key: ${{ secrets.RUNPOD_API_KEY }}
+          summary_file: /tmp/ppo_summary.md
+
+      - name: Publish summary to job
+        if: always()
+        run: |
+          if [ -f /tmp/ppo_summary.md ]; then
+            cat /tmp/ppo_summary.md >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/scripts/ci/ppo_train.sh
+++ b/scripts/ci/ppo_train.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# ppo_train.sh — Runs a PPO (RL) training run on RunPod GPU, continuing from an
+# SFT checkpoint. Builds the Rust extension, loads the actor (+ critic) via
+# --start-from (a W&B run id OR a local .pt path), runs PPO with a critic
+# warm-up, and logs to W&B. Pre-installed deps + Rust toolchain are expected in
+# the Docker image (beyarkay/factorion-ci-gpu:latest); code should already be at
+# /workspace/factorion/.
+#
+# Required env vars:
+#   WANDB_API_KEY          - W&B API key (logging + artifact download for --start-from)
+#   WANDB_PROJECT          - W&B project name (e.g. factorion)
+#   START_FROM             - SFT checkpoint: a W&B run id OR a local .pt path
+#
+# Optional env vars:
+#   TOTAL_TIMESTEPS        - PPO total timesteps (default: 500000)
+#   SIZE                   - grid size; MUST match the SFT checkpoint (default: 11)
+#   CRITIC_WARMUP          - critic-only warm-up iterations (default: 10)
+#   START_CURRICULUM_LEVEL - num_missing_entities cap; ~2*size blanks the whole
+#                            MOVE_ONE_ITEM factory each episode (default: 22)
+#   SEED                   - random seed (default: 1)
+#   WATCHDOG_SECONDS       - self-terminate watchdog timeout (default: 7200 = 2h)
+#   PR_NUMBER, COMMIT_SHA  - tagging
+#   RUNPOD_POD_ID, RUNPOD_API_KEY - for the self-terminate watchdog
+
+set -euo pipefail
+
+: "${START_FROM:?START_FROM (a W&B run id or a .pt path) is required}"
+TOTAL_TIMESTEPS="${TOTAL_TIMESTEPS:-500000}"
+SIZE="${SIZE:-11}"
+CRITIC_WARMUP="${CRITIC_WARMUP:-10}"
+START_CURRICULUM_LEVEL="${START_CURRICULUM_LEVEL:-22}"
+ENT_COEF="${ENT_COEF:-0}"
+LEARNING_RATE="${LEARNING_RATE:-5e-5}"
+TARGET_KL="${TARGET_KL:-0.02}"
+SEED="${SEED:-1}"
+WATCHDOG_SECONDS="${WATCHDOG_SECONDS:-7200}"
+WANDB_PROJECT="${WANDB_PROJECT:-factorion}"
+PR_NUMBER="${PR_NUMBER:-unknown}"
+COMMIT_SHA="${COMMIT_SHA:-unknown}"
+
+echo "============================================"
+echo "  Factorion PPO Train (RL from SFT)"
+echo "============================================"
+echo "  GPU:                 $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo 'unknown')"
+echo "  CUDA:                $(nvcc --version 2>/dev/null | tail -1 || echo 'unknown')"
+echo "  start_from:          ${START_FROM}"
+echo "  total_timesteps:     ${TOTAL_TIMESTEPS}"
+echo "  size:                ${SIZE}"
+echo "  critic_warmup:       ${CRITIC_WARMUP}"
+echo "  start_curric_level:  ${START_CURRICULUM_LEVEL}"
+echo "  ent_coef:            ${ENT_COEF}"
+echo "  learning_rate:       ${LEARNING_RATE}"
+echo "  target_kl:           ${TARGET_KL}"
+echo "  seed:                ${SEED}"
+echo "  watchdog:            ${WATCHDOG_SECONDS}s"
+echo "  W&B project:         ${WANDB_PROJECT}"
+echo "  PR:                  ${PR_NUMBER}"
+echo "  Commit:              ${COMMIT_SHA}"
+echo "============================================"
+
+# ── Safety net: self-terminate after WATCHDOG_SECONDS if cleanup fails ─
+if [ -n "${RUNPOD_POD_ID:-}" ] && [ -n "${RUNPOD_API_KEY:-}" ]; then
+    echo ">>> Starting self-terminate watchdog (${WATCHDOG_SECONDS}s timeout)..."
+    nohup bash -c "
+      sleep ${WATCHDOG_SECONDS}
+      curl -s 'https://api.runpod.io/graphql?api_key=${RUNPOD_API_KEY}' \
+        -H 'Content-Type: application/json' \
+        -d '{\"query\": \"mutation { podTerminate(input: {podId: \\\"${RUNPOD_POD_ID}\\\"}) }\"}'
+    " &>/dev/null &
+else
+    echo ">>> Watchdog skipped (RUNPOD_POD_ID or RUNPOD_API_KEY not set)"
+fi
+
+cd /workspace/factorion
+
+# ── Ensure Rust is on PATH ────────────────────────────────────────
+export PATH="/root/.cargo/bin:${PATH}"
+
+# ── CuBLAS deterministic mode ────────────────────────────────────
+export CUBLAS_WORKSPACE_CONFIG=:4096:8
+
+# ── Build Rust extension ─────────────────────────────────────────
+if [ -f factorion_rs/Cargo.toml ]; then
+    echo ""
+    echo ">>> Building factorion_rs from source..."
+    (cd factorion_rs && maturin build --release --out dist && pip install dist/*.whl)
+else
+    echo ">>> WARNING: factorion_rs not available."
+fi
+
+# ── Configure W&B (also used to download the --start-from artifact) ──
+export WANDB_API_KEY
+
+# ── Run PPO ──────────────────────────────────────────────────────
+echo ""
+echo ">>> Starting PPO (${TOTAL_TIMESTEPS} timesteps, from ${START_FROM})..."
+
+python ppo.py \
+    --seed "$SEED" \
+    --env-id factorion/FactorioEnv-v0 \
+    --size "$SIZE" \
+    --start-from "$START_FROM" \
+    --critic-warmup "$CRITIC_WARMUP" \
+    --start-curriculum-level "$START_CURRICULUM_LEVEL" \
+    --ent-coef-start "$ENT_COEF" \
+    --ent-coef-end "$ENT_COEF" \
+    --learning-rate "$LEARNING_RATE" \
+    --target-kl "$TARGET_KL" \
+    --total-timesteps "$TOTAL_TIMESTEPS" \
+    --track \
+    --wandb-project-name "$WANDB_PROJECT" \
+    --tags ci ppo-train "pr:${PR_NUMBER}" "sha:${COMMIT_SHA}" "from:${START_FROM}" \
+    --summary-path /workspace/factorion/ppo_summary.json
+
+echo ""
+echo "============================================"
+echo "  PPO training completed successfully"
+echo "============================================"
+
+# ── Generate summary markdown (fetched by runpod-teardown) ───────
+SUMMARY_JSON="/workspace/factorion/ppo_summary.json"
+SUMMARY_MD="/workspace/summary.md"
+
+if [ -f "$SUMMARY_JSON" ]; then
+    GPU_NAME=$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo 'unknown')
+    python3 -c "
+import json
+s = json.load(open('$SUMMARY_JSON'))
+gpu = '''$GPU_NAME'''
+pr = '''$PR_NUMBER'''
+sha = '''$COMMIT_SHA'''
+start_from = '''$START_FROM'''
+wandb_url = s.get('wandb_url') or 'N/A'
+wandb_link = f'[View on W&B]({wandb_url})' if wandb_url != 'N/A' else 'N/A'
+print(f'''## PPO Train Results (RL from SFT)
+
+| Metric | Value |
+|--------|-------|
+| **Moving-avg throughput** | {s['moving_avg_throughput']:.4f} |
+| **Curriculum score** | {s['curriculum_score']:.4f} |
+| **Max missing entities** | {s['max_missing_entities']} |
+| **Total timesteps** | {s['total_timesteps']:,} |
+| **Global step** | {s['global_step']:,} |
+| **Runtime** | {s['runtime_human']} |
+| **Steps/sec** | {s['sps']:,} |
+| **Grid size** | {s['grid_size']}x{s['grid_size']} |
+| **Started from** | {start_from} |
+| **GPU** | {gpu} |
+
+{wandb_link}
+
+<sub>Commit {sha[:8]} · PR #{pr}</sub>''')
+" > "$SUMMARY_MD"
+    echo ">>> Summary written to $SUMMARY_MD"
+else
+    echo ">>> WARNING: ppo_summary.json not found, skipping summary"
+fi


### PR DESCRIPTION
## What

Adds the **PPO Train (manual)** RunPod workflow (`.github/workflows/ppo-train.yml` + `scripts/ci/ppo_train.sh`), mirroring **SFT Train (manual)**. It's a `workflow_dispatch` that spins up a RunPod A100 and runs PPO continuing from an SFT checkpoint.

## Why a separate, workflow-only PR

`workflow_dispatch` workflows are only triggerable when the file is on the **default branch** — so the workflow has to land on `main` to be dispatchable. This PR is intentionally **just the workflow + in-pod script**, branched off `main`, so it can merge without dragging in the in-flight MOVE_ONE_ITEM experiment scaffolding.

## How it runs

- **`start_from` (required)** takes a **W&B run id** (the SFT run to continue RL from — its newest `model` artifact is downloaded by `ppo.py`'s `--start-from` resolver) or a local `.pt` path.
- Other inputs default to the **stable SFT→PPO finetuning recipe** we validated locally: `ent_coef=0`, `learning_rate=5e-5`, `target_kl=0.02`, `critic_warmup=10`, `start_curriculum_level=22`, `size=11`.
- The **training code** (`ppo.py` with `--critic-warmup` / `--start-from` resolution / `charts/actor_frozen` logging, and `ppo_train.sh`) is pulled at run time from whatever branch you pass as **`ref`** — so point `ref` at the branch carrying the PPO-RL code (currently `worktree-overfit-on-move-one-item`).

The job derives its watchdog + timeout from `total_timesteps`, builds `factorion_rs`, runs `ppo.py --track`, writes `summary.md`, then tears down the pod and posts the summary to the Actions run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
