### PR TITLE
build_factory: reject-and-resample zero-throughput MOVE_ONE_ITEM factories

### DIFF
--- a/factorion.py
+++ b/factorion.py
@@ -1813,16 +1813,43 @@ def build_factory(
                 ).permute(2, 0, 1)
                 # Restart the loop until we get a source+sink that can be connected
                 continue
-            else:
-                # Choose a valid path at random and add it to the map
-                chosen_path = random.choice(paths)
-                total_entities = len(chosen_path)
-                for x, y, d in chosen_path:
-                    world_CWH[Channel.ENTITIES.value, x, y] = str2ent(
+
+            # Choose a valid path that ACTUALLY carries throughput.
+            # find_belt_paths_with_source_sink_orient can return paths that are
+            # geometrically connected but functionally broken (carry zero items)
+            # when the random source/sink placement is degenerate — too close,
+            # adjacent, or oriented so the belt can't deliver. Laying one of those
+            # blindly produced ~5-13% zero-throughput MOVE_ONE_ITEM factories
+            # (size-dependent) — broken training targets no policy can complete.
+            # So try paths in random order and keep the first that simulates to
+            # positive throughput; if none do, the source/sink is degenerate —
+            # resample it.
+            random.shuffle(paths)
+            chosen_path = None
+            for candidate in paths:
+                trial = world_CWH.clone()
+                for x, y, d in candidate:
+                    trial[Channel.ENTITIES.value, x, y] = str2ent(
                         "transport_belt"
                     ).value
-                    world_CWH[Channel.DIRECTION.value, x, y] = d.value
+                    trial[Channel.DIRECTION.value, x, y] = d.value
+                tp, _ = factorion_rs.simulate_throughput(
+                    trial.permute(1, 2, 0).to(torch.int64).numpy()
+                )
+                if tp > 0:
+                    chosen_path = candidate
+                    world_CWH = trial
+                    break
 
+            if chosen_path is None:
+                # Every candidate path is functionally broken → degenerate
+                # source/sink. Reject this factory and resample.
+                world_CWH = torch.tensor(
+                    new_world(width=size, height=size)
+                ).permute(2, 0, 1)
+                continue
+
+            total_entities = len(chosen_path)
             break
         if count == 0:
             return None

--- a/tests/test_move_one_item_throughput.py
+++ b/tests/test_move_one_item_throughput.py
@@ -1,0 +1,54 @@
+"""MOVE_ONE_ITEM factories must actually carry throughput.
+
+`build_factory` chose a random belt path via `random.choice(paths)` WITHOUT
+validating it. `find_belt_paths_with_source_sink_orient` can return
+geometrically-connected but functionally-broken paths when the random source/sink
+placement is degenerate (too close, adjacent, or facing off-grid), so the
+generator emitted ~5-13% (size-dependent) MOVE_ONE_ITEM factories that simulate to
+ZERO throughput. Those are broken training targets — no policy can complete them.
+
+The generator must reject-and-resample any factory whose throughput is zero. This
+is the regression test for that fix.
+"""
+
+import pytest
+
+from helpers import (
+    LessonKind,
+    blank_entities,
+    build_factory,
+    rs_throughput,
+)
+
+
+@pytest.mark.parametrize("size", [5, 8, 11, 12])
+def test_move_one_item_every_factory_has_throughput(size):
+    """Across many seeds, EVERY generated MOVE_ONE_ITEM factory must carry
+    positive throughput. Before the fix ~5-13% (size-dependent) were zero."""
+    broken = []
+    n_built = 0
+    for seed in range(120):
+        factory = build_factory(size=size, kind=LessonKind.MOVE_ONE_ITEM, seed=seed)
+        if factory is None:
+            continue
+        n_built += 1
+        world, _ = blank_entities(factory, num_missing_entities=0)
+        tp, _ = rs_throughput(world.permute(1, 2, 0))
+        if tp <= 0:
+            broken.append(seed)
+    assert n_built > 0, f"size={size}: build_factory never returned a factory"
+    assert not broken, (
+        f"size={size}: build_factory emitted {len(broken)}/{n_built} "
+        f"MOVE_ONE_ITEM factories with zero throughput (seeds {broken}); the "
+        f"generator must reject-and-resample broken factories"
+    )
+
+
+@pytest.mark.parametrize("seed", range(40))
+def test_move_one_item_size11_seed_has_throughput(seed):
+    """Per-seed granularity at size 11 (matches the SPLITTER_SPLIT test style)."""
+    factory = build_factory(size=11, kind=LessonKind.MOVE_ONE_ITEM, seed=seed)
+    assert factory is not None
+    world, _ = blank_entities(factory, num_missing_entities=0)
+    tp, _ = rs_throughput(world.permute(1, 2, 0))
+    assert tp > 0, f"seed={seed}: MOVE_ONE_ITEM factory has zero throughput"


### PR DESCRIPTION
## Problem

`build_factory` emitted **broken MOVE_ONE_ITEM factories** — ones that simulate to
**zero throughput** — at a rate of **~5–13%** (smaller grids are worse):

| size | broken (before) |
|------|-----------------|
| 5    | 13/120 (10.8%)  |
| 8    | 16/120 (13.3%)  |
| 11   | 6/120 (5.0%)    |
| 12   | 5/120 (4.2%)    |

These are broken training targets — no policy can ever complete a factory that
moves nothing — and they silently cap any "fraction of factories built" metric.

**Why:** `find_belt_paths_with_source_sink_orient` can return paths that are
*geometrically* connected but *functionally* broken (carry zero items) when the
random source/sink placement is degenerate — too close, adjacent, or oriented so
the belt can't deliver (e.g. a source at the grid edge facing off-grid).
`build_factory` picked one with `random.choice(paths)` **without validating it**.

## Fix

Try candidate paths in random order and keep the first that **simulates to positive
throughput**; if none do, the source/sink is degenerate, so resample it (reusing
the existing retry loop). Cost: ~1 throughput sim per generated factory in the
common case (the first path usually works).

## Tests (written first — red before the fix)

`tests/test_move_one_item_throughput.py` asserts **every** generated MOVE_ONE_ITEM
factory carries positive throughput, across sizes {5, 8, 11, 12} × 120 seeds plus
per-seed at size 11. Before the fix: 7 failing cases. After: **0/300 broken**, full
suite 3392 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
