### PR TITLE
SFT sweep plumbing: dynamic CNN architecture (--layers / --kernel-size)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -821,7 +821,7 @@ jobs:
           SWEEP_URL="${{ steps.create.outputs.sweep_url }}"
           SWEEP_PODS="${{ inputs.sweep_agents || '1' }}"
           AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '5' }}"
-          SWEEP_COUNT="${{ inputs.sweep_count || '20' }}"
+          SWEEP_COUNT="${{ inputs.sweep_count || '30' }}"
           TOTAL_AGENTS=$(( SWEEP_PODS * AGENTS_PER_POD ))
           gh pr comment "${{ github.event.pull_request.number }}" --body "$(cat <<EOF
           **SFT W&B Sweep started** — ${SWEEP_COUNT} iterations across ${SWEEP_PODS} pod(s) x ${AGENTS_PER_POD} agents/pod (${TOTAL_AGENTS} total agents)
@@ -835,7 +835,7 @@ jobs:
         run: |
           NUM_PODS="${{ inputs.sweep_agents || '1' }}"
           AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '5' }}"
-          TOTAL_COUNT="${{ inputs.sweep_count || '20' }}"
+          TOTAL_COUNT="${{ inputs.sweep_count || '30' }}"
           TOTAL_AGENTS=$(( NUM_PODS * AGENTS_PER_POD ))
           COUNT_PER=$(( TOTAL_COUNT / TOTAL_AGENTS ))
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ Before claiming work is done, run all of the following:
 4. **Python tests**: `WANDB_MODE=disabled WANDB_DISABLED=true uv run python -m pytest tests/ -v`
 5. **Python linter**: `uv run ruff check .`
 6. **PPO smoke test**: `WANDB_MODE=disabled uv run python ppo.py --seed 1 --env-id factorion/FactorioEnv-v0 --total-timesteps 5000`
-7. **SFT smoke test**: `WANDB_MODE=disabled uv run python sft.py --seed 1 --size 5 --num-samples 200 --epochs 2 --batch-size 32 --chan1 16 --chan2 16 --chan3 16 --checkpoint-path /tmp/sft_smoke.pt --summary-path /tmp/sft_smoke.json`
+7. **SFT smoke test**: `WANDB_MODE=disabled uv run python sft.py --seed 1 --size 5 --num-samples 200 --epochs 2 --batch-size 32 --layer1 16 --layer2 16 --layer3 16 --checkpoint-path /tmp/sft_smoke.pt --summary-path /tmp/sft_smoke.json`
 
 All seven must pass before the work is considered complete.
 

--- a/factorion-mod/server/server.py
+++ b/factorion-mod/server/server.py
@@ -44,6 +44,7 @@ log = logging.getLogger("factorion-server")
 # RCON client (inlined; no extra deps).
 # --------------------------------------------------------------------------- #
 
+
 class RconError(RuntimeError):
     pass
 
@@ -56,7 +57,12 @@ class RconClient:
     RESP = 0
 
     def __init__(self, host: str, port: int, password: str, timeout: float = 5.0):
-        self.host, self.port, self.password, self.timeout = host, port, password, timeout
+        self.host, self.port, self.password, self.timeout = (
+            host,
+            port,
+            password,
+            timeout,
+        )
         self._sock: Optional[socket.socket] = None
         self._counter = 1
 
@@ -126,6 +132,7 @@ class RconClient:
 # Model loading & inference.
 # --------------------------------------------------------------------------- #
 
+
 def _duck_envs(size: int):
     """AgentCNN reads grid size off `envs.envs[0].unwrapped.size`."""
     return SimpleNamespace(envs=[SimpleNamespace(unwrapped=SimpleNamespace(size=size))])
@@ -148,10 +155,17 @@ class Hyperparams:
 
 
 def load_agent(ckpt_path: Path, hp: Hyperparams, device: torch.device) -> AgentCNN:
-    log.info("Loading checkpoint %s (grid=%d, chans=%d/%d/%d)",
-             ckpt_path, hp.grid_size, hp.chan1, hp.chan2, hp.chan3)
-    agent = AgentCNN(_duck_envs(hp.grid_size),
-                     chan1=hp.chan1, chan2=hp.chan2, chan3=hp.chan3).to(device)
+    log.info(
+        "Loading checkpoint %s (grid=%d, chans=%d/%d/%d)",
+        ckpt_path,
+        hp.grid_size,
+        hp.chan1,
+        hp.chan2,
+        hp.chan3,
+    )
+    agent = AgentCNN(
+        _duck_envs(hp.grid_size), layers=(hp.chan1, hp.chan2, hp.chan3)
+    ).to(device)
     state = torch.load(ckpt_path, map_location=device, weights_only=True)
     agent.load_state_dict(state)
     agent.eval()
@@ -161,6 +175,7 @@ def load_agent(ckpt_path: Path, hp: Hyperparams, device: torch.device) -> AgentC
 # --------------------------------------------------------------------------- #
 # Request → obs tensor.
 # --------------------------------------------------------------------------- #
+
 
 def _source_id() -> int:
     e = str2ent("source")
@@ -208,6 +223,7 @@ def request_to_obs(req: dict) -> np.ndarray:
 # --------------------------------------------------------------------------- #
 # Iterative inference: place one entity at a time, greedy (argmax).
 # --------------------------------------------------------------------------- #
+
 
 def _argmax_action(agent: AgentCNN, obs_CWH: np.ndarray, device) -> dict:
     x = torch.from_numpy(obs_CWH).unsqueeze(0).to(device)
@@ -266,17 +282,25 @@ def _apply_placement(obs_CWH: np.ndarray, action: dict) -> bool:
 
 
 def run_inference(
-    agent: AgentCNN, req: dict, max_steps: int, device, eot_threshold: float = 0.5,
+    agent: AgentCNN,
+    req: dict,
+    max_steps: int,
+    device,
+    eot_threshold: float = 0.5,
 ) -> tuple[np.ndarray, dict]:
     """Iteratively place entities until eot_head signals "done", the model
     emits a no-op, or we hit the safety budget."""
     obs = request_to_obs(req)
 
     # Dump the initial obs summary so we can see what the model is starting from
-    src_ids = [(int(s["x"]), int(s["y"]), s.get("direction"), s.get("item"))
-               for s in req.get("sources", [])]
-    snk_ids = [(int(s["x"]), int(s["y"]), s.get("direction"), s.get("item"))
-               for s in req.get("sinks", [])]
+    src_ids = [
+        (int(s["x"]), int(s["y"]), s.get("direction"), s.get("item"))
+        for s in req.get("sources", [])
+    ]
+    snk_ids = [
+        (int(s["x"]), int(s["y"]), s.get("direction"), s.get("item"))
+        for s in req.get("sinks", [])
+    ]
     log.info("  initial sources (x,y,dir,item): %s", src_ids)
     log.info("  initial sinks   (x,y,dir,item): %s", snk_ids)
     fp_count = int(obs[Channel.FOOTPRINT.value].sum())
@@ -299,7 +323,9 @@ def run_inference(
             stats["first_eot_prob"] = eot_p
         stats["final_eot_prob"] = eot_p
         if eot_p > eot_threshold:
-            log.info("  step %d: eot_prob=%.3f > %.2f → STOP", step, eot_p, eot_threshold)
+            log.info(
+                "  step %d: eot_prob=%.3f > %.2f → STOP", step, eot_p, eot_threshold
+            )
             stats["stop_reason"] = "eot"
             stats["steps_taken"] = step
             break
@@ -308,23 +334,32 @@ def run_inference(
         ent_name = entities[ent_id].name if ent_id in entities else "?"
         item_id = action["item"]
         item_name = entities[item_id].name if item_id in entities else "?"
-        stats["placements"].append({
-            "step": step,
-            "eot": eot_p,
-            "entity_id": ent_id,
-            "entity_name": ent_name,
-            "x": int(action["xy"][0]),
-            "y": int(action["xy"][1]),
-            "direction": int(action["direction"]),
-            "item_id": item_id,
-            "item_name": item_name,
-            "misc": int(action["misc"]),
-        })
+        stats["placements"].append(
+            {
+                "step": step,
+                "eot": eot_p,
+                "entity_id": ent_id,
+                "entity_name": ent_name,
+                "x": int(action["xy"][0]),
+                "y": int(action["xy"][1]),
+                "direction": int(action["direction"]),
+                "item_id": item_id,
+                "item_name": item_name,
+                "misc": int(action["misc"]),
+            }
+        )
         log.info(
             "  step %d: eot=%.3f place=%s(id=%d) at (%d,%d) dir=%d item=%s(id=%d) misc=%d",
-            step, eot_p, ent_name, ent_id,
-            action["xy"][0], action["xy"][1],
-            action["direction"], item_name, item_id, action["misc"],
+            step,
+            eot_p,
+            ent_name,
+            ent_id,
+            action["xy"][0],
+            action["xy"][1],
+            action["direction"],
+            item_name,
+            item_id,
+            action["misc"],
         )
         if not _apply_placement(obs, action):
             log.info("  → empty/no-op placement, stopping")
@@ -402,9 +437,14 @@ def poll_loop(
 def handle_request(
     req: dict, agent: AgentCNN, rcon: RconClient, *, max_steps: int, device
 ):
-    log.info("Request %s: grid=%dx%d, %d sources, %d sinks",
-             req["request_id"], req["grid_size"], req["grid_size"],
-             len(req.get("sources", [])), len(req.get("sinks", [])))
+    log.info(
+        "Request %s: grid=%dx%d, %d sources, %d sinks",
+        req["request_id"],
+        req["grid_size"],
+        req["grid_size"],
+        len(req.get("sources", [])),
+        len(req.get("sinks", [])),
+    )
 
     t0 = time.time()
     obs_CWH, stats = run_inference(agent, req, max_steps=max_steps, device=device)
@@ -414,8 +454,8 @@ def handle_request(
     # results, where the player would otherwise see a blank blueprint with
     # no clue why.
     src_id, snk_id = _source_id(), _sink_id()
-    placed_count = 0   # model-placed entities (belts, inserters, etc.)
-    marker_count = 0   # source/sink markers (rendered as chests)
+    placed_count = 0  # model-placed entities (belts, inserters, etc.)
+    marker_count = 0  # source/sink markers (rendered as chests)
     for xx in range(obs_CWH.shape[1]):
         for yy in range(obs_CWH.shape[2]):
             eid = int(obs_CWH[Channel.ENTITIES.value, xx, yy])
@@ -441,8 +481,10 @@ def handle_request(
         item_tag = ""
         if p["item_name"] not in ("empty", "?", ""):
             item_tag = " [item=" + p["item_name"].replace("_", "-") + "]"
-        return (f"{p['step']}: {ent_tag} ({p['x']},{p['y']}) "
-                f"{dir_label}{_MISC_LABEL.get(p['misc'], '')}{item_tag}")
+        return (
+            f"{p['step']}: {ent_tag} ({p['x']},{p['y']}) "
+            f"{dir_label}{_MISC_LABEL.get(p['misc'], '')}{item_tag}"
+        )
 
     placements = stats.get("placements", [])
     # Description has a hard ~500 char limit in Factorio 2.0; truncation
@@ -465,8 +507,10 @@ def handle_request(
         trace_lines.append(line)
         used += len(line) + 1
 
-    label = (f"Factorion: {total_entities} entities "
-             f"({placed_count} placed + {marker_count} markers)")
+    label = (
+        f"Factorion: {total_entities} entities "
+        f"({placed_count} placed + {marker_count} markers)"
+    )
     description_parts = [
         f"sources={len(req.get('sources', []))} "
         f"sinks={len(req.get('sinks', []))} "
@@ -475,24 +519,35 @@ def handle_request(
     ] + trace_lines
     description = "\n".join(description_parts)
     bp_str = world_tensor_to_blueprint_string(
-        obs_CWH, label=label, description=description,
+        obs_CWH,
+        label=label,
+        description=description,
     )
-    log.info("Inference %.2fs; blueprint %d chars  label=%r",
-             time.time() - t0, len(bp_str), label)
+    log.info(
+        "Inference %.2fs; blueprint %d chars  label=%r",
+        time.time() - t0,
+        len(bp_str),
+        label,
+    )
 
     # Decode the blueprint so we can log what's actually inside (entity
     # counts, names, positions) — easier than eyeballing the b64.
     try:
         from factorion import b64_to_dict
+
         decoded = b64_to_dict(bp_str)
         entities_list = decoded.get("blueprint", {}).get("entities", [])
         log.info("  blueprint contains %d entities:", len(entities_list))
         for e in entities_list[:40]:  # cap to 40 to avoid log spam
-            log.info("    %s @ (%s,%s) dir=%s%s%s",
-                     e.get("name"), e["position"]["x"], e["position"]["y"],
-                     e.get("direction", "-"),
-                     " recipe=" + e["recipe"] if "recipe" in e else "",
-                     " type=" + e["type"] if "type" in e else "")
+            log.info(
+                "    %s @ (%s,%s) dir=%s%s%s",
+                e.get("name"),
+                e["position"]["x"],
+                e["position"]["y"],
+                e.get("direction", "-"),
+                " recipe=" + e["recipe"] if "recipe" in e else "",
+                " type=" + e["type"] if "type" in e else "",
+            )
         if len(entities_list) > 40:
             log.info("    ... and %d more", len(entities_list) - 40)
         log.info("  blueprint string: %s", bp_str)
@@ -501,8 +556,10 @@ def handle_request(
 
     # Single-quoted Lua string: blueprint b64 alphabet [A-Za-z0-9+/=] plus
     # our "0" version prefix contains no single quotes, so this is safe.
-    cmd = "/silent-command remote.call('factorion','deliver_blueprint','{}','{}')".format(
-        req["request_id"], bp_str
+    cmd = (
+        "/silent-command remote.call('factorion','deliver_blueprint','{}','{}')".format(
+            req["request_id"], bp_str
+        )
     )
     resp = rcon.exec(cmd)
     if resp:
@@ -515,10 +572,15 @@ def handle_request(
 # CLI.
 # --------------------------------------------------------------------------- #
 
+
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--checkpoint", required=True, type=Path,
-                    help="Path to a torch.save'd AgentCNN state_dict.")
+    ap.add_argument(
+        "--checkpoint",
+        required=True,
+        type=Path,
+        help="Path to a torch.save'd AgentCNN state_dict.",
+    )
     ap.add_argument("--rcon-host", default="127.0.0.1")
     ap.add_argument("--rcon-port", type=int, default=27015)
     ap.add_argument("--rcon-password", default="factorion")
@@ -526,8 +588,12 @@ def main():
     ap.add_argument("--chan1", type=int, default=32)
     ap.add_argument("--chan2", type=int, default=64)
     ap.add_argument("--chan3", type=int, default=64)
-    ap.add_argument("--max-steps", type=int, default=64,
-                    help="Iterative inference budget per request.")
+    ap.add_argument(
+        "--max-steps",
+        type=int,
+        default=64,
+        help="Iterative inference budget per request.",
+    )
     ap.add_argument("--device", default="cpu", choices=["cpu", "cuda", "mps"])
     ap.add_argument("--log-level", default="INFO")
     args = ap.parse_args()
@@ -543,7 +609,9 @@ def main():
     sidecar = Hyperparams.from_json_sibling(args.checkpoint)
     defaults = Hyperparams()
     hp = Hyperparams(
-        grid_size=args.grid_size if args.grid_size != defaults.grid_size else sidecar.grid_size,
+        grid_size=args.grid_size
+        if args.grid_size != defaults.grid_size
+        else sidecar.grid_size,
         chan1=args.chan1 if args.chan1 != defaults.chan1 else sidecar.chan1,
         chan2=args.chan2 if args.chan2 != defaults.chan2 else sidecar.chan2,
         chan3=args.chan3 if args.chan3 != defaults.chan3 else sidecar.chan3,
@@ -558,13 +626,21 @@ def main():
         # game yet" rather than a fatal error.
         try:
             r = rcon.exec("/silent-command rcon.print(remote.call('factorion','ping'))")
-            log.info("Mod ping: %s", (r or "(no response — load a save with factorion enabled)").strip())
+            log.info(
+                "Mod ping: %s",
+                (r or "(no response — load a save with factorion enabled)").strip(),
+            )
         except Exception:
-            log.warning("Could not ping factorion mod — is the save loaded with the mod enabled?")
+            log.warning(
+                "Could not ping factorion mod — is the save loaded with the mod enabled?"
+            )
 
         poll_loop(
-            agent, rcon,
-            poll_interval=0.25, max_steps=args.max_steps, device=device,
+            agent,
+            rcon,
+            poll_interval=0.25,
+            max_steps=args.max_steps,
+            device=device,
         )
 
 

--- a/ppo.py
+++ b/ppo.py
@@ -44,6 +44,7 @@ for _ in range(moving_average_length):
     end_of_episode_thputs.append(0)
 min_belts_thoughputs = [deque(maxlen=100) for _ in range(10)]
 
+
 @dataclass
 class Args:
     exp_name: str = os.path.basename(__file__)[: -len(".py")]
@@ -129,14 +130,21 @@ class Args:
     """The epsilon parameter for Adam"""
     weight_decay: float = 0.0
     """L2 weight decay for the Adam optimiser."""
-    chan1: int = 48
-    """Number of channels in the first layer of the CNN encoder"""
-    chan2: int = 48
-    """Number of channels in the second layer of the CNN encoder"""
-    chan3: int = 48
-    """Number of channels in the third layer of the CNN encoder"""
-    flat_dim: int = 128
-    """Output size of the fully connected layer after the encoder"""
+    # CNN encoder width per layer slot. The encoder uses every slot with
+    # positive width, in order; a slot of 0 drops that layer. Exposing depth +
+    # per-layer width as independent numeric slots (rather than one categorical
+    # "64,64,64" string) lets a W&B Bayesian sweep optimise the architecture
+    # ordinally. RF = 1 + n_layers * (kernel_size - 1).
+    layer1: int = 48
+    layer2: int = 48
+    layer3: int = 48
+    layer4: int = 0
+    layer5: int = 0
+    layer6: int = 0
+    layer7: int = 0
+    layer8: int = 0
+    kernel_size: int = 3
+    """CNN conv kernel size (odd); padding pinned to kernel_size // 2 ("same")"""
     tile_head_std: float = 0.06503
     """Initialization std for the tile selection conv head (smaller = more uniform initial exploration)"""
     dropout: float = 0.0
@@ -164,43 +172,57 @@ class Args:
 def make_env(env_id, idx, capture_video, size, run_name):
     def thunk():
         kwargs = {"render_mode": "rgb_array"} if capture_video else {}
-        kwargs.update({'size': size, 'max_steps': 2*size, 'idx': idx})
+        kwargs.update({"size": size, "max_steps": 2 * size, "idx": idx})
         # kwargs.update({'size': size, 'max_steps': 6})
         env = gym.make(env_id, **kwargs)
         if capture_video:
-            env = gym.wrappers.RecordVideo(env, f"videos/{run_name}/env_{idx}", episode_trigger=lambda e: (e+1) % 10 == 0)
+            env = gym.wrappers.RecordVideo(
+                env,
+                f"videos/{run_name}/env_{idx}",
+                episode_trigger=lambda e: (e + 1) % 10 == 0,
+            )
             # env = gym.wrappers.RecordVideo(env, f"videos/{run_name}/env_{idx}", episode_trigger=lambda _: True)
         env = gym.wrappers.RecordEpisodeStatistics(env)
         return env
+
     return thunk
+
 
 def layer_init(layer, std=np.sqrt(2), bias_const=0.0):
     torch.nn.init.orthogonal_(layer.weight, std)
     torch.nn.init.constant_(layer.bias, bias_const)
     return layer
 
+
 mapping = {
     # transport belt
-    (1, 1): '↑',
-    (1, 2): '→',
-    (1, 3): '↓',
-    (1, 4): '←',
+    (1, 1): "↑",
+    (1, 2): "→",
+    (1, 3): "↓",
+    (1, 4): "←",
     # sink
-    (5, 1):  '📥',
-    (5, 2):  '📥',
-    (5, 3):  '📥',
-    (5, 4): '📥',
+    (5, 1): "📥",
+    (5, 2): "📥",
+    (5, 3): "📥",
+    (5, 4): "📥",
     # source
-    (6, 1):  '📤',
-    (6, 2):  '📤',
-    (6, 3):  '📤',
-    (6, 4): '📤',
+    (6, 1): "📤",
+    (6, 2): "📤",
+    (6, 3): "📤",
+    (6, 4): "📤",
 }
 
+
 def get_pretty_format(tensor, entity_dir_map):
-    assert isinstance(tensor, torch.Tensor), f"Input must be a torch tensor but is {tensor}"
-    assert tensor.ndim == 3 and tensor.shape[0] >= 2, f"Tensor must have shape (2+, W, H) but has shape {tensor.shape}"
-    assert tensor.shape[1] == tensor.shape[2], f"Expected world to be square, but is of shape {tensor.shape}"
+    assert isinstance(tensor, torch.Tensor), (
+        f"Input must be a torch tensor but is {tensor}"
+    )
+    assert tensor.ndim == 3 and tensor.shape[0] >= 2, (
+        f"Tensor must have shape (2+, W, H) but has shape {tensor.shape}"
+    )
+    assert tensor.shape[1] == tensor.shape[2], (
+        f"Expected world to be square, but is of shape {tensor.shape}"
+    )
     # assert torch.is_integral(tensor), "Tensor must contain integers"
 
     _, W, H = tensor.shape
@@ -216,9 +238,9 @@ def get_pretty_format(tensor, entity_dir_map):
             ent = int(entities[x, y])
             direc = int(directions[x, y])
             char = entity_dir_map.get((ent, direc), str(ent))
-            if char == '0':
-                char = '.'
-            if char in ('📤', '📥'):
+            if char == "0":
+                char = "."
+            if char in ("📤", "📥"):
                 line.append(f"{char:^2}")
             else:
                 line.append(f"{char:^3}")
@@ -265,17 +287,18 @@ class FactorioEnv(gym.Env):
             dtype=int,
         )
 
-
-        self.action_space = gym.spaces.Dict({
-            "xy": gym.spaces.Box(low=0, high=self.size, shape=(2,), dtype=int),
-            "entity": gym.spaces.Discrete(len(entities)),
-            "direction": gym.spaces.Discrete(len(Direction)),
-            "item": gym.spaces.Discrete(len(items)),
-            "misc": gym.spaces.Discrete(len(Misc))
-        })
+        self.action_space = gym.spaces.Dict(
+            {
+                "xy": gym.spaces.Box(low=0, high=self.size, shape=(2,), dtype=int),
+                "entity": gym.spaces.Discrete(len(entities)),
+                "direction": gym.spaces.Discrete(len(Direction)),
+                "item": gym.spaces.Discrete(len(items)),
+                "misc": gym.spaces.Discrete(len(Misc)),
+            }
+        )
         # Cache source/sink IDs (non-placeable prototypes)
-        self._source_id = str2ent('stack_inserter').value
-        self._sink_id = str2ent('bulk_inserter').value
+        self._source_id = str2ent("stack_inserter").value
+        self._sink_id = str2ent("bulk_inserter").value
         self._reset_options = options if options is not None else {}
 
         self.steps = 0
@@ -286,13 +309,13 @@ class FactorioEnv(gym.Env):
     def _get_info(self):
         return {
             # 'num_missing_entities': self.num_missing_entities,
-            'throughput': self._throughput,
-            'frac_reachable': self._frac_reachable,
-            'frac_hallucin': self._frac_hallucin,
-            'final_dir_reward': self._final_dir_reward,
-            'material_cost': self._material_cost,
-            'reward': self._reward,
-            'cum_reward': self._cum_reward,
+            "throughput": self._throughput,
+            "frac_reachable": self._frac_reachable,
+            "frac_hallucin": self._frac_hallucin,
+            "final_dir_reward": self._final_dir_reward,
+            "material_cost": self._material_cost,
+            "reward": self._reward,
+            "cum_reward": self._cum_reward,
         }
 
     def _compute_solution_match(self):
@@ -303,7 +326,7 @@ class FactorioEnv(gym.Env):
         orig_dir = self._solved_world_CWH[Channel.DIRECTION.value]
         curr_dir = self._world_CWH[Channel.DIRECTION.value]
 
-        mask = (orig_ent != 0)
+        mask = orig_ent != 0
         n = mask.sum().item()
         if n == 0:
             return 1.0, 1.0, 1.0
@@ -333,7 +356,9 @@ class FactorioEnv(gym.Env):
         self._terminated = False
         self._truncated = False
         self.max_entities = 2
-        self._num_missing_entities = self._reset_options['num_missing_entities'] # TODO also change max_steps in tandem
+        self._num_missing_entities = self._reset_options[
+            "num_missing_entities"
+        ]  # TODO also change max_steps in tandem
 
         self.actions = []
         # Lesson kind is settable per-reset. Default (omitted or None) is
@@ -348,14 +373,16 @@ class FactorioEnv(gym.Env):
         # itself for a given (size, kind, seed); for the random-kind
         # path we just sample a different kind, since they have very
         # different rejection rates on small grids.
-        kind_opt = self._reset_options.get('kind', None)
+        kind_opt = self._reset_options.get("kind", None)
         factory = None
         if kind_opt is None:
             kinds_list = list(LessonKind)
             for _ in range(16):
                 kind = kinds_list[int(self.np_random.integers(0, len(kinds_list)))]
                 factory = build_factory(
-                    size=self.size, kind=kind, seed=self._seed,
+                    size=self.size,
+                    kind=kind,
+                    seed=self._seed,
                 )
                 if factory is not None:
                     break
@@ -367,12 +394,13 @@ class FactorioEnv(gym.Env):
         else:
             kind = kind_opt
             factory = build_factory(
-                size=self.size, kind=kind, seed=self._seed,
+                size=self.size,
+                kind=kind,
+                seed=self._seed,
             )
             if factory is None:
                 raise RuntimeError(
-                    f"build_factory returned None for kind={kind} "
-                    f"seed={self._seed}"
+                    f"build_factory returned None for kind={kind} seed={self._seed}"
                 )
         self._solved_world_CWH = factory.world_CWH
         self._world_CWH, min_entities_required = blank_entities(
@@ -393,10 +421,13 @@ class FactorioEnv(gym.Env):
         item_id = action["item"]
         misc = action["misc"]
 
-
         # (x, y), entity_id, direc = action
-        assert 0 <= x < self._world_CWH.shape[1], f"x={x} out of bounds [0, {self._world_CWH.shape[1]})"
-        assert 0 <= y < self._world_CWH.shape[2], f"y={y} out of bounds [0, {self._world_CWH.shape[2]})"
+        assert 0 <= x < self._world_CWH.shape[1], (
+            f"x={x} out of bounds [0, {self._world_CWH.shape[1]})"
+        )
+        assert 0 <= y < self._world_CWH.shape[2], (
+            f"y={y} out of bounds [0, {self._world_CWH.shape[2]})"
+        )
         source_id = self._source_id
         sink_id = self._sink_id
 
@@ -406,16 +437,16 @@ class FactorioEnv(gym.Env):
         self.actions.append(None)
         action_is_invalid = False
         invalid_reason = {
-            'placed_on_masked_tile': False,
-            'replaced_source_or_sink': False,
-            'placed_source_or_sink': False,
-            'place_asm_mach_wo_recipe': False,
-            'placement_wo_direction': False,
-            'direction_wo_entity': False,
-            'ug_belt_wo_up_or_down': False,
-            'placement_with_unneeded_misc': False,
-            'too_wide': False,
-            'too_tall': False,
+            "placed_on_masked_tile": False,
+            "replaced_source_or_sink": False,
+            "placed_source_or_sink": False,
+            "place_asm_mach_wo_recipe": False,
+            "placement_wo_direction": False,
+            "direction_wo_entity": False,
+            "ug_belt_wo_up_or_down": False,
+            "placement_with_unneeded_misc": False,
+            "too_wide": False,
+            "too_tall": False,
         }
 
         # Check that the action is actually valid
@@ -427,32 +458,42 @@ class FactorioEnv(gym.Env):
             action_is_invalid = True
         elif entity_id in (source_id, sink_id):
             # agent tried to place a source or sink
-            invalid_reason['placed_source_or_sink'] = True
+            invalid_reason["placed_source_or_sink"] = True
             action_is_invalid = True
-        elif entity_id == str2ent('assembling_machine_1').value and item_id == str2item('empty'):
+        elif entity_id == str2ent("assembling_machine_1").value and item_id == str2item(
+            "empty"
+        ):
             # Model is trying to place an assembling machine without a recipe
-            invalid_reason['place_asm_mach_wo_recipe'] = True
+            invalid_reason["place_asm_mach_wo_recipe"] = True
             action_is_invalid = True
             pass
-        elif entity_id not in (str2ent('empty').value, str2ent('assembling_machine_1').value) and direc == Direction.NONE.value:
+        elif (
+            entity_id
+            not in (str2ent("empty").value, str2ent("assembling_machine_1").value)
+            and direc == Direction.NONE.value
+        ):
             # Model is trying to put a thing without giving a direction
-            invalid_reason['placement_wo_direction'] = True
+            invalid_reason["placement_wo_direction"] = True
             action_is_invalid = True
             pass
-        elif entity_id == str2ent('empty').value and direc != Direction.NONE.value:
+        elif entity_id == str2ent("empty").value and direc != Direction.NONE.value:
             # Model is trying to put a thing without giving a direction
-            invalid_reason['direction_wo_entity'] = True
+            invalid_reason["direction_wo_entity"] = True
             action_is_invalid = True
             pass
-        elif (misc == Misc.NONE.value) and (entity_id == str2ent('underground_belt').value):
+        elif (misc == Misc.NONE.value) and (
+            entity_id == str2ent("underground_belt").value
+        ):
             # model is trying to place an underground belt without giving a down/up
-            invalid_reason['ug_belt_wo_up_or_down'] = True
+            invalid_reason["ug_belt_wo_up_or_down"] = True
             action_is_invalid = True
             pass
-        elif (misc != Misc.NONE.value) and (entity_id != str2ent('underground_belt').value):
+        elif (misc != Misc.NONE.value) and (
+            entity_id != str2ent("underground_belt").value
+        ):
             # model is trying to place a thing that doesn't need a Misc but
             # still giving it a Misc
-            invalid_reason['placement_with_unneeded_misc'] = True
+            invalid_reason["placement_with_unneeded_misc"] = True
             action_is_invalid = True
             pass
         else:
@@ -461,7 +502,9 @@ class FactorioEnv(gym.Env):
             # rotation correctly; the previous x+width/y+height bounds
             # checks were direction-agnostic and wrong for rotated splitters.
             proto = entities[entity_id]
-            tiles_list = factorion_rs.py_entity_tiles(x, y, direc, proto.width, proto.height)
+            tiles_list = factorion_rs.py_entity_tiles(
+                x, y, direc, proto.width, proto.height
+            )
             if tiles_list is None:
                 tiles_list = [(x, y)]
             tiles_list = [tuple(t) for t in tiles_list]
@@ -475,20 +518,21 @@ class FactorioEnv(gym.Env):
                 for tx, ty in tiles_list
             )
             if out_of_bounds:
-                invalid_reason['too_wide'] = True
+                invalid_reason["too_wide"] = True
                 action_is_invalid = True
             elif any(
                 self._world_CWH[Channel.FOOTPRINT.value, tx, ty]
-                    == Footprint.UNAVAILABLE.value
+                == Footprint.UNAVAILABLE.value
                 for tx, ty in tiles_list
             ):
-                invalid_reason['placed_on_masked_tile'] = True
+                invalid_reason["placed_on_masked_tile"] = True
                 action_is_invalid = True
             elif any(
-                int(self._world_CWH[Channel.ENTITIES.value, tx, ty]) in (source_id, sink_id)
+                int(self._world_CWH[Channel.ENTITIES.value, tx, ty])
+                in (source_id, sink_id)
                 for tx, ty in tiles_list
             ):
-                invalid_reason['replaced_source_or_sink'] = True
+                invalid_reason["replaced_source_or_sink"] = True
                 action_is_invalid = True
             else:
                 action_is_invalid = False
@@ -502,16 +546,18 @@ class FactorioEnv(gym.Env):
                 self._world_CWH[Channel.ITEMS.value, x, y] = item_id
                 self._world_CWH[Channel.MISC.value, x, y] = misc
                 self.actions[-1] = {
-                    'entity': entities[entity_id].name,
-                    'xy': (x, y),
-                    'direction': Direction(direc),
-                    'item': items[item_id].name,
-                    'misc': Misc(misc),
+                    "entity": entities[entity_id].name,
+                    "xy": (x, y),
+                    "direction": Direction(direc),
+                    "item": items[item_id].name,
+                    "misc": Misc(misc),
                 }
 
         self.invalid_actions += 1 if action_is_invalid else 0
 
-        throughput, num_unreachable = factorion_rs.simulate_throughput(self._world_CWH.permute(1, 2, 0).to(torch.int64).numpy())
+        throughput, num_unreachable = factorion_rs.simulate_throughput(
+            self._world_CWH.permute(1, 2, 0).to(torch.int64).numpy()
+        )
         # TODO don't always divide by 15
         throughput /= 15.0
 
@@ -521,7 +567,11 @@ class FactorioEnv(gym.Env):
         # NOTE: weird bug with num_unreachable calculations, not planning on
         # fixing any time super soon. really the calculation should be to
         # calculate frac_reachable directly, not go via frac_unreachable
-        frac_reachable = 0 if num_entities == 2 else max(0, 1.0 - (float(num_unreachable) / (num_entities - 2)))
+        frac_reachable = (
+            0
+            if num_entities == 2
+            else max(0, 1.0 - (float(num_unreachable) / (num_entities - 2)))
+        )
         frac_hallucin = 0
 
         # Give some small reward for having the belt be the right direction.
@@ -529,12 +579,14 @@ class FactorioEnv(gym.Env):
         # MOVE_ONE_ITEM case). Other lesson kinds (e.g. SPLITTER_SPLIT)
         # place multiple sinks or none, so this shaping term gets zeroed
         # instead of asserting.
-        sink_locs = torch.where(self._world_CWH[Channel.ENTITIES.value] == self._sink_id)
+        sink_locs = torch.where(
+            self._world_CWH[Channel.ENTITIES.value] == self._sink_id
+        )
         C, W, H = self._world_CWH.shape
         if len(sink_locs[0]) == 1:
             w_sink, h_sink = sink_locs[0][0], sink_locs[1][0]
-            w_belt = torch.clamp(w_sink, 1, W-2)
-            h_belt = torch.clamp(h_sink, 1, H-2)
+            w_belt = torch.clamp(w_sink, 1, W - 2)
+            h_belt = torch.clamp(h_sink, 1, H - 2)
             final_belt_dir = self._world_CWH[Channel.DIRECTION.value, w_belt, h_belt]
             sink_dir = self._world_CWH[Channel.DIRECTION.value, w_sink, h_sink]
             final_dir_reward = 1.0 if final_belt_dir == sink_dir else 0.0
@@ -542,9 +594,21 @@ class FactorioEnv(gym.Env):
             final_dir_reward = 0.0
 
         material_cost = (
-            1.0 * (self._world_CWH[Channel.DIRECTION.value] == str2ent('transport_belt').value).sum()
-            + 1.5 * (self._world_CWH[Channel.DIRECTION.value] == str2ent('underground_belt').value).sum()
-            + 2.0 * (self._world_CWH[Channel.DIRECTION.value] == str2ent('assembling_machine_1').value).sum()
+            1.0
+            * (
+                self._world_CWH[Channel.DIRECTION.value]
+                == str2ent("transport_belt").value
+            ).sum()
+            + 1.5
+            * (
+                self._world_CWH[Channel.DIRECTION.value]
+                == str2ent("underground_belt").value
+            ).sum()
+            + 2.0
+            * (
+                self._world_CWH[Channel.DIRECTION.value]
+                == str2ent("assembling_machine_1").value
+            ).sum()
         )
 
         # ── Diagnostic tile-match metrics (for logging, NOT used in reward) ──
@@ -553,11 +617,13 @@ class FactorioEnv(gym.Env):
         orig_dir = self._solved_world_CWH[Channel.DIRECTION.value]
         curr_dir = self._world_CWH[Channel.DIRECTION.value]
 
-        solution_nonempty = (orig_ent != 0)
-        current_nonempty = (curr_ent != 0)
+        solution_nonempty = orig_ent != 0
+        current_nonempty = curr_ent != 0
         num_solution_nonempty = solution_nonempty.sum().item()
         if num_solution_nonempty > 0:
-            tile_match_location = (solution_nonempty & current_nonempty).sum().item() / num_solution_nonempty
+            tile_match_location = (
+                solution_nonempty & current_nonempty
+            ).sum().item() / num_solution_nonempty
         else:
             tile_match_location = 1.0
         tile_match_entity = (curr_ent == orig_ent).float().mean().item()
@@ -565,20 +631,24 @@ class FactorioEnv(gym.Env):
 
         # ── Normalized weighted reward (throughput + validity only) ──
         reward_components = {
-            'throughput': {
-                'coeff': Args.coeff_throughput if 'args' not in locals() else args.coeff_throughput,
-                'value': throughput,
+            "throughput": {
+                "coeff": Args.coeff_throughput
+                if "args" not in locals()
+                else args.coeff_throughput,
+                "value": throughput,
             },
-            'validity': {
-                'coeff': Args.coeff_validity if 'args' not in locals() else args.coeff_validity,
-                'value': 0 if action_is_invalid else 1,
+            "validity": {
+                "coeff": Args.coeff_validity
+                if "args" not in locals()
+                else args.coeff_validity,
+                "value": 0 if action_is_invalid else 1,
             },
         }
         pre_reward = 0.0
         normalisation = 0.0
         for name, item in reward_components.items():
-            pre_reward += item['coeff'] * item['value']
-            normalisation += item['coeff']
+            pre_reward += item["coeff"] * item["value"]
+            normalisation += item["coeff"]
 
         pre_reward /= normalisation
 
@@ -590,9 +660,21 @@ class FactorioEnv(gym.Env):
         dir_delta = curr_match[2] - self._prev_match[2]
         self._prev_match = curr_match
 
-        coeff_loc = Args.coeff_shaping_location if 'args' not in locals() else args.coeff_shaping_location
-        coeff_ent = Args.coeff_shaping_entity if 'args' not in locals() else args.coeff_shaping_entity
-        coeff_dir = Args.coeff_shaping_direction if 'args' not in locals() else args.coeff_shaping_direction
+        coeff_loc = (
+            Args.coeff_shaping_location
+            if "args" not in locals()
+            else args.coeff_shaping_location
+        )
+        coeff_ent = (
+            Args.coeff_shaping_entity
+            if "args" not in locals()
+            else args.coeff_shaping_entity
+        )
+        coeff_dir = (
+            Args.coeff_shaping_direction
+            if "args" not in locals()
+            else args.coeff_shaping_direction
+        )
 
         pre_reward += coeff_loc * loc_delta
         pre_reward += coeff_ent * ent_delta
@@ -622,33 +704,37 @@ class FactorioEnv(gym.Env):
         observation = self._get_obs()
         info = self._get_info()
         if terminated or truncated:
-            info.update({ 'steps_taken': self.steps })
+            info.update({"steps_taken": self.steps})
 
-        num_placed_entities = len([a for a in self.actions if a is not None and a['entity'] != 'empty'])
+        num_placed_entities = len(
+            [a for a in self.actions if a is not None and a["entity"] != "empty"]
+        )
 
-        info.update({
-            'throughput': throughput,
-            'frac_reachable': frac_reachable,
-            'frac_hallucin': frac_hallucin,
-            'final_dir_reward': final_dir_reward,
-            'material_cost': material_cost,
-            'completion_bonus': self.max_steps - self.steps,
-            'min_entities_required': self.min_entities_required,
-            'num_entities': num_entities,
-            'num_placed_entities': num_placed_entities,
-            'frac_invalid_actions': self.invalid_actions / self.max_steps,
-            'max_entities': self.max_entities,
-            'invalid_reason': invalid_reason,
-            'tile_match_location': tile_match_location,
-            'tile_match_entity': tile_match_entity,
-            'tile_match_direction': tile_match_direction,
-            'shaping_location_match': curr_match[0],
-            'shaping_entity_match': curr_match[1],
-            'shaping_direction_match': curr_match[2],
-            'shaping_location_delta': loc_delta,
-            'shaping_entity_delta': ent_delta,
-            'shaping_direction_delta': dir_delta,
-        })
+        info.update(
+            {
+                "throughput": throughput,
+                "frac_reachable": frac_reachable,
+                "frac_hallucin": frac_hallucin,
+                "final_dir_reward": final_dir_reward,
+                "material_cost": material_cost,
+                "completion_bonus": self.max_steps - self.steps,
+                "min_entities_required": self.min_entities_required,
+                "num_entities": num_entities,
+                "num_placed_entities": num_placed_entities,
+                "frac_invalid_actions": self.invalid_actions / self.max_steps,
+                "max_entities": self.max_entities,
+                "invalid_reason": invalid_reason,
+                "tile_match_location": tile_match_location,
+                "tile_match_entity": tile_match_entity,
+                "tile_match_direction": tile_match_direction,
+                "shaping_location_match": curr_match[0],
+                "shaping_entity_match": curr_match[1],
+                "shaping_direction_match": curr_match[2],
+                "shaping_location_delta": loc_delta,
+                "shaping_entity_delta": ent_delta,
+                "shaping_direction_delta": dir_delta,
+            }
+        )
 
         self._cum_reward += reward
         self.steps += 1
@@ -661,10 +747,10 @@ class FactorioEnv(gym.Env):
         Returns an RGB uint8 array compatible with Gymnasium video wrappers.
         """
         # ------------------- constants -------------------
-        ICON_DIR       = Path("factorio-icons")   # where all *.png live
-        CELL_PX        = 64                       # tile size in pixels
-        MINI_PX        = 18                       # size for arrow + recipe icon
-        GRID_COLOR     = (0, 0, 0)                # black grid lines
+        ICON_DIR = Path("factorio-icons")  # where all *.png live
+        CELL_PX = 64  # tile size in pixels
+        MINI_PX = 18  # size for arrow + recipe icon
+        GRID_COLOR = (0, 0, 0)  # black grid lines
 
         # ---------------- lazy one-time setup ------------
         if not hasattr(self, "_render_cache"):
@@ -675,7 +761,13 @@ class FactorioEnv(gym.Env):
             for ent_id, ent in entities.items():
                 p = ICON_DIR / f"{ent.name}.png"
                 if p.exists():
-                    img = Image.open(p).convert("RGBA").resize(((CELL_PX // 10) * 8, (CELL_PX // 10) * 8), Image.BICUBIC)
+                    img = (
+                        Image.open(p)
+                        .convert("RGBA")
+                        .resize(
+                            ((CELL_PX // 10) * 8, (CELL_PX // 10) * 8), Image.BICUBIC
+                        )
+                    )
                     self._render_cache["entity"][ent_id] = img
 
             # item (recipe) icons (resized to MINI_PX)
@@ -684,7 +776,11 @@ class FactorioEnv(gym.Env):
                     continue
                 p = ICON_DIR / f"{itm.name}.png"
                 if p.exists():
-                    img = Image.open(p).convert("RGBA").resize((MINI_PX, MINI_PX), Image.BICUBIC)
+                    img = (
+                        Image.open(p)
+                        .convert("RGBA")
+                        .resize((MINI_PX, MINI_PX), Image.BICUBIC)
+                    )
                     self._render_cache["item"][itm_id] = img
 
             # tiny triangular arrow, rotated for each cardinal direction
@@ -695,41 +791,51 @@ class FactorioEnv(gym.Env):
             shaft_x0 = (MINI_PX - shaft_w) // 2
             draw.rectangle(
                 [shaft_x0, MINI_PX // 3, shaft_x0 + shaft_w, MINI_PX - 1],
-                fill=(0, 0, 0, 255)
+                fill=(0, 0, 0, 255),
             )
             # head: triangle at the top
             draw.polygon(
                 [
-                    (MINI_PX // 2, 0),           # tip
-                    (shaft_x0 + shaft_w*4, MINI_PX // 3),
-                    (shaft_x0 - shaft_w*4, MINI_PX // 3),
+                    (MINI_PX // 2, 0),  # tip
+                    (shaft_x0 + shaft_w * 4, MINI_PX // 3),
+                    (shaft_x0 - shaft_w * 4, MINI_PX // 3),
                 ],
-                fill=(0, 0, 0, 255)
+                fill=(0, 0, 0, 255),
             )
             # cache rotations for each cardinal direction
             self._render_cache["arrow"][Direction.NORTH.value] = base
-            self._render_cache["arrow"][Direction.EAST.value]  = base.rotate(-90, expand=True)
-            self._render_cache["arrow"][Direction.SOUTH.value] = base.rotate(180, expand=True)
-            self._render_cache["arrow"][Direction.WEST.value]  = base.rotate(90,  expand=True)
+            self._render_cache["arrow"][Direction.EAST.value] = base.rotate(
+                -90, expand=True
+            )
+            self._render_cache["arrow"][Direction.SOUTH.value] = base.rotate(
+                180, expand=True
+            )
+            self._render_cache["arrow"][Direction.WEST.value] = base.rotate(
+                90, expand=True
+            )
 
             # default font for fallback label
             self._render_cache["font"] = ImageFont.load_default()
 
         cache = self._render_cache
-        ENT, DIR, ITEM = Channel.ENTITIES.value, Channel.DIRECTION.value, Channel.ITEMS.value
+        ENT, DIR, ITEM = (
+            Channel.ENTITIES.value,
+            Channel.DIRECTION.value,
+            Channel.ITEMS.value,
+        )
 
         # ---------------- canvas -------------------------
-        HUD_PX = 32*4                                     # height of stats strip
+        HUD_PX = 32 * 4  # height of stats strip
         canvas_w = canvas_h = self.size * CELL_PX
         canvas = Image.new("RGB", (canvas_w, canvas_h + HUD_PX), (255, 255, 255))
-        draw   = ImageDraw.Draw(canvas)
+        draw = ImageDraw.Draw(canvas)
 
-        ent_layer  = self._world_CWH[ENT].cpu().numpy()
-        dir_layer  = self._world_CWH[DIR].cpu().numpy()
+        ent_layer = self._world_CWH[ENT].cpu().numpy()
+        dir_layer = self._world_CWH[DIR].cpu().numpy()
         item_layer = self._world_CWH[ITEM].cpu().numpy()
 
-        for gx in range(self.size):          # grid row
-            for gy in range(self.size):      # grid col
+        for gx in range(self.size):  # grid row
+            for gy in range(self.size):  # grid col
                 x0, y0 = gx * CELL_PX, gy * CELL_PX
                 x1, y1 = x0 + CELL_PX, y0 + CELL_PX
                 draw.rectangle([x0, y0, x1, y1], outline=GRID_COLOR, width=1)
@@ -737,21 +843,26 @@ class FactorioEnv(gym.Env):
                 ent_id = int(ent_layer[gx, gy])
                 sprite = cache["entity"].get(ent_id)
                 if sprite is not None:
-                    canvas.paste(sprite, (x0 + CELL_PX//10, y0 + CELL_PX//10), sprite)
+                    canvas.paste(
+                        sprite, (x0 + CELL_PX // 10, y0 + CELL_PX // 10), sprite
+                    )
                 else:
                     # fallback: draw first letter
                     letter = entities[ent_id].name[0].upper()
-                    font   = cache["font"]
-                    canvas_w, canvas_h   = font.getbbox(letter)[2:]
+                    font = cache["font"]
+                    canvas_w, canvas_h = font.getbbox(letter)[2:]
                     draw.text(
-                        (x0 + (CELL_PX - canvas_w) // 2, y0 + (CELL_PX - canvas_h) // 2),
+                        (
+                            x0 + (CELL_PX - canvas_w) // 2,
+                            y0 + (CELL_PX - canvas_h) // 2,
+                        ),
                         letter,
                         fill=(0, 0, 0),
                         font=font,
                     )
                 # Draw the xy-coords onto the cell
                 text = f"{gx},{gy}"
-                font   = cache["font"]
+                font = cache["font"]
                 draw.text(
                     (x0 + (CELL_PX // 10) * 8, y0 + CELL_PX // 10),
                     text,
@@ -760,13 +871,13 @@ class FactorioEnv(gym.Env):
                 )
 
                 itm_id = int(item_layer[gx, gy])
-                mini   = cache["item"].get(itm_id)
+                mini = cache["item"].get(itm_id)
                 if mini is not None:
                     off = CELL_PX - MINI_PX - 2
                     canvas.paste(mini, (x0 + off, y0 + off), mini)
 
                 dir_id = Direction(dir_layer[gx, gy]).value
-                arrow  = cache["arrow"].get(dir_id)
+                arrow = cache["arrow"].get(dir_id)
                 if arrow is not None:
                     canvas.paste(arrow, (x0 + 2, y0 + 2), arrow)
 
@@ -790,7 +901,9 @@ class FactorioEnv(gym.Env):
         bbox = font.getbbox(lines[0])
         txt_h = bbox[3] - bbox[1]
 
-        draw.rectangle([(0, canvas_h), (canvas_w, canvas_h + HUD_PX)], fill=(230, 230, 230))
+        draw.rectangle(
+            [(0, canvas_h), (canvas_w, canvas_h + HUD_PX)], fill=(230, 230, 230)
+        )
         for i, line in enumerate(lines):
             draw.text(
                 (4, 4 + canvas_h + i * txt_h * 1.25),
@@ -802,8 +915,30 @@ class FactorioEnv(gym.Env):
         return np.asarray(canvas, dtype=np.uint8)
 
 
+NUM_LAYER_SLOTS = 8
+
+
+def layers_from_args(args) -> list[int]:
+    """Compact the ``layer1..layer{NUM_LAYER_SLOTS}`` width slots on an
+    ``Args``/``SFTArgs`` into the CNN encoder's channel list: every slot with
+    positive width becomes one conv layer, in slot order; a zero-width slot is
+    dropped.
+
+    This is what lets a W&B Bayesian sweep tune the encoder's depth *and*
+    per-layer width as independent numeric dimensions (drive a slot toward 0 to
+    remove a layer) instead of an opaque categorical ``"64,64,64"`` string the
+    optimiser can't reason about ordinally."""
+    slots = [getattr(args, f"layer{i}") for i in range(1, NUM_LAYER_SLOTS + 1)]
+    layers = [c for c in slots if c > 0]
+    if not layers:
+        raise ValueError("at least one of layer1..layer8 must have positive width")
+    return layers
+
+
 class AgentCNN(nn.Module):
-    def __init__(self, envs, chan1=32, chan2=64, chan3=64, flat_dim=256, tile_head_std=0.01, dropout=0.0):
+    def __init__(
+        self, envs, layers=(48, 48, 64), kernel_size=3, tile_head_std=0.01, dropout=0.0
+    ):
         super().__init__()
         base_env = envs.envs[0].unwrapped
         self.width = base_env.size
@@ -817,28 +952,52 @@ class AgentCNN(nn.Module):
         self.num_directions = len(Direction)
         self.num_items = len(items)
         self.num_misc = len(Misc)
-        self.chan3 = chan3
 
-        self.encoder = nn.Sequential(
-            layer_init(nn.Conv2d(self.channels, chan1, kernel_size=3, padding=1)),
-            nn.ReLU(),
-            nn.Dropout2d(dropout),
-            layer_init(nn.Conv2d(chan1, chan2, kernel_size=3, padding=1)),
-            nn.ReLU(),
-            nn.Dropout2d(dropout),
-            layer_init(nn.Conv2d(chan2, chan3, kernel_size=3, padding=1)),
-            nn.ReLU(),
-            nn.Dropout2d(dropout),
-        )
+        # Variable-depth conv encoder: one conv layer per entry in `layers`,
+        # that entry giving the layer's channel width. `kernel_size` sets each
+        # layer's receptive field (RF = 1 + len(layers) * (kernel_size - 1));
+        # padding is pinned to kernel_size // 2 so every conv preserves the
+        # W x H spatial dims ("same" convolution). That invariant is
+        # load-bearing: the tile head emits one logit per grid cell and the
+        # per-tile heads index encoded[:, :, x, y], both of which require the
+        # feature map to stay exactly grid-sized.
+        #
+        # `nn.Dropout2d(dropout)` (spatial dropout) trails each ReLU; p=0.0 is a
+        # no-op and dropout is inert in eval(), so the default leaves behaviour
+        # unchanged. Because dropout inserts a non-conv module between convs, the
+        # conv layers no longer sit at encoder.0/2/4 — anything reading conv
+        # weights back from a checkpoint must locate them by shape, not index.
+        if kernel_size % 2 == 0:
+            raise ValueError(f"kernel_size must be odd, got {kernel_size}")
+        if len(layers) == 0:
+            raise ValueError("layers must contain at least one conv layer")
+        padding = kernel_size // 2
+        conv_stack = []
+        in_ch = self.channels
+        for ch in layers:
+            conv_stack.append(
+                layer_init(
+                    nn.Conv2d(in_ch, ch, kernel_size=kernel_size, padding=padding)
+                )
+            )
+            conv_stack.append(nn.ReLU())
+            conv_stack.append(nn.Dropout2d(dropout))
+            in_ch = ch
+        self.encoder = nn.Sequential(*conv_stack)
+        self.layers = tuple(layers)
+        self.kernel_size = kernel_size
+        last_chan = layers[-1]  # encoder output channels — feeds every head
         num_params_encoder = sum(p.numel() for p in self.encoder.parameters())
-        print(f"Encoder has {num_params_encoder} params")
+        print(
+            f"Encoder has {num_params_encoder} params "
+            f"({len(layers)} layers {tuple(layers)}, kernel_size={kernel_size})"
+        )
 
-        flat_dim = chan3 * self.width * self.height
+        flat_dim = last_chan * self.width * self.height
 
         # Project encoded state to value
         self.critic_head = nn.Sequential(
-            nn.Flatten(),
-            layer_init(nn.Linear(flat_dim, 1), std=1.0)
+            nn.Flatten(), layer_init(nn.Linear(flat_dim, 1), std=1.0)
         )
 
         # Binary end-of-turn head. Predicts whether the factory is complete
@@ -856,17 +1015,19 @@ class AgentCNN(nn.Module):
         )
 
         # Tile selection: 1x1 conv producing one logit per spatial position
-        self.tile_logits = layer_init(nn.Conv2d(chan3, 1, kernel_size=1), std=tile_head_std)
+        self.tile_logits = layer_init(
+            nn.Conv2d(last_chan, 1, kernel_size=1), std=tile_head_std
+        )
 
         # Per-tile entity/direction/item/misc heads (conditioned on selected
         # tile features). The env's step() requires all four to be set
         # consistently — e.g. an underground_belt placement must carry
         # misc=UNDERGROUND_DOWN/UP, and an assembling_machine_1 placement
         # must carry a recipe in `item`.
-        self.ent_head = layer_init(nn.Linear(chan3, self.num_entities))
-        self.dir_head = layer_init(nn.Linear(chan3, self.num_directions))
-        self.item_head = layer_init(nn.Linear(chan3, self.num_items))
-        self.misc_head = layer_init(nn.Linear(chan3, self.num_misc))
+        self.ent_head = layer_init(nn.Linear(last_chan, self.num_entities))
+        self.dir_head = layer_init(nn.Linear(last_chan, self.num_directions))
+        self.item_head = layer_init(nn.Linear(last_chan, self.num_items))
+        self.misc_head = layer_init(nn.Linear(last_chan, self.num_misc))
         self.time_for_get_value = None
         self.time_for_get_action_and_value = None
 
@@ -905,18 +1066,18 @@ class AgentCNN(nn.Module):
         t0 = time.time()
 
         # Encode input once and reuse for both action and value heads
-        encoded_BCWH = self.encoder(x_BCWH)  # (B, chan3, W, H)
+        encoded_BCWH = self.encoder(x_BCWH)  # (B, C, W, H)
         value_B = self.critic_head(encoded_BCWH).squeeze(-1)
 
         B = encoded_BCWH.shape[0]
 
         # --- Tile selection: joint (x, y) via 1x1 conv ---
-        tile_logits_B1WH = self.tile_logits(encoded_BCWH)      # (B, 1, W, H)
-        tile_logits_BN = tile_logits_B1WH.reshape(B, -1)       # (B, W*H)
+        tile_logits_B1WH = self.tile_logits(encoded_BCWH)  # (B, 1, W, H)
+        tile_logits_BN = tile_logits_B1WH.reshape(B, -1)  # (B, W*H)
         dist_tile = Categorical(logits=tile_logits_BN)
 
         if action is None:
-            tile_idx_B = dist_tile.sample()                     # (B,)
+            tile_idx_B = dist_tile.sample()  # (B,)
         else:
             # Reconstruct tile index from stored (x, y)
             tile_idx_B = action[:, 0] * self.height + action[:, 1]
@@ -927,7 +1088,7 @@ class AgentCNN(nn.Module):
 
         # --- Extract per-tile features at selected (x, y) ---
         batch_idx = torch.arange(B, device=encoded_BCWH.device)
-        tile_features_BC = encoded_BCWH[batch_idx, :, x_B, y_B]  # (B, chan3)
+        tile_features_BC = encoded_BCWH[batch_idx, :, x_B, y_B]  # (B, C)
 
         # --- Entity / direction / item / misc heads (conditioned on tile features) ---
         logits_e_BE = self.ent_head(tile_features_BC)
@@ -952,18 +1113,18 @@ class AgentCNN(nn.Module):
 
         # --- Log probs and entropy ---
         logp_B = (
-            dist_tile.log_prob(tile_idx_B) +
-            dist_e.log_prob(ent_B) +
-            dist_d.log_prob(dir_B) +
-            dist_i.log_prob(item_B) +
-            dist_m.log_prob(misc_B)
+            dist_tile.log_prob(tile_idx_B)
+            + dist_e.log_prob(ent_B)
+            + dist_d.log_prob(dir_B)
+            + dist_i.log_prob(item_B)
+            + dist_m.log_prob(misc_B)
         )
         entropy_B = (
-            dist_tile.entropy() +
-            dist_e.entropy() +
-            dist_d.entropy() +
-            dist_i.entropy() +
-            dist_m.entropy()
+            dist_tile.entropy()
+            + dist_e.entropy()
+            + dist_d.entropy()
+            + dist_i.entropy()
+            + dist_m.entropy()
         )
 
         action_out = {
@@ -976,6 +1137,7 @@ class AgentCNN(nn.Module):
         self.time_for_get_action_and_value = time.time() - t0
         return action_out, logp_B, entropy_B, value_B
 
+
 if __name__ == "__main__":
     print("Starting...")
     start_time = time.time()
@@ -985,15 +1147,20 @@ if __name__ == "__main__":
     args.num_iterations = args.total_timesteps // args.batch_size
     # 16 * 256 * (50000/(16*256))
     num_gsteps = args.num_envs * args.num_steps * args.num_iterations
-    print(f"batch_size: {args.batch_size}, minibatch_size: {args.minibatch_size}, num_iterations: {args.num_iterations}, num_gsteps: {num_gsteps}")
+    print(
+        f"batch_size: {args.batch_size}, minibatch_size: {args.minibatch_size}, num_iterations: {args.num_iterations}, num_gsteps: {num_gsteps}"
+    )
 
-    iso8601 = datetime.now().replace(microsecond=0).isoformat(sep='T')
+    iso8601 = datetime.now().replace(microsecond=0).isoformat(sep="T")
     run_name = f"{iso8601} seed{args.seed}"
     run = None
     if args.track:
         import wandb
+
         if args.start_from_wandb is not None and args.start_from is None:
-            raise Exception(f"args.start_from_wandb is not None ({args.start_from_wandb}) and args.start_from is None")
+            raise Exception(
+                f"args.start_from_wandb is not None ({args.start_from_wandb}) and args.start_from is None"
+            )
 
         run = wandb.init(
             project=args.wandb_project_name,
@@ -1012,25 +1179,43 @@ if __name__ == "__main__":
             f"num_iterations:{args.num_iterations}",
             f"seed:{args.seed}",
             f"size:{args.size}",
-            f"timesteps:{args.total_timesteps//1000}K",
-            f"chan1:{args.chan1}",
-            f"chan2:{args.chan2}",
-            f"chan3:{args.chan3}",
-            f"flat_dim:{args.flat_dim}",
+            f"timesteps:{args.total_timesteps // 1000}K",
+            f"layers:{'-'.join(map(str, layers_from_args(args)))}",
+            f"kernel_size:{args.kernel_size}",
         )
 
         # Define metric axes and summary aggregation
         wandb.define_metric("*", step_metric="global_step")
-        for m in ["throughput", "reward", "length", "invalid_frac",
-                   "num_entities", "entity_efficiency", "frac_reachable"]:
+        for m in [
+            "throughput",
+            "reward",
+            "length",
+            "invalid_frac",
+            "num_entities",
+            "entity_efficiency",
+            "frac_reachable",
+        ]:
             wandb.define_metric(f"episode/{m}", summary="last")
-        for m in ["tile_location", "tile_entity", "tile_direction",
-                   "delta_location", "delta_entity", "delta_direction"]:
+        for m in [
+            "tile_location",
+            "tile_entity",
+            "tile_direction",
+            "delta_location",
+            "delta_entity",
+            "delta_direction",
+        ]:
             wandb.define_metric(f"shaping/{m}", summary="last")
         wandb.define_metric("curriculum/score", summary="max")
         wandb.define_metric("curriculum/level", summary="max")
         wandb.define_metric("curriculum/throughput_avg", summary="last")
-        for m in ["policy", "value", "entropy", "approx_kl", "clipfrac", "explained_var"]:
+        for m in [
+            "policy",
+            "value",
+            "entropy",
+            "approx_kl",
+            "clipfrac",
+            "explained_var",
+        ]:
             wandb.define_metric(f"losses/{m}", summary="last")
         for m in ["lr", "ent_coef", "grad_norm"]:
             wandb.define_metric(f"optim/{m}", summary="last")
@@ -1050,7 +1235,11 @@ if __name__ == "__main__":
     torch.backends.cudnn.deterministic = args.torch_deterministic
     torch.use_deterministic_algorithms(args.torch_deterministic)
 
-    device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else ("mps" if torch.backends.mps.is_available() and args.metal else "cpu"))
+    device = torch.device(
+        "cuda"
+        if torch.cuda.is_available() and args.cuda
+        else ("mps" if torch.backends.mps.is_available() and args.metal else "cpu")
+    )
     if device.type == "mps":
         # metal doesn't like anything but f32
         torch.set_default_dtype(torch.float32)
@@ -1059,16 +1248,22 @@ if __name__ == "__main__":
     print(f"Setting up envs with {args}")
     # env setup
     envs = gym.vector.SyncVectorEnv(
-        [make_env(args.env_id, i, args.capture_video, args.size, run_name) for i in range(args.num_envs)],
+        [
+            make_env(args.env_id, i, args.capture_video, args.size, run_name)
+            for i in range(args.num_envs)
+        ],
     )
 
-    print(f"Creating agent with {args.chan1=}, {args.chan2=}, {args.chan3=}, {args.flat_dim=}, {args.tile_head_std=}, {args.dropout=} ")
+    encoder_layers = layers_from_args(args)
+    print(
+        f"Creating agent with layers={encoder_layers}, "
+        f"kernel_size={args.kernel_size}, tile_head_std={args.tile_head_std}, "
+        f"dropout={args.dropout}"
+    )
     agent = AgentCNN(
         envs,
-        chan1=args.chan1,
-        chan2=args.chan2,
-        chan3=args.chan3,
-        flat_dim=args.flat_dim,
+        layers=encoder_layers,
+        kernel_size=args.kernel_size,
         tile_head_std=args.tile_head_std,
         dropout=args.dropout,
     )
@@ -1084,17 +1279,36 @@ if __name__ == "__main__":
     print("Compiling agent with torch.compile()")
     agent = torch.compile(agent)
 
-    optimizer = optim.Adam(agent.parameters(), lr=args.learning_rate, eps=args.adam_epsilon, weight_decay=args.weight_decay)
+    optimizer = optim.Adam(
+        agent.parameters(),
+        lr=args.learning_rate,
+        eps=args.adam_epsilon,
+        weight_decay=args.weight_decay,
+    )
 
     print("Allocating storage space")
     # ALGO Logic: Storage setup
-    obs_SECWH = torch.zeros((args.num_steps, args.num_envs) + envs.single_observation_space.shape, dtype=torch.float32, device=device)
+    obs_SECWH = torch.zeros(
+        (args.num_steps, args.num_envs) + envs.single_observation_space.shape,
+        dtype=torch.float32,
+        device=device,
+    )
     ACTION_SPACE_SHAPE = (6,)
-    actions_SEA = torch.zeros((args.num_steps, args.num_envs) + ACTION_SPACE_SHAPE, dtype=int, device=device)
-    logprobs_SE = torch.zeros((args.num_steps, args.num_envs), dtype=torch.float32, device=device)
-    rewards_SE = torch.zeros((args.num_steps, args.num_envs), dtype=torch.float32, device=device)
-    dones_SE = torch.zeros((args.num_steps, args.num_envs), dtype=torch.float32, device=device)
-    values_SE = torch.zeros((args.num_steps, args.num_envs), dtype=torch.float32, device=device)
+    actions_SEA = torch.zeros(
+        (args.num_steps, args.num_envs) + ACTION_SPACE_SHAPE, dtype=int, device=device
+    )
+    logprobs_SE = torch.zeros(
+        (args.num_steps, args.num_envs), dtype=torch.float32, device=device
+    )
+    rewards_SE = torch.zeros(
+        (args.num_steps, args.num_envs), dtype=torch.float32, device=device
+    )
+    dones_SE = torch.zeros(
+        (args.num_steps, args.num_envs), dtype=torch.float32, device=device
+    )
+    values_SE = torch.zeros(
+        (args.num_steps, args.num_envs), dtype=torch.float32, device=device
+    )
 
     # TRY NOT TO MODIFY: start the game
     global_step = 0
@@ -1102,10 +1316,14 @@ if __name__ == "__main__":
     next_obs_ECWH, _ = envs.reset(
         seed=args.seed,
         options={
-            'num_missing_entities': int(torch.randint(0, max_missing_entities+1, (1,))[0]),
-        }
+            "num_missing_entities": int(
+                torch.randint(0, max_missing_entities + 1, (1,))[0]
+            ),
+        },
     )
-    next_obs_ECWH = torch.as_tensor(np.array(next_obs_ECWH), dtype=torch.float32, device=device)
+    next_obs_ECWH = torch.as_tensor(
+        np.array(next_obs_ECWH), dtype=torch.float32, device=device
+    )
     next_done = torch.zeros(args.num_envs, dtype=torch.float32, device=device)
     final_thputs_100ma = sum(end_of_episode_thputs) / len(end_of_episode_thputs)
     unclipped_grad_norm = np.nan
@@ -1113,11 +1331,14 @@ if __name__ == "__main__":
 
     # Log initial eval metrics at step 0 (before any training)
     if args.track:
-        wandb.log({
-            "curriculum/level": max_missing_entities,
-            "curriculum/score": (max_missing_entities - 1) + final_thputs_100ma,
-            "curriculum/throughput_avg": final_thputs_100ma,
-        }, step=0)
+        wandb.log(
+            {
+                "curriculum/level": max_missing_entities,
+                "curriculum/score": (max_missing_entities - 1) + final_thputs_100ma,
+                "curriculum/throughput_avg": final_thputs_100ma,
+            },
+            step=0,
+        )
 
     # Accumulate episode-level metrics during rollout, log means once per iteration
     _episode_metrics: dict[str, list[float]] = {}
@@ -1147,12 +1368,16 @@ if __name__ == "__main__":
 
         # Entropy coefficient annealing: linear from ent_coef_start to ent_coef_end
         ent_frac = 1.0 - (iteration - 1.0) / args.num_iterations
-        ent_coef = args.ent_coef_end + ent_frac * (args.ent_coef_start - args.ent_coef_end)
+        ent_coef = args.ent_coef_end + ent_frac * (
+            args.ent_coef_start - args.ent_coef_end
+        )
 
         for step in range(0, args.num_steps):
             global_step += args.num_envs
-            if (step+1) % 10 == 0 or step + 1 == args.num_steps:
-                pbar.set_description(f"taking step {step+1: 4}/{args.num_steps}; gstep:{global_step: 6}; score:{(max_missing_entities - 1) + final_thputs_100ma:.2f} (lvl:{max_missing_entities} thput:{final_thputs_100ma:.2f})")
+            if (step + 1) % 10 == 0 or step + 1 == args.num_steps:
+                pbar.set_description(
+                    f"taking step {step + 1: 4}/{args.num_steps}; gstep:{global_step: 6}; score:{(max_missing_entities - 1) + final_thputs_100ma:.2f} (lvl:{max_missing_entities} thput:{final_thputs_100ma:.2f})"
+                )
             obs_SECWH[step] = next_obs_ECWH
             dones_SE[step] = next_done
 
@@ -1160,7 +1385,9 @@ if __name__ == "__main__":
             with torch.no_grad():
                 # TODO update for new action logic
                 # D for dictionary
-                action_ED, logprobs_E, _entropy_E, value_E = agent.get_action_and_value(next_obs_ECWH)
+                action_ED, logprobs_E, _entropy_E, value_E = agent.get_action_and_value(
+                    next_obs_ECWH
+                )
                 values_SE[step] = value_E
                 # Flatten action
                 # (xy_B2, direc_B1, entities_B1) = action_ED
@@ -1181,20 +1408,33 @@ if __name__ == "__main__":
 
             action_ED_numpy = {k: v.cpu().numpy() for k, v in action_ED.items()}
             # TRY NOT TO MODIFY: execute the game and log data.
-            next_obs_ECWH, reward, terminations, truncations, infos = envs.step(action_ED_numpy)
+            next_obs_ECWH, reward, terminations, truncations, infos = envs.step(
+                action_ED_numpy
+            )
             next_done = np.logical_or(terminations, truncations)
-            rewards_SE[step] = torch.as_tensor(np.array(reward), dtype=torch.float32, device=device)
+            rewards_SE[step] = torch.as_tensor(
+                np.array(reward), dtype=torch.float32, device=device
+            )
 
             # Reset only the done environments with updated num_missing_entities
             done_indices = np.where(next_done)[0]
             for idx in done_indices:
-                obs, _ = envs.envs[idx].reset(seed=args.seed + idx, options={
-                    'num_missing_entities': int(torch.randint(0, max_missing_entities+1, (1,))[0])
-                })
+                obs, _ = envs.envs[idx].reset(
+                    seed=args.seed + idx,
+                    options={
+                        "num_missing_entities": int(
+                            torch.randint(0, max_missing_entities + 1, (1,))[0]
+                        )
+                    },
+                )
                 next_obs_ECWH[idx] = obs
 
-            next_obs_ECWH = torch.as_tensor(np.array(next_obs_ECWH), dtype=torch.float32, device=device)
-            next_done = torch.as_tensor(np.array(next_done), dtype=torch.float32, device=device)
+            next_obs_ECWH = torch.as_tensor(
+                np.array(next_obs_ECWH), dtype=torch.float32, device=device
+            )
+            next_done = torch.as_tensor(
+                np.array(next_done), dtype=torch.float32, device=device
+            )
 
             if "episode" in infos:
                 # The "_episode" mask indicates which environments finished this step
@@ -1218,25 +1458,44 @@ if __name__ == "__main__":
 
                     end_of_episode_thputs.append(end_of_episode_thput)
 
-                    _record_episode({
-                        "episode/throughput": float(end_of_episode_thput),
-                        "episode/reward": float(episode_return),
-                        "episode/length": float(episode_len),
-                        "episode/invalid_frac": float(infos['frac_invalid_actions'][i]),
-                        "episode/num_entities": float(infos['num_entities'][i]),
-                        "episode/entity_efficiency": float(infos['min_entities_required'][i]) / float(infos['num_entities'][i]),
-                        "episode/frac_reachable": float(final_frac_reachable),
-                        "shaping/tile_location": float(infos['tile_match_location'][i]),
-                        "shaping/tile_entity": float(infos['tile_match_entity'][i]),
-                        "shaping/tile_direction": float(infos['tile_match_direction'][i]),
-                        "shaping/delta_location": float(infos['shaping_location_delta'][i]),
-                        "shaping/delta_entity": float(infos['shaping_entity_delta'][i]),
-                        "shaping/delta_direction": float(infos['shaping_direction_delta'][i]),
-                    })
+                    _record_episode(
+                        {
+                            "episode/throughput": float(end_of_episode_thput),
+                            "episode/reward": float(episode_return),
+                            "episode/length": float(episode_len),
+                            "episode/invalid_frac": float(
+                                infos["frac_invalid_actions"][i]
+                            ),
+                            "episode/num_entities": float(infos["num_entities"][i]),
+                            "episode/entity_efficiency": float(
+                                infos["min_entities_required"][i]
+                            )
+                            / float(infos["num_entities"][i]),
+                            "episode/frac_reachable": float(final_frac_reachable),
+                            "shaping/tile_location": float(
+                                infos["tile_match_location"][i]
+                            ),
+                            "shaping/tile_entity": float(infos["tile_match_entity"][i]),
+                            "shaping/tile_direction": float(
+                                infos["tile_match_direction"][i]
+                            ),
+                            "shaping/delta_location": float(
+                                infos["shaping_location_delta"][i]
+                            ),
+                            "shaping/delta_entity": float(
+                                infos["shaping_entity_delta"][i]
+                            ),
+                            "shaping/delta_direction": float(
+                                infos["shaping_direction_delta"][i]
+                            ),
+                        }
+                    )
 
             # Log eval metrics every 256 global steps during rollout
             if args.track and global_step >= _next_eval_log_step:
-                final_thputs_100ma = sum(end_of_episode_thputs) / len(end_of_episode_thputs)
+                final_thputs_100ma = sum(end_of_episode_thputs) / len(
+                    end_of_episode_thputs
+                )
                 eval_metrics = {
                     "curriculum/level": max_missing_entities,
                     "curriculum/score": (max_missing_entities - 1) + final_thputs_100ma,
@@ -1258,8 +1517,14 @@ if __name__ == "__main__":
                 else:
                     nextnonterminal = 1.0 - dones_SE[t + 1]
                     nextvalues = values_SE[t + 1]
-                delta = rewards_SE[t] + args.gamma * nextvalues * nextnonterminal - values_SE[t]
-                lastgaelam = delta + args.gamma * args.gae_lambda * nextnonterminal * lastgaelam
+                delta = (
+                    rewards_SE[t]
+                    + args.gamma * nextvalues * nextnonterminal
+                    - values_SE[t]
+                )
+                lastgaelam = (
+                    delta + args.gamma * args.gae_lambda * nextnonterminal * lastgaelam
+                )
                 advantages_SE[t] = lastgaelam
             returns_SE = advantages_SE + values_SE
 
@@ -1278,15 +1543,16 @@ if __name__ == "__main__":
         idxs_B = np.arange(args.batch_size)
         clipfracs = []
         for epoch in range(args.update_epochs):
-            pbar.set_description(f"optimiser epoch {epoch+1}/{args.update_epochs}; grad norm:{unclipped_grad_norm:5.2f}; kl:{approx_kl:5.3f}; score:{(max_missing_entities - 1) + final_thputs_100ma:.2f}")
+            pbar.set_description(
+                f"optimiser epoch {epoch + 1}/{args.update_epochs}; grad norm:{unclipped_grad_norm:5.2f}; kl:{approx_kl:5.3f}; score:{(max_missing_entities - 1) + final_thputs_100ma:.2f}"
+            )
             np.random.shuffle(idxs_B)
             for start in range(0, args.batch_size, args.minibatch_size):
                 end = start + args.minibatch_size
                 idxs = idxs_B[start:end]
 
-                _action_BA, newlogprobs_B, entropy_B, newvalue_B = agent.get_action_and_value(
-                    obs_B[idxs],
-                    actions_B.long()[idxs]
+                _action_BA, newlogprobs_B, entropy_B, newvalue_B = (
+                    agent.get_action_and_value(obs_B[idxs], actions_B.long()[idxs])
                 )
                 newlogprobs_B = newlogprobs_B.reshape(-1)
                 logratio_B = newlogprobs_B - logprobs_B[idxs].reshape(-1)
@@ -1296,16 +1562,24 @@ if __name__ == "__main__":
                     # calculate approx_kl http://joschu.net/blog/kl-approx.html
                     old_approx_kl = (-logratio_B).mean()
                     approx_kl = ((ratio_B - 1) - logratio_B).mean()
-                    clipfracs += [((ratio_B - 1.0).abs() > args.clip_coef).float().mean().item()]
+                    clipfracs += [
+                        ((ratio_B - 1.0).abs() > args.clip_coef).float().mean().item()
+                    ]
 
-                assert not torch.isnan(advantages_B).any(), f"Some advantages are NaN: {advantages_B=}"
+                assert not torch.isnan(advantages_B).any(), (
+                    f"Some advantages are NaN: {advantages_B=}"
+                )
                 advantages_mB = advantages_B[idxs]
                 if args.norm_adv:
-                    advantages_mB = (advantages_mB - advantages_mB.mean()) / (advantages_mB.std() + 1e-8)
+                    advantages_mB = (advantages_mB - advantages_mB.mean()) / (
+                        advantages_mB.std() + 1e-8
+                    )
 
                 # Policy loss
                 pg_loss1 = -advantages_mB * ratio_B
-                pg_loss2 = -advantages_mB * torch.clamp(ratio_B, 1 - args.clip_coef, 1 + args.clip_coef)
+                pg_loss2 = -advantages_mB * torch.clamp(
+                    ratio_B, 1 - args.clip_coef, 1 + args.clip_coef
+                )
                 pg_loss = torch.max(pg_loss1, pg_loss2).mean()
 
                 # Value loss
@@ -1331,7 +1605,9 @@ if __name__ == "__main__":
                 optimizer.zero_grad(set_to_none=True)
                 assert not torch.isnan(loss), "Loss is NaN, probably a bug"
                 loss.backward()
-                unclipped_grad_norm = nn.utils.clip_grad_norm_(agent.parameters(), args.max_grad_norm)
+                unclipped_grad_norm = nn.utils.clip_grad_norm_(
+                    agent.parameters(), args.max_grad_norm
+                )
                 optimizer.step()
 
             if args.target_kl is not None and approx_kl > args.target_kl:
@@ -1364,28 +1640,42 @@ if __name__ == "__main__":
         if len(end_of_episode_thputs) > 0:
             final_thputs_100ma = sum(end_of_episode_thputs) / len(end_of_episode_thputs)
             if len(end_of_episode_thputs) > int(moving_average_length * 0.9):
-                if final_thputs_100ma > 0.95 and iteration - iteration_of_last_increase > 10:
+                if (
+                    final_thputs_100ma > 0.95
+                    and iteration - iteration_of_last_increase > 10
+                ):
                     iteration_of_last_increase = iteration
                     end_of_episode_thputs.clear()
                     for _ in range(moving_average_length):
                         end_of_episode_thputs.append(0)
-                    max_missing_entities = min(max_missing_entities + 1, args.size*2)
+                    max_missing_entities = min(max_missing_entities + 1, args.size * 2)
                     print(f"\nNow working with {max_missing_entities=}")
             # Recompute after potential level-up so we use the reset buffer
             final_thputs_100ma = sum(end_of_episode_thputs) / len(end_of_episode_thputs)
             iter_metrics["curriculum/level"] = max_missing_entities
-            iter_metrics["curriculum/score"] = (max_missing_entities - 1) + final_thputs_100ma
+            iter_metrics["curriculum/score"] = (
+                max_missing_entities - 1
+            ) + final_thputs_100ma
             iter_metrics["curriculum/throughput_avg"] = final_thputs_100ma
 
         # Single wandb.log() call per iteration
         if args.track:
             wandb.log(iter_metrics, step=global_step)
 
-        if args.capture_video and ((iteration-1) % 50 == 0 or iteration + 1 == args.num_iterations):
+        if args.capture_video and (
+            (iteration - 1) % 50 == 0 or iteration + 1 == args.num_iterations
+        ):
             print(f"Recording agent progress at {iteration}")
             num_render_envs = 5
-            render_envs = gym.vector.SyncVectorEnv([make_env(args.env_id, i, False, args.size, run_name) for i in range(num_render_envs)])
-            next_obs_ECWH_render, _ = render_envs.reset(seed=args.seed, options={'num_missing_entities': max_missing_entities})
+            render_envs = gym.vector.SyncVectorEnv(
+                [
+                    make_env(args.env_id, i, False, args.size, run_name)
+                    for i in range(num_render_envs)
+                ]
+            )
+            next_obs_ECWH_render, _ = render_envs.reset(
+                seed=args.seed, options={"num_missing_entities": max_missing_entities}
+            )
 
             temp_dirs = [tempfile.mkdtemp() for _ in range(num_render_envs)]
             frame_counts = [0] * num_render_envs
@@ -1394,39 +1684,65 @@ if __name__ == "__main__":
                 # Save initial frames
                 for env_idx, img in enumerate(render_envs.render()):
                     image = Image.fromarray(img, mode="RGB")
-                    frame_path = os.path.join(temp_dirs[env_idx], f'frame_{frame_counts[env_idx]:06d}.png')
+                    frame_path = os.path.join(
+                        temp_dirs[env_idx], f"frame_{frame_counts[env_idx]:06d}.png"
+                    )
                     image.save(frame_path, format="png", optimize=True)
                     frame_counts[env_idx] += 1
 
                 # Run simulation and save frames
                 for i in range(1, 10):
                     with torch.no_grad():
-                        action_ED_render, _logprobs_E, _entropy_E, _value_E = agent.get_action_and_value(torch.Tensor(next_obs_ECWH_render).to(device))
-                        action_ED_numpy = {k: v.cpu().numpy() for k, v in action_ED_render.items()}
-                        next_obs_ECWH_render, _reward, terminations_render, truncations_render, _infos = render_envs.step(action_ED_numpy)
+                        action_ED_render, _logprobs_E, _entropy_E, _value_E = (
+                            agent.get_action_and_value(
+                                torch.Tensor(next_obs_ECWH_render).to(device)
+                            )
+                        )
+                        action_ED_numpy = {
+                            k: v.cpu().numpy() for k, v in action_ED_render.items()
+                        }
+                        (
+                            next_obs_ECWH_render,
+                            _reward,
+                            terminations_render,
+                            truncations_render,
+                            _infos,
+                        ) = render_envs.step(action_ED_numpy)
 
                     for env_idx, img in enumerate(render_envs.render()):
                         image = Image.fromarray(img, mode="RGB")
-                        frame_path = os.path.join(temp_dirs[env_idx], f'frame_{frame_counts[env_idx]:06d}.png')
+                        frame_path = os.path.join(
+                            temp_dirs[env_idx], f"frame_{frame_counts[env_idx]:06d}.png"
+                        )
                         image.save(frame_path, format="png", optimize=True)
                         frame_counts[env_idx] += 1
 
                 # Create videos for each environment
-                iso8601 = datetime.now().replace(microsecond=0).isoformat(sep='T').replace(":", "-")
-                Path('videos').mkdir(parents=True, exist_ok=True)
+                iso8601 = (
+                    datetime.now()
+                    .replace(microsecond=0)
+                    .isoformat(sep="T")
+                    .replace(":", "-")
+                )
+                Path("videos").mkdir(parents=True, exist_ok=True)
 
                 for env_idx in range(num_render_envs):
-                    output_path = f'videos/world_inits/{iso8601}_size{args.size}_missing{max_missing_entities}_iter{iteration:06}_env{env_idx}.mp4'
+                    output_path = f"videos/world_inits/{iso8601}_size{args.size}_missing{max_missing_entities}_iter{iteration:06}_env{env_idx}.mp4"
 
                     ffmpeg_cmd = [
-                        'ffmpeg',
-                        '-y',
-                        '-framerate', '2',
-                        '-i', os.path.join(temp_dirs[env_idx], 'frame_%06d.png'),
-                        '-c:v', 'libx264',
-                        '-pix_fmt', 'yuv420p',
-                        '-crf', '23',
-                        output_path
+                        "ffmpeg",
+                        "-y",
+                        "-framerate",
+                        "2",
+                        "-i",
+                        os.path.join(temp_dirs[env_idx], "frame_%06d.png"),
+                        "-c:v",
+                        "libx264",
+                        "-pix_fmt",
+                        "yuv420p",
+                        "-crf",
+                        "23",
+                        output_path,
                     ]
 
                     try:
@@ -1439,25 +1755,37 @@ if __name__ == "__main__":
                 for temp_dir in temp_dirs:
                     shutil.rmtree(temp_dir, ignore_errors=True)
                 render_envs.close()
-    final_thput = 0 if len(end_of_episode_thputs) == 0 else sum(end_of_episode_thputs) / len(end_of_episode_thputs)
+    final_thput = (
+        0
+        if len(end_of_episode_thputs) == 0
+        else sum(end_of_episode_thputs) / len(end_of_episode_thputs)
+    )
     # curriculum_score: monotonically increasing with agent capability.
     # Advancing a curriculum level is always worth more than any throughput
     # gain within a level (since throughput is in [0, 1]).
     curriculum_score = (max_missing_entities - 1) + final_thput
+
     def format_duration(seconds: float) -> str:
         total_seconds = int(round(seconds))
         hours = total_seconds // 3600
         minutes = (total_seconds % 3600) // 60
         secs = total_seconds % 60
         return f"{hours:02d}h{minutes:02d}m{secs:02d}s"
+
     runtime = time.time() - start_time
     if args.track:
-        run.tags = run.tags + (f"score:{curriculum_score:.2f}", f"thput:{final_thput*100:.0f}", f"duration:{format_duration(runtime)}")
+        run.tags = run.tags + (
+            f"score:{curriculum_score:.2f}",
+            f"thput:{final_thput * 100:.0f}",
+            f"duration:{format_duration(runtime)}",
+        )
     envs.close()
-    if runtime > 60 * 5: # 5 minutes
+    if runtime > 60 * 5:  # 5 minutes
         # avg_throughput = 0 if len(final_throughputs) == 0 else float(sum(final_throughputs) / len(final_throughputs))
         # Save the model to a file
-        run_name_dir_safe = run_name.replace('/', '-').replace(':', '-').replace(' ', '_')
+        run_name_dir_safe = (
+            run_name.replace("/", "-").replace(":", "-").replace(" ", "_")
+        )
         agent_name = f"agent-{run_name_dir_safe}"
         print(f"Saving model to artifacts/{agent_name}.pt")
         os.makedirs("artifacts", exist_ok=True)
@@ -1467,7 +1795,7 @@ if __name__ == "__main__":
             artifact.add_file(f"artifacts/{agent_name}.pt")
             wandb.log_artifact(artifact)
     else:
-        print(f'Not saving because: {time.time() - start_time:.2f} <= {60 * 5}')
+        print(f"Not saving because: {time.time() - start_time:.2f} <= {60 * 5}")
 
     # Write summary JSON (used by CI to post results to PR)
     summary = {
@@ -1484,10 +1812,10 @@ if __name__ == "__main__":
         "grid_size": args.size,
         "wandb_url": run.url if args.track and run else None,
     }
-    summary_path = args.summary_path or os.path.join(os.path.dirname(os.path.abspath(__file__)), "summary.json")
+    summary_path = args.summary_path or os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "summary.json"
+    )
     os.makedirs(os.path.dirname(os.path.abspath(summary_path)), exist_ok=True)
     with open(summary_path, "w") as f:
         json.dump(summary, f, indent=2)
     print(f"Summary written to {summary_path}")
-
-

--- a/scripts/ci/apply_sft_sweep_best.py
+++ b/scripts/ci/apply_sft_sweep_best.py
@@ -32,9 +32,15 @@ TUNABLE_PARAMS = {
     "num_samples": "int",
     "epochs": "int",
     "max_level": "int",
-    "chan1": "int",
-    "chan2": "int",
-    "chan3": "int",
+    "layer1": "int",
+    "layer2": "int",
+    "layer3": "int",
+    "layer4": "int",
+    "layer5": "int",
+    "layer6": "int",
+    "layer7": "int",
+    "layer8": "int",
+    "kernel_size": "int",
     "tile_head_std": "float",
 }
 
@@ -103,12 +109,8 @@ def main():
         required=True,
         help="Full sweep path (entity/project/sweep_id)",
     )
-    parser.add_argument(
-        "--sft-file", default="sft.py", help="Path to sft.py"
-    )
-    parser.add_argument(
-        "--base-branch", default="main", help="Base branch for the PR"
-    )
+    parser.add_argument("--sft-file", default="sft.py", help="Path to sft.py")
+    parser.add_argument("--base-branch", default="main", help="Base branch for the PR")
     parser.add_argument(
         "--pr-number",
         default=None,
@@ -135,7 +137,7 @@ def main():
         sys.exit(1)
 
     metric_cfg = sweep.config.get("metric", {})
-    metric_name = metric_cfg.get("name", "val/acc")
+    metric_name = metric_cfg.get("name", "val/throughput")
     metric_goal = metric_cfg.get("goal", "maximize")
     reverse = metric_goal == "maximize"
 
@@ -228,11 +230,17 @@ def main():
 
     result = run(
         [
-            "gh", "pr", "create",
-            "--title", pr_title,
-            "--body", pr_body,
-            "--base", args.base_branch,
-            "--head", branch_name,
+            "gh",
+            "pr",
+            "create",
+            "--title",
+            pr_title,
+            "--body",
+            pr_body,
+            "--base",
+            args.base_branch,
+            "--head",
+            branch_name,
         ],
         check=False,
     )

--- a/scripts/ci/apply_sft_sweep_best.py
+++ b/scripts/ci/apply_sft_sweep_best.py
@@ -137,7 +137,7 @@ def main():
         sys.exit(1)
 
     metric_cfg = sweep.config.get("metric", {})
-    metric_name = metric_cfg.get("name", "val/throughput")
+    metric_name = metric_cfg.get("name", "best_val_throughput")
     metric_goal = metric_cfg.get("goal", "maximize")
     reverse = metric_goal == "maximize"
 

--- a/scripts/ci/apply_sft_sweep_best.py
+++ b/scripts/ci/apply_sft_sweep_best.py
@@ -137,7 +137,7 @@ def main():
         sys.exit(1)
 
     metric_cfg = sweep.config.get("metric", {})
-    metric_name = metric_cfg.get("name", "best_val_throughput")
+    metric_name = metric_cfg.get("name", "val/throughput")
     metric_goal = metric_cfg.get("goal", "maximize")
     reverse = metric_goal == "maximize"
 

--- a/scripts/ci/apply_sweep_best.py
+++ b/scripts/ci/apply_sweep_best.py
@@ -29,9 +29,15 @@ from wandb_metric import read_metric
 # Only these will be updated; other sweep config keys are ignored.
 TUNABLE_PARAMS = {
     "adam_epsilon": "float",
-    "chan1": "int",
-    "chan2": "int",
-    "chan3": "int",
+    "layer1": "int",
+    "layer2": "int",
+    "layer3": "int",
+    "layer4": "int",
+    "layer5": "int",
+    "layer6": "int",
+    "layer7": "int",
+    "layer8": "int",
+    "kernel_size": "int",
     "clip_coef": "float",
     "coeff_throughput": "float",
     "coeff_shaping_direction": "float",
@@ -39,7 +45,6 @@ TUNABLE_PARAMS = {
     "coeff_shaping_location": "float",
     "ent_coef_start": "float",
     "ent_coef_end": "float",
-    "flat_dim": "int",
     "gae_lambda": "float",
     "gamma": "float",
     "learning_rate": "float",
@@ -118,12 +123,8 @@ def main():
         required=True,
         help="Full sweep path (entity/project/sweep_id)",
     )
-    parser.add_argument(
-        "--ppo-file", default="ppo.py", help="Path to ppo.py"
-    )
-    parser.add_argument(
-        "--base-branch", default="main", help="Base branch for the PR"
-    )
+    parser.add_argument("--ppo-file", default="ppo.py", help="Path to ppo.py")
+    parser.add_argument("--base-branch", default="main", help="Base branch for the PR")
     parser.add_argument(
         "--pr-number",
         default=None,
@@ -248,11 +249,17 @@ def main():
 
     result = run(
         [
-            "gh", "pr", "create",
-            "--title", pr_title,
-            "--body", pr_body,
-            "--base", args.base_branch,
-            "--head", branch_name,
+            "gh",
+            "pr",
+            "create",
+            "--title",
+            pr_title,
+            "--body",
+            pr_body,
+            "--base",
+            args.base_branch,
+            "--head",
+            branch_name,
         ],
         check=False,
     )

--- a/scripts/ci/wandb_metric.py
+++ b/scripts/ci/wandb_metric.py
@@ -1,17 +1,29 @@
 """Read a sweep metric out of a W&B run summary as a sortable scalar.
 
-W&B stores slash-namespaced metrics (e.g. ``curriculum/throughput_avg``)
-as *nested* dicts in a run's summary. A plain ``summary.get("a/b")`` can
-therefore return a nested ``SummarySubDict`` node — either because the
-full slash key misses (the value lives at ``summary["a"]["b"]``) or
-because the metric name points at a namespace rather than a leaf. Those
-nodes are unorderable, so feeding them to ``sorted()``/``list.sort()``
-raises ``TypeError: '<' not supported between instances of
-'SummarySubDict'``.
+Two W&B summary representations defeat a naive ``float(summary.get("a/b"))``:
 
-``read_metric`` resolves the slash path and only ever returns a float (or
-the caller's ``missing`` sentinel), so runs can be sorted safely.
+1. **Slash-namespaced metrics** (e.g. ``curriculum/throughput_avg``) can be
+   stored as *nested* dicts, so the full ``"a/b"`` key misses and the value
+   lives at ``summary["a"]["b"]``. A metric name pointing at a namespace
+   rather than a leaf yields a nested ``SummarySubDict`` node.
+
+2. **``define_metric(summary="max"|"min"|...)`` metrics** are stored as a
+   single-stat dict — ``val/throughput`` becomes ``{"max": 0.04}`` rather
+   than a bare ``0.04``. ``define_metric`` is exactly how the SFT greedy
+   throughput sweep records its objective, so this is the common case, not
+   an edge one.
+
+Both yield a non-scalar (a dict / ``SummarySubDict``) where the caller wants
+a number; ``float(dict)`` raises ``TypeError`` and unorderable nodes break
+``sorted()``/``list.sort()``. ``read_metric`` resolves the slash path,
+unwraps a summary-stat dict, and only ever returns a float (or the caller's
+``missing`` sentinel), so runs can be sorted safely.
 """
+
+# define_metric(summary=...) stores the chosen statistic under one of these
+# keys. Ordered by preference so a maximize objective unwraps to its "max"
+# and a minimize objective (no "max" present) falls through to "min".
+_SUMMARY_STAT_KEYS = ("max", "min", "last", "mean", "value")
 
 
 def read_metric(summary, metric_name, missing):
@@ -38,6 +50,19 @@ def read_metric(summary, metric_name, missing):
             if node is None:
                 break
         val = node
+    # A define_metric(summary="max"|...) value is a single-stat mapping
+    # ({"max": 0.04}); unwrap it to the underlying scalar. W&B's SummarySubDict
+    # is dict-LIKE but does NOT subclass dict, so duck-type on `.keys()` rather
+    # than isinstance(dict) (which silently misses the real object). A namespace
+    # mapping with no stat keys (e.g. {"greedy": .., "random": ..}) is left
+    # alone and falls through to `missing` below — we can't pick one for the
+    # caller.
+    if val is not None and hasattr(val, "keys"):
+        keys = set(val.keys())
+        for stat in _SUMMARY_STAT_KEYS:
+            if stat in keys:
+                val = val[stat]
+                break
     try:
         return float(val)
     except (TypeError, ValueError):

--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -167,13 +167,15 @@ def world_CWH_to_grid(world_CWH: torch.Tensor) -> list[list[dict]]:
             item_v = int(world_CWH[Channel.ITEMS.value, x, y].item())
             misc_v = int(world_CWH[Channel.MISC.value, x, y].item())
             foot_v = int(world_CWH[Channel.FOOTPRINT.value, x, y].item())
-            row.append({
-                "entity": name_for_value.get(ent_v, "empty"),
-                "direction": dir_for_value.get(dir_v, "NONE"),
-                "item": name_for_value.get(item_v, "empty"),
-                "misc": misc_for_value.get(misc_v, "NONE"),
-                "footprint": footprint_for_value.get(foot_v, "AVAILABLE"),
-            })
+            row.append(
+                {
+                    "entity": name_for_value.get(ent_v, "empty"),
+                    "direction": dir_for_value.get(dir_v, "NONE"),
+                    "item": name_for_value.get(item_v, "empty"),
+                    "misc": misc_for_value.get(misc_v, "NONE"),
+                    "footprint": footprint_for_value.get(foot_v, "AVAILABLE"),
+                }
+            )
         rows.append(row)
     return rows
 
@@ -229,8 +231,9 @@ def render_graph_png(grid: list[list[dict]]) -> dict:
             "edges": [],
         }
 
-    fig = plt.figure(figsize=(max(6, len(G.nodes) ** 0.5 * 3),
-                              max(4, len(G.nodes) ** 0.5 * 3)))
+    fig = plt.figure(
+        figsize=(max(6, len(G.nodes) ** 0.5 * 3), max(4, len(G.nodes) ** 0.5 * 3))
+    )
     try:
         plot_flow_network(G)
         # plot_flow_network calls plt.show() which is a no-op under Agg;
@@ -266,8 +269,10 @@ def render_graph_png(grid: list[list[dict]]) -> dict:
 # action heads for inference.
 
 _AGENT_DEVICE = torch.device(
-    "cuda" if torch.cuda.is_available()
-    else "mps" if torch.backends.mps.is_available()
+    "cuda"
+    if torch.cuda.is_available()
+    else "mps"
+    if torch.backends.mps.is_available()
     else "cpu"
 )
 _AGENT_CACHE: dict[int, AgentCNN] = {}
@@ -288,12 +293,16 @@ _DIR_NAMES = {d.value: d.name for d in Direction}
 _MISC_NAMES = {m.value: m.name for m in Misc}
 
 
-def _encoder_channels(state) -> tuple[int, int, int]:
-    """Infer (chan1, chan2, chan3) from a checkpoint's encoder conv
-    weights. Filters by 4-D weight shape and sorts by layer index rather
-    than hardcoding `encoder.0/2/4`, so inserting non-conv layers (e.g.
-    Dropout2d) into the encoder Sequential doesn't shift the conv indices
-    out from under us."""
+def _encoder_arch(state: dict) -> tuple[list[int], int]:
+    """Infer the encoder architecture (per-layer channel widths, kernel size)
+    from a saved AgentCNN state_dict. Conv weights are the 4-D tensors under
+    `encoder.*`, with shape (out_channels, in_channels, k, k); we filter by
+    shape and sort by layer index rather than hardcoding `encoder.0/2/4`, so
+    non-conv modules interleaved into the encoder Sequential (e.g. the
+    Dropout2d trailing each ReLU) don't shift the conv indices out from under
+    us. Reading the conv shapes back lets the server reconstruct an
+    arbitrary-depth/kernel encoder — no sidecar, no assumption of exactly
+    three layers."""
     conv_keys = sorted(
         (
             k
@@ -302,8 +311,9 @@ def _encoder_channels(state) -> tuple[int, int, int]:
         ),
         key=lambda k: int(k.split(".")[1]),
     )
-    chan1, chan2, chan3 = (state[k].shape[0] for k in conv_keys)
-    return chan1, chan2, chan3
+    layers = [int(state[k].shape[0]) for k in conv_keys]
+    kernel_size = int(state[conv_keys[0]].shape[-1])
+    return layers, kernel_size
 
 
 def _load_checkpoint(path: str) -> None:
@@ -316,10 +326,10 @@ def _load_checkpoint(path: str) -> None:
     _CHECKPOINT_STATE = state
     _CHECKPOINT_PATH = path
     _AGENT_CACHE.clear()
-    chan1, chan2, chan3 = _encoder_channels(state)
+    layers, kernel_size = _encoder_arch(state)
     print(
         f"Loaded checkpoint {path} "
-        f"(chan1={chan1}, chan2={chan2}, chan3={chan3}, device={_AGENT_DEVICE})"
+        f"(layers={layers}, kernel_size={kernel_size}, device={_AGENT_DEVICE})"
     )
 
 
@@ -330,14 +340,13 @@ def _model_info() -> dict:
     if _CHECKPOINT_STATE is None:
         return {"loaded": False}
     s = _CHECKPOINT_STATE
-    chan1, chan2, chan3 = _encoder_channels(s)
+    layers, kernel_size = _encoder_arch(s)
     return {
         "loaded": True,
         "path": _CHECKPOINT_PATH,
         "source": _CHECKPOINT_SOURCE,
-        "chan1": chan1,
-        "chan2": chan2,
-        "chan3": chan3,
+        "layers": layers,
+        "kernel_size": kernel_size,
         "device": str(_AGENT_DEVICE),
     }
 
@@ -372,18 +381,18 @@ def _get_agent(size: int) -> AgentCNN:
     if size in _AGENT_CACHE:
         return _AGENT_CACHE[size]
 
-    chan1, chan2, chan3 = _encoder_channels(_CHECKPOINT_STATE)
+    layers, kernel_size = _encoder_arch(_CHECKPOINT_STATE)
 
     env_id = "factorion/FactorioEnv-v0-fb"
     if env_id not in gym.registry:
         gym.register(id=env_id, entry_point=FactorioEnv)
     envs = gym.vector.SyncVectorEnv([make_env(env_id, 0, False, size, "fb")])
     try:
-        agent = AgentCNN(envs, chan1=chan1, chan2=chan2, chan3=chan3)
+        agent = AgentCNN(envs, layers=layers, kernel_size=kernel_size)
     finally:
         envs.close()
     # critic_head and eot_head are both Linear(flat_dim, 1) where
-    # flat_dim = chan3 * W * H, so their saved weights are the wrong
+    # flat_dim = layers[-1] * W * H, so their saved weights are the wrong
     # shape whenever the UI grid size != the training size. strict=False
     # would *not* save us here — it ignores missing/unexpected keys but
     # still raises on shape mismatches, so we filter explicitly.
@@ -396,20 +405,21 @@ def _get_agent(size: int) -> AgentCNN:
     # UI's eot panel shows the real trained prediction. Pre-#103
     # checkpoints have no eot_head keys at all → load_state_dict
     # (strict=False) leaves the freshly-initialised head in place.
-    expected_flat = chan3 * size * size
+    expected_flat = layers[-1] * size * size
     saved_eot_w = _CHECKPOINT_STATE.get("eot_head.1.weight")
     keep_eot = saved_eot_w is not None and saved_eot_w.shape[1] == expected_flat
     drop_prefixes: tuple[str, ...] = ("critic_head.",)
     if not keep_eot:
         drop_prefixes = drop_prefixes + ("eot_head.",)
     filtered = {
-        k: v for k, v in _CHECKPOINT_STATE.items()
-        if not k.startswith(drop_prefixes)
+        k: v for k, v in _CHECKPOINT_STATE.items() if not k.startswith(drop_prefixes)
     }
     missing, unexpected = agent.load_state_dict(filtered, strict=False)
     ignorable = {
-        "critic_head.1.weight", "critic_head.1.bias",
-        "eot_head.1.weight", "eot_head.1.bias",
+        "critic_head.1.weight",
+        "critic_head.1.bias",
+        "eot_head.1.weight",
+        "eot_head.1.bias",
     }
     real_missing = [k for k in missing if k not in ignorable]
     real_unexpected = [k for k in unexpected if k not in ignorable]
@@ -423,7 +433,9 @@ def _get_agent(size: int) -> AgentCNN:
     return agent
 
 
-def _top_p_named(probs: torch.Tensor, names: dict, top_p: float = 0.95) -> tuple[list[dict], float]:
+def _top_p_named(
+    probs: torch.Tensor, names: dict, top_p: float = 0.95
+) -> tuple[list[dict], float]:
     """Sort `probs` (1-D) by descending probability, take entries until
     cumulative mass >= top_p, return them as [{name, p}, ...] plus the
     remaining "rest" mass. Useful for showing the model's distribution
@@ -440,7 +452,9 @@ def _top_p_named(probs: torch.Tensor, names: dict, top_p: float = 0.95) -> tuple
     return top, max(0.0, 1.0 - cum)
 
 
-def _tile_top_p(probs: torch.Tensor, H: int, top_p: float = 0.95) -> tuple[list[dict], float]:
+def _tile_top_p(
+    probs: torch.Tensor, H: int, top_p: float = 0.95
+) -> tuple[list[dict], float]:
     """Same as _top_p_named but emits (x, y, p) entries for the tile
     head, since each entry is a 2-D coordinate rather than a named
     category."""
@@ -499,13 +513,21 @@ def _predict(grid: list[list[dict]]) -> dict:
         x, y = tile_idx // H, tile_idx % H
 
         feats = encoded_BCWH[0, :, x, y].unsqueeze(0)
-        ent_top, ent_rest = _top_p_named(F.softmax(agent.ent_head(feats), dim=-1)[0], _ENT_NAMES)
-        dir_top, dir_rest = _top_p_named(F.softmax(agent.dir_head(feats), dim=-1)[0], _DIR_NAMES)
-        item_top, item_rest = _top_p_named(F.softmax(agent.item_head(feats), dim=-1)[0], _ITEM_NAMES)
-        misc_top, misc_rest = _top_p_named(F.softmax(agent.misc_head(feats), dim=-1)[0], _MISC_NAMES)
+        ent_top, ent_rest = _top_p_named(
+            F.softmax(agent.ent_head(feats), dim=-1)[0], _ENT_NAMES
+        )
+        dir_top, dir_rest = _top_p_named(
+            F.softmax(agent.dir_head(feats), dim=-1)[0], _DIR_NAMES
+        )
+        item_top, item_rest = _top_p_named(
+            F.softmax(agent.item_head(feats), dim=-1)[0], _ITEM_NAMES
+        )
+        misc_top, misc_rest = _top_p_named(
+            F.softmax(agent.misc_head(feats), dim=-1)[0], _MISC_NAMES
+        )
 
         # Per-tile argmax for ent/dir/item/misc — one matmul per head
-        # against the whole spatial map, reshaped to (W*H, chan3).
+        # against the whole spatial map, reshaped to (W*H, C).
         feats_all = encoded_BCWH[0].permute(1, 2, 0).reshape(W * H, -1)
         ent_pick = agent.ent_head(feats_all).argmax(dim=-1)
         dir_pick = agent.dir_head(feats_all).argmax(dim=-1)
@@ -513,17 +535,32 @@ def _predict(grid: list[list[dict]]) -> dict:
         misc_pick = agent.misc_head(feats_all).argmax(dim=-1)
 
         candidates: list[dict] = []
-        mask = (tile_probs > CANDIDATE_TILE_THRESHOLD).nonzero(as_tuple=False).squeeze(-1).tolist()
+        mask = (
+            (tile_probs > CANDIDATE_TILE_THRESHOLD)
+            .nonzero(as_tuple=False)
+            .squeeze(-1)
+            .tolist()
+        )
         for t in mask:
-            candidates.append({
-                "x": t // H,
-                "y": t % H,
-                "p_tile": float(tile_probs[t].item()),
-                "entity": _ENT_NAMES.get(int(ent_pick[t].item()), str(int(ent_pick[t].item()))),
-                "direction": _DIR_NAMES.get(int(dir_pick[t].item()), str(int(dir_pick[t].item()))),
-                "item": _ITEM_NAMES.get(int(item_pick[t].item()), str(int(item_pick[t].item()))),
-                "misc": _MISC_NAMES.get(int(misc_pick[t].item()), str(int(misc_pick[t].item()))),
-            })
+            candidates.append(
+                {
+                    "x": t // H,
+                    "y": t % H,
+                    "p_tile": float(tile_probs[t].item()),
+                    "entity": _ENT_NAMES.get(
+                        int(ent_pick[t].item()), str(int(ent_pick[t].item()))
+                    ),
+                    "direction": _DIR_NAMES.get(
+                        int(dir_pick[t].item()), str(int(dir_pick[t].item()))
+                    ),
+                    "item": _ITEM_NAMES.get(
+                        int(item_pick[t].item()), str(int(item_pick[t].item()))
+                    ),
+                    "misc": _MISC_NAMES.get(
+                        int(misc_pick[t].item()), str(int(misc_pick[t].item()))
+                    ),
+                }
+            )
 
     return {
         "x": x,
@@ -600,19 +637,12 @@ def render_index(default_size: int) -> str:
     # The recipe/filter dropdown can hold any item, not just the curated
     # palette set — generated lessons routinely set obscure recipes
     # (e.g. burner_mining_drill) and we want them visible + editable.
-    all_item_names = sorted(
-        {it.name for it in items.values() if it.name != "empty"}
-    )
+    all_item_names = sorted({it.name for it in items.values() if it.name != "empty"})
     all_item_options = "".join(
-        f'<option value="{n}">{n}</option>'
-        for n in (["empty"] + all_item_names)
+        f'<option value="{n}">{n}</option>' for n in (["empty"] + all_item_names)
     )
-    direction_options = "".join(
-        f'<option value="{d}">{d}</option>' for d in DIRECTIONS
-    )
-    misc_options = "".join(
-        f'<option value="{m}">{m}</option>' for m in MISC_VALUES
-    )
+    direction_options = "".join(f'<option value="{d}">{d}</option>' for d in DIRECTIONS)
+    misc_options = "".join(f'<option value="{m}">{m}</option>' for m in MISC_VALUES)
     lesson_options = "".join(
         f'<option value="{k.name}">{k.name}</option>' for k in LessonKind
     )
@@ -624,26 +654,26 @@ def render_index(default_size: int) -> str:
         '<div class="model-panel">'
         '<h3 style="margin-top:0.8em;">'
         '<span class="swatch"></span>Model'
-        '</h3>'
+        "</h3>"
         '<div class="model-current help" id="model-current">checking…</div>'
         '<div class="model-loader">'
-        '<label>switch model'
+        "<label>switch model"
         '  <input id="model-value" type="text" placeholder="sft_local.pt or run_id">'
-        '</label>'
+        "</label>"
         '<div class="model-buttons">'
         '<button id="model-load" title="Local path if the file exists, else wandb run id">'
-        'Load model</button>'
-        '</div>'
+        "Load model</button>"
+        "</div>"
         '<div id="model-load-status" class="help"></div>'
-        '</div>'
+        "</div>"
         '<h3 style="margin-top:0.8em;">Prediction</h3>'
         '<div id="model-info" class="help">(no prediction yet)</div>'
         '<pre id="model-action"></pre>'
         '<div class="model-buttons">'
         '<button id="model-apply" title="Apply the predicted placement at the highlighted tile">'
         'Apply prediction <span class="kbd">a</span></button>'
-        '</div>'
-        '</div>'
+        "</div>"
+        "</div>"
     )
 
     return f"""<!doctype html>
@@ -1279,8 +1309,8 @@ async function refreshModelInfo() {{
     const data = await resp.json();
     if (data.loaded) {{
       modelLoaded = true;
-      const shape = 'c1=' + data.chan1 + ' c2=' + data.chan2 +
-        ' c3=' + data.chan3 + ' ' + data.device;
+      const shape = 'layers=' + (data.layers || []).join('-') +
+        ' k=' + data.kernel_size + ' ' + data.device;
       const src = data.source || {{}};
       if (src.kind === 'wandb') {{
         // Show the run id directly — that's what the user types into
@@ -1543,7 +1573,9 @@ def main(args: Args) -> None:
         raise SystemExit("pass either --checkpoint or --wandb-run, not both")
     if args.wandb_run:
         ckpt_path, source = _resolve_wandb_checkpoint(
-            args.wandb_run, args.wandb_project, args.wandb_entity,
+            args.wandb_run,
+            args.wandb_project,
+            args.wandb_entity,
         )
         _load_checkpoint(ckpt_path)
         _CHECKPOINT_SOURCE = source

--- a/sft.py
+++ b/sft.py
@@ -36,7 +36,7 @@ from factorion import (  # noqa: E402
     entities,
 )
 
-from ppo import AgentCNN, FactorioEnv, make_env  # noqa: E402
+from ppo import AgentCNN, FactorioEnv, make_env, layers_from_args  # noqa: E402
 
 
 def extract_expert_actions(solved_CWH, task_CWH):
@@ -209,14 +209,21 @@ class SFTArgs:
     """EOT-head prob above which we mark the model "would stop" (for val/throughput_eot)"""
     checkpoint_path: str = "sft_checkpoint.pt"
     """path to save the trained model"""
-    chan1: int = 48
-    """CNN encoder channel 1"""
-    chan2: int = 48
-    """CNN encoder channel 2"""
-    chan3: int = 64
-    """CNN encoder channel 3"""
-    flat_dim: int = 128
-    """flat dim (unused, kept for compat with AgentCNN)"""
+    # CNN encoder width per layer slot. The encoder uses every slot with
+    # positive width, in order; a slot of 0 drops that layer. Independent
+    # numeric slots (vs one categorical "64,64,64" string) let a W&B Bayesian
+    # sweep optimise depth + per-layer width ordinally.
+    # RF = 1 + n_layers * (kernel_size - 1).
+    layer1: int = 48
+    layer2: int = 48
+    layer3: int = 64
+    layer4: int = 0
+    layer5: int = 0
+    layer6: int = 0
+    layer7: int = 0
+    layer8: int = 0
+    kernel_size: int = 3
+    """CNN conv kernel size (odd); padding pinned to kernel_size // 2 ("same")"""
     tile_head_std: float = 0.02208
     """tile head init std"""
     track: bool = False
@@ -267,12 +274,13 @@ def _artifact_name(args: "SFTArgs") -> str:
     get their own artifact. `best_val_acc` deliberately goes to the alias
     instead, since baking a varying number into the name would defeat
     versioning."""
-    chans = (args.chan1, args.chan2, args.chan3)
-    chan_str = (
-        f"c{args.chan1}"
-        if len(set(chans)) == 1
-        else f"c{args.chan1}-{args.chan2}-{args.chan3}"
-    )
+    # Encode the full layer list (one token per conv layer) so runs that
+    # differ in depth *or* width get distinct artifacts; append the kernel
+    # size only when it's non-default so existing names stay stable.
+    layers = layers_from_args(args)
+    chan_str = "c" + "-".join(str(c) for c in layers)
+    if args.kernel_size != 3:
+        chan_str += f"-k{args.kernel_size}"
     return (
         f"sft-s{args.size}"
         f"-n{_humanize_count(args.num_samples)}"
@@ -725,10 +733,8 @@ def train_sft(args: SFTArgs):
 
     agent = AgentCNN(
         envs,
-        chan1=args.chan1,
-        chan2=args.chan2,
-        chan3=args.chan3,
-        flat_dim=args.flat_dim,
+        layers=layers_from_args(args),
+        kernel_size=args.kernel_size,
         tile_head_std=args.tile_head_std,
     )
     envs.close()
@@ -1379,9 +1385,8 @@ def train_sft(args: SFTArgs):
                 "best_val_throughput": best_val_throughput,
                 "best_val_acc": best_val_acc,
                 "size": args.size,
-                "chan1": args.chan1,
-                "chan2": args.chan2,
-                "chan3": args.chan3,
+                "layers": "-".join(map(str, layers_from_args(args))),
+                "kernel_size": args.kernel_size,
                 "num_samples": args.num_samples,
                 "epochs": args.epochs,
                 "batch_size": args.batch_size,

--- a/sft.py
+++ b/sft.py
@@ -183,6 +183,8 @@ class SFTArgs:
     """cosine decay floor as a fraction of lr (final LR = lr * min_lr_ratio)"""
     weight_decay: float = 2.902e-4
     """AdamW weight decay"""
+    dropout: float = 0.0
+    """spatial dropout (Dropout2d) after each encoder conv. 0.0 = off (no-op)."""
     max_grad_norm: float = 2.104
     """grad L2-norm clip (0 disables clipping)"""
     lw_tile: float = 1.162
@@ -743,6 +745,7 @@ def train_sft(args: SFTArgs):
         layers=layers_from_args(args),
         kernel_size=args.kernel_size,
         tile_head_std=args.tile_head_std,
+        dropout=args.dropout,
     )
     envs.close()
 
@@ -844,6 +847,7 @@ def train_sft(args: SFTArgs):
     print(f"Training for {args.epochs} epochs on {device}...")
 
     for epoch in range(1, args.epochs + 1):
+        t_train = time.time()
         agent.train()
         train_loss = 0.0
         train_loss_tile = 0.0
@@ -857,10 +861,26 @@ def train_sft(args: SFTArgs):
         train_eot_correct = 0
         grad_norm_sum = 0.0
         grad_norm_count = 0
+        # Wall-clock attribution for the train pass, with NO added syncs. The
+        # loop already calls .item() every batch (loss/accuracy accumulation),
+        # which makes the GPU finish that batch before we read it — so each
+        # batch's wall time genuinely splits into "waiting for the DataLoader to
+        # hand us the batch" vs "computing it". That tells us whether we're
+        # data-loading-bound or compute-bound. (A finer forward/backward/optim
+        # split is NOT measurable this way: isolating them needs syncs between
+        # each, which serialise a normally-overlapped pipeline and measure a
+        # number a real run never produces.)
+        train_data_s = 0.0
+        train_compute_s = 0.0
+        num_batches = 0
 
         # batch_kind is carried through the loader so val can aggregate
         # per-kind metrics; we ignore it in the train pass.
+        t_batch = time.time()
         for batch in train_loader:
+            t_ready = time.time()
+            train_data_s += t_ready - t_batch
+            num_batches += 1
             (
                 batch_obs,
                 batch_tile,
@@ -928,7 +948,6 @@ def train_sft(args: SFTArgs):
                 + args.lw_misc * loss_misc
                 + args.lw_eot * loss_eot
             )
-
             optimizer.zero_grad()
             loss.backward()
             if args.max_grad_norm > 0:
@@ -979,6 +998,10 @@ def train_sft(args: SFTArgs):
             train_correct += int(correct.sum().item())
             train_total += B
             train_eot_correct += int(eot_correct_t.sum().item())
+            # The .item() reads above synced this batch's GPU work, so now is
+            # the real "batch finished" moment.
+            t_batch = time.time()
+            train_compute_s += t_batch - t_ready
 
         train_loss /= train_total
         train_loss_tile /= train_total
@@ -989,8 +1012,10 @@ def train_sft(args: SFTArgs):
         train_loss_eot /= train_total
         train_acc = train_correct / train_total
         train_eot_acc = train_eot_correct / train_total
+        train_seconds = time.time() - t_train
 
         # Validation
+        t_val = time.time()
         agent.eval()
         val_loss = 0.0
         val_loss_tile = 0.0
@@ -1212,6 +1237,8 @@ def train_sft(args: SFTArgs):
                 per_kind_misc_correct[k.name] / n
             )
 
+        val_seconds = time.time() - t_val
+
         # Rollout eval: every N epochs greedy-play the held-out factories
         # and record final throughput. Same lessons as val accuracy, so
         # val/throughput is directly comparable to val/acc curves.
@@ -1261,6 +1288,11 @@ def train_sft(args: SFTArgs):
                 f"  val_thp={overall_thp:.3f} ({rollout_seconds:.1f}s)"
                 if overall_thp is not None
                 else ""
+            )
+            + (
+                f" | t: train={train_seconds:.1f}s "
+                f"(data={train_data_s:.1f}s compute={train_compute_s:.1f}s) "
+                f"val={val_seconds:.1f}s"
             )
         )
         if per_kind_metrics:
@@ -1319,6 +1351,12 @@ def train_sft(args: SFTArgs):
                     "train/grad_norm": (grad_norm_sum / grad_norm_count)
                     if grad_norm_count > 0
                     else float("nan"),
+                    # Real wall-clock (no added syncs); train splits into
+                    # DataLoader wait vs compute to expose data-vs-compute bound.
+                    "perf/train_seconds": train_seconds,
+                    "perf/train_data_seconds": train_data_s,
+                    "perf/train_compute_seconds": train_compute_s,
+                    "perf/val_seconds": val_seconds,
                     **per_kind_metrics,
                 },
                 step=samples_seen,

--- a/sft.py
+++ b/sft.py
@@ -474,7 +474,14 @@ def run_rollout_eval(
     was_training = agent.training
     agent.eval()
 
-    max_level = args.max_level if args.max_level > 0 else 2 * args.size
+    # Greedy build metric = build from a COMPLETELY EMPTY grid. Blank the
+    # whole factory: size*size >= any factory's entity count, so
+    # blank_entities removes every placeable entity (it caps at
+    # total_entities). The old 2*size left 6/7 lesson kinds partly built
+    # (e.g. ASSEMBLE_2IN_1OUT has up to 66 entities >> 2*size=22), which
+    # measured "finish a half-built factory", not true build skill. Mirrors
+    # the training-side full blank (max_level == size*size when unset).
+    max_level = args.max_level if args.max_level > 0 else args.size * args.size
 
     # Deterministic, run-stable subsample of val seeds. Sorting first
     # makes the selection independent of dict iteration order, then we

--- a/sft.py
+++ b/sft.py
@@ -796,6 +796,13 @@ def train_sft(args: SFTArgs):
             group=args.wandb_group,
             tags=sft_tags,
         )
+        # Summarise the greedy-build metrics as their MAX over training rather
+        # than the default last-epoch value: that max is the checkpoint-
+        # selection number and the right sweep objective, while the metric
+        # still streams to history every epoch (so a sweep sees incremental
+        # progress and can rank / early-stop on it). See sft_sweep.yaml.
+        run.define_metric("val/throughput", summary="max")
+        run.define_metric("val/throughput_eot", summary="max")
         # Dataset composition is a one-shot constant for the run — write it
         # to summary (which keeps the value visible in the run sidebar)
         # rather than wandb.log (which would create a flat plottable line).

--- a/sft_sweep.yaml
+++ b/sft_sweep.yaml
@@ -1,106 +1,90 @@
-# sft_sweep.yaml — SFT pre-training hyperparameter sweep
+# sft_sweep.yaml — SFT CNN-architecture sweep
 #
-# Compute-budget knobs that are monotonic-ish in val/acc (num_samples,
-# epochs, chan{1,2,3}) are pinned to the smoketest production config so
-# Bayes can't trivially saturate them and every run is directly
-# comparable to the prod checkpoint. The sweep instead optimises knobs
-# with a genuine interior optimum:
-#   - cosine LR schedule (issue #101): lr, warmup_frac, min_lr_ratio
-#   - regularisation: weight_decay, max_grad_norm
-#   - per-head loss weights (5 placement heads + EOT): lw_*
-#   - data-shape tradeoffs: batch_size, max_level, tile_head_std
+# Searches the encoder architecture (depth + per-layer width + receptive
+# field) against the greedy-build metric `val/throughput` — the honest
+# "can it actually build the factory" number, not the per-head accuracy.
+#
+# Compute-budget knobs (size, num_samples, epochs) are PINNED to the C7
+# high-throughput regime (held-out greedy 0.947: size 11, ~300k expert
+# pairs, 50 epochs, a deep 6-layer encoder with RF >= grid) so every run
+# is directly comparable and Bayes spends its budget discovering the
+# architecture instead of re-deriving the data scale.
+#
+# Per-head loss weights (lw_*), the LR-schedule shape (warmup/min_lr),
+# regularisation and tile_head_std are deliberately NOT swept here: their
+# SFTArgs defaults are the previous (val/acc) sweep's winner, and adding
+# them would blow the search dimensionality past what run_cap=60 can
+# resolve. Re-balance heads in a follow-up sweep on the winning encoder
+# if dir_acc still bottlenecks greedy build.
 
 method: bayes
 run_cap: 60
 metric:
-  name: "val/acc"
+  name: "val/throughput"
   goal: maximize
 
 parameters:
-  # Pinned because val/acc is monotonic in these: more data, more epochs,
-  # and a lower max_level all make the val task trivially easier and
-  # Bayes would just saturate them. Channels are NOT pinned — bigger
-  # encoders can overfit a fixed dataset (no dropout in AgentCNN), so
-  # there's a real interior optimum.
+  # ── Pinned compute budget (C7 regime) ────────────────────────────
   size:
     value: 11
   num_samples:
     value: 300000
   epochs:
-    value: 30
+    value: 50
   max_level:
-    value: 0  # auto = 2*size = 22 entities blanked
+    value: 0  # auto = 2*size entities blanked (full-chain build)
 
-  # ── LR schedule (issue #101) ─────────────────────────────────────
+  # ── Encoder architecture (the search) ────────────────────────────
+  # Each layer{1..8} is that conv layer's channel width; the encoder uses
+  # every slot with width > 0, in order, so driving a slot to 0 drops a
+  # layer — Bayes tunes depth AND width as independent ordinal dimensions
+  # (int_uniform, not a categorical "64,64,64" string it can't reason
+  # about). layer1..3 stay positive to keep a sane minimum depth of 3;
+  # layer4..8 may reach 0. RF = 1 + n_layers * (kernel_size - 1): the C7
+  # winner was 6 layers @ kernel 3 (RF 13 >= the grid). kernel_size 5
+  # reaches the same RF in fewer, wider layers.
+  layer1:
+    distribution: int_uniform
+    min: 32
+    max: 96
+  layer2:
+    distribution: int_uniform
+    min: 32
+    max: 96
+  layer3:
+    distribution: int_uniform
+    min: 32
+    max: 96
+  layer4:
+    distribution: int_uniform
+    min: 0
+    max: 96
+  layer5:
+    distribution: int_uniform
+    min: 0
+    max: 96
+  layer6:
+    distribution: int_uniform
+    min: 0
+    max: 96
+  layer7:
+    distribution: int_uniform
+    min: 0
+    max: 96
+  layer8:
+    distribution: int_uniform
+    min: 0
+    max: 96
+  kernel_size:
+    values: [3, 5]
+
+  # ── LR (co-varies with depth, so swept alongside architecture) ────
+  # A fixed LR would unfairly favour whatever depth that LR happens to
+  # suit; letting it adapt keeps the architecture comparison honest.
   lr:
     distribution: log_uniform_values
     min: 1e-4
     max: 3e-3
-  warmup_frac:
-    values: [0.0, 0.02, 0.05, 0.1]
-  min_lr_ratio:
-    distribution: log_uniform_values
-    min: 1e-3
-    max: 1e-1
-
-  # ── Regularisation ────────────────────────────────────────────────
-  weight_decay:
-    distribution: log_uniform_values
-    min: 1e-6
-    max: 1e-2
-  max_grad_norm:
-    distribution: uniform
-    min: 0.5
-    max: 3.0
-
-  # ── Data-shape tradeoffs ──────────────────────────────────────────
-  batch_size:
-    values: [256, 512, 1024]
-  tile_head_std:
-    distribution: log_uniform_values
-    min: 0.001
-    max: 0.1
-
-  # ── Encoder capacity ──────────────────────────────────────────────
-  # AgentCNN has no dropout, so bigger encoders can overfit the (fixed)
-  # 300k-sample SFT dataset. Genuine interior optimum.
-  chan1:
-    values: [32, 48, 64]
-  chan2:
-    values: [48, 64]
-  chan3:
-    values: [48, 64]
-
-  # ── Per-head loss weights ─────────────────────────────────────────
-  # With 6 losses summed, equal weighting (= 1.0 each) implicitly
-  # assumes each head's gradient signal is equally informative — almost
-  # certainly wrong now that recipe/item and EOT heads exist alongside
-  # entity/direction. Log-uniform around 1.0 lets Bayes search find a
-  # useful re-balancing without blowing up scale.
-  lw_tile:
-    distribution: log_uniform_values
-    min: 0.3
-    max: 3.0
-  lw_ent:
-    distribution: log_uniform_values
-    min: 0.3
-    max: 3.0
-  lw_dir:
-    distribution: log_uniform_values
-    min: 0.3
-    max: 3.0
-  lw_item:
-    distribution: log_uniform_values
-    min: 0.3
-    max: 3.0
-  lw_misc:
-    distribution: log_uniform_values
-    min: 0.3
-    max: 3.0
-  lw_eot:
-    distribution: log_uniform_values
-    min: 0.3
-    max: 3.0
 
 program: sft.py
 

--- a/sft_sweep.yaml
+++ b/sft_sweep.yaml
@@ -4,18 +4,19 @@
 # field) against the greedy-build metric — the honest "can it actually
 # build the factory" number, not the per-head accuracy.
 #
-# Target is `best_val_throughput`: the run.summary scalar sft.py sets to
-# the MAX greedy throughput over training (the same number that selects
-# the checkpoint). Optimising the per-epoch `val/throughput` history key
-# would instead chase the LAST epoch's value — sft.py defines no
-# summary="max" for it — so it would reward late-epoch noise, not the
-# best achievable architecture.
+# Target is `val/throughput` (greedy build rate): sft.py logs it to history
+# every epoch AND — via define_metric(summary="max") — summarises it as the
+# MAX over training, the same number that selects the checkpoint. So Bayes
+# optimises the best achievable architecture while still seeing each run's
+# progress incrementally (rankable / early-stoppable mid-run) rather than
+# waiting for an end-of-run-only scalar.
 #
-# Compute-budget knobs (size, num_samples, epochs) are PINNED to the C7
+# Compute-budget knobs (size, num_samples) are PINNED to the C7
 # high-throughput regime (held-out greedy 0.947: size 11, ~300k expert
-# pairs, 50 epochs, a deep 6-layer encoder with RF >= grid) so every run
-# is directly comparable and Bayes spends its budget discovering the
-# architecture instead of re-deriving the data scale.
+# pairs, deep encoder with RF >= grid) so every run is comparable and Bayes
+# spends its budget on architecture. epochs is cut to 15 (vs C7's 50) so all
+# configs finish inside the pod budget — enough to rank architectures;
+# verify the winner at the full 50 epochs afterwards.
 #
 # Per-head loss weights (lw_*), the LR-schedule shape (warmup/min_lr),
 # regularisation and tile_head_std are deliberately NOT swept here: their
@@ -27,7 +28,7 @@
 method: bayes
 run_cap: 60
 metric:
-  name: "best_val_throughput"
+  name: "val/throughput"
   goal: maximize
 
 parameters:
@@ -37,9 +38,9 @@ parameters:
   num_samples:
     value: 300000
   epochs:
-    value: 50
+    value: 15
   max_level:
-    value: 0  # auto = 2*size entities blanked (full-chain build)
+    value: 0 # auto = 2*size entities blanked (full-chain build)
 
   # ── Encoder architecture (the search) ────────────────────────────
   # Each layer{1..8} is a conv layer's channel width; the encoder uses every
@@ -68,25 +69,27 @@ parameters:
     min: 32
     max: 96
   layer4:
-    values: [0, 32, 48, 64, 96]
+    values: [0, 0, 0, 0, 32, 48, 64, 96]
   layer5:
-    values: [0, 32, 48, 64, 96]
+    values: [0, 0, 0, 0, 32, 48, 64, 96]
   layer6:
-    values: [0, 32, 48, 64, 96]
+    values: [0, 0, 0, 0, 32, 48, 64, 96]
   layer7:
-    values: [0, 32, 48, 64, 96]
+    values: [0, 0, 0, 0, 32, 48, 64, 96]
   layer8:
-    values: [0, 32, 48, 64, 96]
+    values: [0, 0, 0, 0, 32, 48, 64, 96]
   kernel_size:
-    values: [3, 5]
+    values: [3, 5, 7]
 
   # ── LR (co-varies with depth, so swept alongside architecture) ────
-  # A fixed LR would unfairly favour whatever depth that LR happens to
-  # suit; letting it adapt keeps the architecture comparison honest.
+  # A fixed LR would unfairly favour whatever depth that LR happens to suit;
+  # letting it adapt keeps the architecture comparison honest. Floor raised
+  # to 3e-4: at 15 epochs an lr of 1e-4 barely converges (the first sweep's
+  # 1e-4 runs sat near 0 even at epoch 20), so it just wastes runs.
   lr:
     distribution: log_uniform_values
-    min: 1.0e-4
-    max: 3.0e-3
+    min: 3.0e-4
+    max: 5.0e-3
 
 program: sft.py
 

--- a/sft_sweep.yaml
+++ b/sft_sweep.yaml
@@ -19,12 +19,12 @@
 #   num_samples 300k -> 100k, epochs 50 -> 15, and the per-epoch greedy eval
 #   (the costly, CPU-bound part) is thinned to every 3rd epoch on 50 seeds.
 #
-# Per-head loss weights (lw_*), the LR-schedule shape (warmup/min_lr),
-# regularisation and tile_head_std are deliberately NOT swept here: their
-# SFTArgs defaults are the previous (val/acc) sweep's winner, and adding
-# them would blow the search dimensionality past what run_cap=60 can
-# resolve. Re-balance heads in a follow-up sweep on the winning encoder
-# if dir_acc still bottlenecks greedy build.
+# Per-head loss weights (lw_*), the LR-schedule shape (warmup/min_lr) and
+# tile_head_std are deliberately NOT swept here: their SFTArgs defaults are the
+# previous (val/acc) sweep's winner, and adding them would blow the search
+# dimensionality past what run_cap=60 can resolve. Regularisation (dropout +
+# weight_decay) IS swept this round — #2 overfit, so finding the right
+# regularisation strength is part of the point (see the section below).
 
 method: bayes
 run_cap: 60
@@ -37,33 +37,26 @@ parameters:
   size:
     value: 11
   num_samples:
-    value: 100000
+    value: 200000
   epochs:
-    value: 23
+    value: 10 # 200k x 10 => each sample seen 10x (vs #2's 23x): curbs overfit
   max_level:
     value: 0 # auto = size*size: training blanks the full factory
-  # Thin the per-epoch greedy eval — its rollouts hammer the Rust throughput
-  # sim every step (CPU-bound) and dominate wall-time under 5-way pod
-  # contention. Every 3rd epoch on 50 seeds (~8 eval points over 23 epochs)
-  # feeds the summary=max objective at a fraction of the cost. Dropping the
-  # slow k=7 nets (see below) buys back the wall-time for the extra epochs.
   eval_rollouts_every_n_epochs:
-    value: 3
+    value: 2
   eval_rollouts_max_seeds:
-    value: 50
+    value: 100
 
-  # ── Encoder architecture (the REFINED search) ─────────────────────
-  # Refinement of the first 20-run sweep (k13mwoj8), which gave a sharp
-  # verdict: of 3 runs that built anything, ALL were kernel_size=3 (3/4 k=3
-  # runs built; 0/16 k=5/k=7 runs did), 4-6 layers, lr ~0.0017-0.0026. k=7
-  # never trained past val/acc 0.16 in-budget. So:
-  #   - kernel_size in {3,5} (drop the dead k=7; k=5 kept — its 3 prior
-  #     failures all had low lr, so it was never fairly tested).
-  #   - depth capped at 6: layer7/layer8 pinned to 0 (every builder was <=6).
-  # Each layer{1..6} is a conv layer's channel width; a slot of 0 drops that
-  # layer. layer1..3 are always-present ordinal widths (int_uniform, min
-  # depth 3); layer4..6 are a small ORDERED set INCLUDING 0 so depth varies
-  # 3..6. RF = 1 + n_layers * (kernel_size - 1).
+  # ── Encoder architecture (k=3 pinned; depth + width still searched) ──
+  # Sweep #2 (yxvpjz1f, 20 runs) settled the KERNEL: kernel_size=3 dominates
+  # (top-6 by greedy throughput all k=3, best 0.14 [52,59,58,96]; best k=5 only
+  # 0.06), so it's pinned to 3. Depth/width stay OPEN: #2's winners were 4-5
+  # layers, but on a handful of runs under heavier (23-epoch) overfit, and this
+  # round changes the regime (more data, fewer epochs) — so a shallower net
+  # that overfit before may do fine now. layer1..2 always-on (int_uniform);
+  # layer3..5 each may drop to 0 (depth 2-5); layer6/7/8 = 0. Each layer{1..5}
+  # is a conv width; a 0 drops the slot and layers_from_args() compacts the
+  # rest. Widths 32..96 (winners spanned the range). RF = 1 + n_layers*(k-1).
   layer1:
     distribution: int_uniform
     min: 32
@@ -72,31 +65,40 @@ parameters:
     distribution: int_uniform
     min: 32
     max: 96
-  layer3:
-    distribution: int_uniform
-    min: 32
-    max: 96
-  layer4:
-    values: [0, 0, 0, 0, 32, 48, 64, 96]
-  layer5:
-    values: [0, 0, 0, 0, 32, 48, 64, 96]
-  layer6:
-    values: [0, 0, 0, 0, 32, 48, 64, 96]
-  layer7:
-    value: 0
-  layer8:
-    value: 0
+  layer3: { values: [0, 0, 32, 48, 64, 96] }
+  layer4: { values: [0, 0, 32, 48, 64, 96] }
+  layer5: { values: [0, 0, 32, 48, 64, 96] }
+  layer6: { value: 0 }
+  layer7: { value: 0 }
+  layer8: { value: 0 }
   kernel_size:
-    values: [3, 5]
+    value: 3
 
   # ── LR (co-varies with depth, so swept alongside architecture) ────
-  # Narrowed to [1e-3, 3e-3] around the first sweep's productive band: the 3
-  # runs that built had lr 0.0017 / 0.0025 / 0.0026, while the lone k=3 run
-  # that failed had lr 0.0004 (val/acc only 0.33). So drop the dead-low end.
+  # Narrowed to [1.5e-3, 3.5e-3]. Both sweeps put every productive run in
+  # ~0.0017-0.0028 (best 0.14 @ 0.0027; #1's builders 0.0017 / 0.0025 / 0.0026)
+  # and BOTH peaked at ~0.0026-0.0027 — independent evidence the optimum sits
+  # there, not higher. So drop the dead-low end (lr <=0.0014 underperformed)
+  # and keep only modest headroom above the known-best.
   lr:
     distribution: log_uniform_values
-    min: 1.0e-3
-    max: 3.0e-3
+    min: 1.5e-3
+    max: 3.5e-3
+
+  # ── Regularisation (the anti-overfit dials, swept this round) ─────
+  # #2 overfit hard at 23 epochs. Alongside the samples-up / epochs-down change
+  # above, search both regularisers: dropout (spatial Dropout2d after each
+  # encoder conv) and AdamW weight_decay. The low ends (dropout 0, wd ~1e-5)
+  # are effectively "off", so the sweep can still land on "no extra
+  # regularisation" if the data/epoch change alone already fixes the overfit.
+  dropout:
+    distribution: uniform
+    min: 0.0
+    max: 0.3
+  weight_decay:
+    distribution: log_uniform_values
+    min: 1.0e-5
+    max: 1.0e-2
 
 program: sft.py
 

--- a/sft_sweep.yaml
+++ b/sft_sweep.yaml
@@ -1,8 +1,15 @@
 # sft_sweep.yaml — SFT CNN-architecture sweep
 #
 # Searches the encoder architecture (depth + per-layer width + receptive
-# field) against the greedy-build metric `val/throughput` — the honest
-# "can it actually build the factory" number, not the per-head accuracy.
+# field) against the greedy-build metric — the honest "can it actually
+# build the factory" number, not the per-head accuracy.
+#
+# Target is `best_val_throughput`: the run.summary scalar sft.py sets to
+# the MAX greedy throughput over training (the same number that selects
+# the checkpoint). Optimising the per-epoch `val/throughput` history key
+# would instead chase the LAST epoch's value — sft.py defines no
+# summary="max" for it — so it would reward late-epoch noise, not the
+# best achievable architecture.
 #
 # Compute-budget knobs (size, num_samples, epochs) are PINNED to the C7
 # high-throughput regime (held-out greedy 0.947: size 11, ~300k expert
@@ -20,7 +27,7 @@
 method: bayes
 run_cap: 60
 metric:
-  name: "val/throughput"
+  name: "best_val_throughput"
   goal: maximize
 
 parameters:
@@ -35,14 +42,19 @@ parameters:
     value: 0  # auto = 2*size entities blanked (full-chain build)
 
   # ── Encoder architecture (the search) ────────────────────────────
-  # Each layer{1..8} is that conv layer's channel width; the encoder uses
-  # every slot with width > 0, in order, so driving a slot to 0 drops a
-  # layer — Bayes tunes depth AND width as independent ordinal dimensions
-  # (int_uniform, not a categorical "64,64,64" string it can't reason
-  # about). layer1..3 stay positive to keep a sane minimum depth of 3;
-  # layer4..8 may reach 0. RF = 1 + n_layers * (kernel_size - 1): the C7
-  # winner was 6 layers @ kernel 3 (RF 13 >= the grid). kernel_size 5
+  # Each layer{1..8} is a conv layer's channel width; the encoder uses every
+  # slot with width > 0, in order, so a slot of 0 drops that layer. Width
+  # and depth are thus tuned together. RF = 1 + n_layers * (kernel_size - 1):
+  # the C7 winner was 6 layers @ kernel 3 (RF 13 >= the grid); kernel_size 5
   # reaches the same RF in fewer, wider layers.
+  #
+  # layer1..3 are always-present ordinal widths (int_uniform), giving a
+  # minimum depth of 3. layer4..8 are a small ORDERED set INCLUDING 0, so
+  # "drop this layer" has real probability (~1/5 each) and depth genuinely
+  # varies across 3..8 — int_uniform almost never samples exactly 0, which
+  # would pin depth at 8 and leave the layer-count knob dead. This is the
+  # one place we accept a per-slot categorical: depth needs a discrete
+  # on/off, and the set stays small + ordered so Bayes still searches it.
   layer1:
     distribution: int_uniform
     min: 32
@@ -56,25 +68,15 @@ parameters:
     min: 32
     max: 96
   layer4:
-    distribution: int_uniform
-    min: 0
-    max: 96
+    values: [0, 32, 48, 64, 96]
   layer5:
-    distribution: int_uniform
-    min: 0
-    max: 96
+    values: [0, 32, 48, 64, 96]
   layer6:
-    distribution: int_uniform
-    min: 0
-    max: 96
+    values: [0, 32, 48, 64, 96]
   layer7:
-    distribution: int_uniform
-    min: 0
-    max: 96
+    values: [0, 32, 48, 64, 96]
   layer8:
-    distribution: int_uniform
-    min: 0
-    max: 96
+    values: [0, 32, 48, 64, 96]
   kernel_size:
     values: [3, 5]
 
@@ -83,8 +85,8 @@ parameters:
   # suit; letting it adapt keeps the architecture comparison honest.
   lr:
     distribution: log_uniform_values
-    min: 1e-4
-    max: 3e-3
+    min: 1.0e-4
+    max: 3.0e-3
 
 program: sft.py
 

--- a/sft_sweep.yaml
+++ b/sft_sweep.yaml
@@ -39,32 +39,31 @@ parameters:
   num_samples:
     value: 100000
   epochs:
-    value: 15
+    value: 23
   max_level:
     value: 0 # auto = size*size: training blanks the full factory
   # Thin the per-epoch greedy eval — its rollouts hammer the Rust throughput
   # sim every step (CPU-bound) and dominate wall-time under 5-way pod
-  # contention. Every 3rd epoch on 50 seeds keeps ~5 eval points across the
-  # 15 epochs (enough for the summary=max objective) at a fraction of the cost.
+  # contention. Every 3rd epoch on 50 seeds (~8 eval points over 23 epochs)
+  # feeds the summary=max objective at a fraction of the cost. Dropping the
+  # slow k=7 nets (see below) buys back the wall-time for the extra epochs.
   eval_rollouts_every_n_epochs:
     value: 3
   eval_rollouts_max_seeds:
     value: 50
 
-  # ── Encoder architecture (the search) ────────────────────────────
-  # Each layer{1..8} is a conv layer's channel width; the encoder uses every
-  # slot with width > 0, in order, so a slot of 0 drops that layer. Width
-  # and depth are thus tuned together. RF = 1 + n_layers * (kernel_size - 1):
-  # the C7 winner was 6 layers @ kernel 3 (RF 13 >= the grid); kernel_size 5
-  # reaches the same RF in fewer, wider layers.
-  #
-  # layer1..3 are always-present ordinal widths (int_uniform), giving a
-  # minimum depth of 3. layer4..8 are a small ORDERED set INCLUDING 0, so
-  # "drop this layer" has real probability (~1/5 each) and depth genuinely
-  # varies across 3..8 — int_uniform almost never samples exactly 0, which
-  # would pin depth at 8 and leave the layer-count knob dead. This is the
-  # one place we accept a per-slot categorical: depth needs a discrete
-  # on/off, and the set stays small + ordered so Bayes still searches it.
+  # ── Encoder architecture (the REFINED search) ─────────────────────
+  # Refinement of the first 20-run sweep (k13mwoj8), which gave a sharp
+  # verdict: of 3 runs that built anything, ALL were kernel_size=3 (3/4 k=3
+  # runs built; 0/16 k=5/k=7 runs did), 4-6 layers, lr ~0.0017-0.0026. k=7
+  # never trained past val/acc 0.16 in-budget. So:
+  #   - kernel_size in {3,5} (drop the dead k=7; k=5 kept — its 3 prior
+  #     failures all had low lr, so it was never fairly tested).
+  #   - depth capped at 6: layer7/layer8 pinned to 0 (every builder was <=6).
+  # Each layer{1..6} is a conv layer's channel width; a slot of 0 drops that
+  # layer. layer1..3 are always-present ordinal widths (int_uniform, min
+  # depth 3); layer4..6 are a small ORDERED set INCLUDING 0 so depth varies
+  # 3..6. RF = 1 + n_layers * (kernel_size - 1).
   layer1:
     distribution: int_uniform
     min: 32
@@ -84,21 +83,20 @@ parameters:
   layer6:
     values: [0, 0, 0, 0, 32, 48, 64, 96]
   layer7:
-    values: [0, 0, 0, 0, 32, 48, 64, 96]
+    value: 0
   layer8:
-    values: [0, 0, 0, 0, 32, 48, 64, 96]
+    value: 0
   kernel_size:
-    values: [3, 5, 7]
+    values: [3, 5]
 
   # ── LR (co-varies with depth, so swept alongside architecture) ────
-  # A fixed LR would unfairly favour whatever depth that LR happens to suit;
-  # letting it adapt keeps the architecture comparison honest. Floor raised
-  # to 3e-4: at 15 epochs an lr of 1e-4 barely converges (the first sweep's
-  # 1e-4 runs sat near 0 even at epoch 20), so it just wastes runs.
+  # Narrowed to [1e-3, 3e-3] around the first sweep's productive band: the 3
+  # runs that built had lr 0.0017 / 0.0025 / 0.0026, while the lone k=3 run
+  # that failed had lr 0.0004 (val/acc only 0.33). So drop the dead-low end.
   lr:
     distribution: log_uniform_values
-    min: 3.0e-4
-    max: 5.0e-3
+    min: 1.0e-3
+    max: 3.0e-3
 
 program: sft.py
 

--- a/sft_sweep.yaml
+++ b/sft_sweep.yaml
@@ -11,12 +11,13 @@
 # progress incrementally (rankable / early-stoppable mid-run) rather than
 # waiting for an end-of-run-only scalar.
 #
-# Compute-budget knobs (size, num_samples) are PINNED to the C7
-# high-throughput regime (held-out greedy 0.947: size 11, ~300k expert
-# pairs, deep encoder with RF >= grid) so every run is comparable and Bayes
-# spends its budget on architecture. epochs is cut to 15 (vs C7's 50) so all
-# configs finish inside the pod budget — enough to rank architectures;
-# verify the winner at the full 50 epochs afterwards.
+# Compute-budget knobs (size, num_samples) are PINNED so every run is
+# comparable and Bayes spends its budget on architecture. They're cut below
+# the C7 regime (size 11, 300k pairs, 50 epochs) so all 20 configs finish on
+# one pod inside the 4h watchdog even with 5 agents sharing the GPU — enough
+# to RANK architectures; verify the winner at full C7 scale afterwards:
+#   num_samples 300k -> 100k, epochs 50 -> 15, and the per-epoch greedy eval
+#   (the costly, CPU-bound part) is thinned to every 3rd epoch on 50 seeds.
 #
 # Per-head loss weights (lw_*), the LR-schedule shape (warmup/min_lr),
 # regularisation and tile_head_std are deliberately NOT swept here: their
@@ -36,11 +37,19 @@ parameters:
   size:
     value: 11
   num_samples:
-    value: 300000
+    value: 100000
   epochs:
     value: 15
   max_level:
-    value: 0 # auto = 2*size entities blanked (full-chain build)
+    value: 0 # auto = size*size: training blanks the full factory
+  # Thin the per-epoch greedy eval — its rollouts hammer the Rust throughput
+  # sim every step (CPU-bound) and dominate wall-time under 5-way pod
+  # contention. Every 3rd epoch on 50 seeds keeps ~5 eval points across the
+  # 15 epochs (enough for the summary=max objective) at a fraction of the cost.
+  eval_rollouts_every_n_epochs:
+    value: 3
+  eval_rollouts_max_seeds:
+    value: 50
 
   # ── Encoder architecture (the search) ────────────────────────────
   # Each layer{1..8} is a conv layer's channel width; the encoder uses every

--- a/sweep.yaml
+++ b/sweep.yaml
@@ -43,10 +43,12 @@ parameters:
     max: 1e-3
 
   # CNN encoder architecture: each layer{1..8} is a conv layer's channel
-  # width; width 0 drops the layer (slots compacted in order), so Bayes tunes
-  # depth and width as independent ordinal dims. layer1..3 stay positive (min
-  # depth 3); layer4..8 may reach 0. kernel_size sets the receptive field
-  # (RF = 1 + n_layers * (kernel_size - 1)).
+  # width; a slot of 0 drops that layer (slots compacted in order), so depth
+  # and width are tuned together. kernel_size sets the receptive field
+  # (RF = 1 + n_layers * (kernel_size - 1)). layer1..3 are always-present
+  # ordinal widths (min depth 3); layer4..8 are a small ordered set INCLUDING
+  # 0 so depth genuinely varies (int_uniform almost never samples exactly 0,
+  # which would pin depth at 8).
   layer1:
     distribution: int_uniform
     min: 32
@@ -60,25 +62,15 @@ parameters:
     min: 32
     max: 64
   layer4:
-    distribution: int_uniform
-    min: 0
-    max: 64
+    values: [0, 32, 48, 64]
   layer5:
-    distribution: int_uniform
-    min: 0
-    max: 64
+    values: [0, 32, 48, 64]
   layer6:
-    distribution: int_uniform
-    min: 0
-    max: 64
+    values: [0, 32, 48, 64]
   layer7:
-    distribution: int_uniform
-    min: 0
-    max: 64
+    values: [0, 32, 48, 64]
   layer8:
-    distribution: int_uniform
-    min: 0
-    max: 64
+    values: [0, 32, 48, 64]
   kernel_size:
     values: [3, 5]
 

--- a/sweep.yaml
+++ b/sweep.yaml
@@ -42,14 +42,45 @@ parameters:
     min: 5e-5
     max: 1e-3
 
-  chan1:
-    values: [32, 48, 64]
-
-  chan2:
-    values: [48, 64]
-
-  chan3:
-    values: [48, 64]
+  # CNN encoder architecture: each layer{1..8} is a conv layer's channel
+  # width; width 0 drops the layer (slots compacted in order), so Bayes tunes
+  # depth and width as independent ordinal dims. layer1..3 stay positive (min
+  # depth 3); layer4..8 may reach 0. kernel_size sets the receptive field
+  # (RF = 1 + n_layers * (kernel_size - 1)).
+  layer1:
+    distribution: int_uniform
+    min: 32
+    max: 64
+  layer2:
+    distribution: int_uniform
+    min: 32
+    max: 64
+  layer3:
+    distribution: int_uniform
+    min: 32
+    max: 64
+  layer4:
+    distribution: int_uniform
+    min: 0
+    max: 64
+  layer5:
+    distribution: int_uniform
+    min: 0
+    max: 64
+  layer6:
+    distribution: int_uniform
+    min: 0
+    max: 64
+  layer7:
+    distribution: int_uniform
+    min: 0
+    max: 64
+  layer8:
+    distribution: int_uniform
+    min: 0
+    max: 64
+  kernel_size:
+    values: [3, 5]
 
   clip_coef:
     distribution: uniform

--- a/tests/test_factory_builder.py
+++ b/tests/test_factory_builder.py
@@ -32,6 +32,7 @@ from ppo import AgentCNN, FactorioEnv, make_env  # noqa: E402
 
 # ── Fixtures ────────────────────────────────────────────────────────────────
 
+
 def _make_tiny_checkpoint(size: int = 4, chan: int = 8) -> Path:
     """Build a small AgentCNN at the given size + channel width, save
     its state_dict to a temp .pt, and return the path. The model isn't
@@ -42,7 +43,7 @@ def _make_tiny_checkpoint(size: int = 4, chan: int = 8) -> Path:
         gym.register(id=env_id, entry_point=FactorioEnv)
     envs = gym.vector.SyncVectorEnv([make_env(env_id, 0, False, size, "fbtest")])
     try:
-        agent = AgentCNN(envs, chan1=chan, chan2=chan, chan3=chan)
+        agent = AgentCNN(envs, layers=(chan, chan, chan))
     finally:
         envs.close()
     fd, path = tempfile.mkstemp(suffix=".pt")
@@ -67,13 +68,22 @@ def _reset_fb_state():
 
 def _empty_grid(size: int) -> list[list[dict]]:
     return [
-        [{"entity": "empty", "direction": "NONE", "item": "empty",
-          "misc": "NONE", "footprint": "AVAILABLE"} for _ in range(size)]
+        [
+            {
+                "entity": "empty",
+                "direction": "NONE",
+                "item": "empty",
+                "misc": "NONE",
+                "footprint": "AVAILABLE",
+            }
+            for _ in range(size)
+        ]
         for _ in range(size)
     ]
 
 
 # ── Pure helpers ────────────────────────────────────────────────────────────
+
 
 class TestTopP:
     def test_top_p_named_includes_until_mass_reached(self):
@@ -118,22 +128,46 @@ class TestBuildWorld:
         direction values into the right channels."""
         size = 3
         grid = _empty_grid(size)
-        grid[1][2] = {"entity": "transport_belt", "direction": "EAST",
-                      "item": "empty", "misc": "NONE", "footprint": "AVAILABLE"}
+        grid[1][2] = {
+            "entity": "transport_belt",
+            "direction": "EAST",
+            "item": "empty",
+            "misc": "NONE",
+            "footprint": "AVAILABLE",
+        }
         world = fb.build_world(grid)
         # fb.items is keyed by Item.value, not by name, so look up via
         # the same name->value map build_world itself constructs.
         name_to_value = {it.name: it.value for it in fb.items.values()}
         # build_world returns WHC; entity channel at (x=2, y=1).
-        assert int(world[2, 1, fb.Channel.ENTITIES.value]) == name_to_value["transport_belt"]
+        assert (
+            int(world[2, 1, fb.Channel.ENTITIES.value])
+            == name_to_value["transport_belt"]
+        )
         assert int(world[2, 1, fb.Channel.DIRECTION.value]) == fb.Direction.EAST.value
 
     def test_non_square_raises(self):
         grid = [
-            [{"entity": "empty", "direction": "NONE", "item": "empty",
-              "misc": "NONE", "footprint": "AVAILABLE"}] * 4,
-            [{"entity": "empty", "direction": "NONE", "item": "empty",
-              "misc": "NONE", "footprint": "AVAILABLE"}] * 3,
+            [
+                {
+                    "entity": "empty",
+                    "direction": "NONE",
+                    "item": "empty",
+                    "misc": "NONE",
+                    "footprint": "AVAILABLE",
+                }
+            ]
+            * 4,
+            [
+                {
+                    "entity": "empty",
+                    "direction": "NONE",
+                    "item": "empty",
+                    "misc": "NONE",
+                    "footprint": "AVAILABLE",
+                }
+            ]
+            * 3,
         ]
         with pytest.raises(ValueError, match="square"):
             fb.build_world(grid)
@@ -143,11 +177,14 @@ class TestBuildWorld:
         grid = _empty_grid(size)
         grid[0][0]["footprint"] = "UNAVAILABLE"
         world = fb.build_world(grid)
-        assert int(world[0, 0, fb.Channel.FOOTPRINT.value]) == \
-            fb.Footprint.UNAVAILABLE.value
+        assert (
+            int(world[0, 0, fb.Channel.FOOTPRINT.value])
+            == fb.Footprint.UNAVAILABLE.value
+        )
 
 
 # ── Model loading + cache ───────────────────────────────────────────────────
+
 
 class TestCheckpointLoading:
     def test_load_checkpoint_populates_state(self):
@@ -234,6 +271,7 @@ class TestSwapModel:
 
 
 # ── End-to-end /predict schema ──────────────────────────────────────────────
+
 
 class TestPredictSchema:
     def test_predict_returns_full_schema(self):
@@ -329,6 +367,6 @@ class TestModelInfo:
             info = fb._model_info()
             assert info["loaded"] is True
             assert info["path"] == str(path)
-            assert info["chan1"] == info["chan2"] == info["chan3"] == 8
+            assert info["layers"] == [8, 8, 8]
         finally:
             path.unlink(missing_ok=True)

--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -33,7 +33,7 @@ from sft import (
     run_rollout_eval,
     train_sft,
 )
-from ppo import FactorioEnv, AgentCNN, make_env
+from ppo import FactorioEnv, AgentCNN, make_env, layers_from_args
 
 
 class TestExtractExpertActions:
@@ -409,14 +409,14 @@ class TestSFTCheckpointLoading:
     def test_checkpoint_roundtrip(self, registered_env, tmp_path):
         """SFT checkpoint should load into AgentCNN and produce valid outputs."""
         envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, 5, "test")])
-        agent = AgentCNN(envs, chan1=16, chan2=16, chan3=16, flat_dim=64)
+        agent = AgentCNN(envs, layers=(16, 16, 16))
 
         # Save checkpoint
         ckpt_path = str(tmp_path / "test_sft.pt")
         torch.save(agent.state_dict(), ckpt_path)
 
         # Load into fresh agent
-        agent2 = AgentCNN(envs, chan1=16, chan2=16, chan3=16, flat_dim=64)
+        agent2 = AgentCNN(envs, layers=(16, 16, 16))
         agent2.load_state_dict(torch.load(ckpt_path))
 
         # Verify identical outputs
@@ -435,13 +435,13 @@ class TestSFTCheckpointLoading:
     def test_sft_to_ppo_start_from(self, registered_env, tmp_path):
         """SFT checkpoint loaded via --start_from should not crash during RL."""
         envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, 5, "test")])
-        agent = AgentCNN(envs, chan1=16, chan2=16, chan3=16, flat_dim=64)
+        agent = AgentCNN(envs, layers=(16, 16, 16))
 
         ckpt_path = str(tmp_path / "test_sft.pt")
         torch.save(agent.state_dict(), ckpt_path)
 
         # Simulate what ppo.py does with --start_from
-        agent2 = AgentCNN(envs, chan1=16, chan2=16, chan3=16, flat_dim=64)
+        agent2 = AgentCNN(envs, layers=(16, 16, 16))
         agent2.load_state_dict(torch.load(ckpt_path))
 
         # Run a forward pass (simulating RL step)
@@ -467,7 +467,7 @@ class TestSFTLossConvergence:
         )
 
         envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, 5, "test")])
-        agent = AgentCNN(envs, chan1=16, chan2=16, chan3=16, flat_dim=64)
+        agent = AgentCNN(envs, layers=(16, 16, 16))
         envs.close()
 
         optimizer = torch.optim.Adam(agent.parameters(), lr=1e-3)
@@ -523,10 +523,9 @@ class TestTrainSFTEndToEnd:
             max_level=2,
             epochs=2,
             batch_size=32,
-            chan1=16,
-            chan2=16,
-            chan3=16,
-            flat_dim=64,
+            layer1=16,
+            layer2=16,
+            layer3=16,
             checkpoint_path=ckpt,
             summary_path=summary,
         )
@@ -570,7 +569,7 @@ class TestRunRolloutEval:
         was eval'd."""
         size = 5
         envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, size, "test")])
-        agent = AgentCNN(envs, chan1=16, chan2=16, chan3=16, flat_dim=64)
+        agent = AgentCNN(envs, layers=(16, 16, 16))
         envs.close()
 
         args = SFTArgs(
@@ -578,10 +577,9 @@ class TestRunRolloutEval:
             size=size,
             num_samples=50,
             max_level=2 * size,
-            chan1=16,
-            chan2=16,
-            chan3=16,
-            flat_dim=64,
+            layer1=16,
+            layer2=16,
+            layer3=16,
         )
         val_seeds_to_kind = self._build_val_seeds_to_kind(size=size, num_kinds=4)
         assert len(val_seeds_to_kind) >= 1, "Sanity: at least one valid lesson"
@@ -620,7 +618,7 @@ class TestRunRolloutEval:
         is larger."""
         size = 5
         envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, size, "test")])
-        agent = AgentCNN(envs, chan1=16, chan2=16, chan3=16, flat_dim=64)
+        agent = AgentCNN(envs, layers=(16, 16, 16))
         envs.close()
 
         args = SFTArgs(
@@ -628,10 +626,9 @@ class TestRunRolloutEval:
             size=size,
             num_samples=50,
             max_level=2 * size,
-            chan1=16,
-            chan2=16,
-            chan3=16,
-            flat_dim=64,
+            layer1=16,
+            layer2=16,
+            layer3=16,
         )
         val_seeds_to_kind = self._build_val_seeds_to_kind(size=size, num_kinds=6)
         assert len(val_seeds_to_kind) >= 3
@@ -650,7 +647,7 @@ class TestRunRolloutEval:
         crashing (defensive — the caller already guards on len(...)>0)."""
         size = 5
         envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, size, "test")])
-        agent = AgentCNN(envs, chan1=16, chan2=16, chan3=16, flat_dim=64)
+        agent = AgentCNN(envs, layers=(16, 16, 16))
         envs.close()
 
         args = SFTArgs(
@@ -658,10 +655,9 @@ class TestRunRolloutEval:
             size=size,
             num_samples=50,
             max_level=2 * size,
-            chan1=16,
-            chan2=16,
-            chan3=16,
-            flat_dim=64,
+            layer1=16,
+            layer2=16,
+            layer3=16,
         )
         roll = run_rollout_eval(
             agent,
@@ -681,7 +677,7 @@ class TestRunRolloutEval:
         step, snapshotting the reset throughput (0) for every seed."""
         size = 5
         envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, size, "test")])
-        agent = AgentCNN(envs, chan1=16, chan2=16, chan3=16, flat_dim=64)
+        agent = AgentCNN(envs, layers=(16, 16, 16))
         envs.close()
 
         args = SFTArgs(
@@ -689,10 +685,9 @@ class TestRunRolloutEval:
             size=size,
             num_samples=50,
             max_level=2 * size,
-            chan1=16,
-            chan2=16,
-            chan3=16,
-            flat_dim=64,
+            layer1=16,
+            layer2=16,
+            layer3=16,
         )
         val_seeds_to_kind = self._build_val_seeds_to_kind(size=size, num_kinds=4)
 
@@ -765,7 +760,7 @@ class TestEotHead:
         """AgentCNN must expose an eot_head producing a single logit per
         observation."""
         envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, 5, "test")])
-        agent = AgentCNN(envs, chan1=16, chan2=16, chan3=16, flat_dim=64)
+        agent = AgentCNN(envs, layers=(16, 16, 16))
         envs.close()
 
         assert hasattr(agent, "eot_head"), "AgentCNN must have an eot_head"
@@ -783,7 +778,7 @@ class TestEotHead:
         returns a bool tensor of the same shape. These are the methods
         inference rollouts call to decide 'I'm done here'."""
         envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, 5, "test")])
-        agent = AgentCNN(envs, chan1=16, chan2=16, chan3=16, flat_dim=64)
+        agent = AgentCNN(envs, layers=(16, 16, 16))
         envs.close()
 
         B = 3
@@ -817,10 +812,9 @@ class TestEotHead:
             epochs=20,
             batch_size=64,
             lr=3e-3,
-            chan1=16,
-            chan2=16,
-            chan3=16,
-            flat_dim=64,
+            layer1=16,
+            layer2=16,
+            layer3=16,
             checkpoint_path=ckpt,
             summary_path=summary,
         )
@@ -923,9 +917,8 @@ class TestArtifactNameHelpers:
         assert _humanize_lr(0) == "0"
 
     def test_artifact_name_default(self):
-        # SFTArgs defaults track the sweep winner (n=300k, chan3=64,
-        # lr=2.542e-3) with size bumped to the project default of 12.
-        # The auto-name expands the channel suffix.
+        # SFTArgs defaults (layers 48,48,64) expand into a per-layer channel
+        # suffix; size is the project default of 12.
         assert _artifact_name(SFTArgs()) == "sft-s12-n300k-e30-bs512-lr2.5e-3-c48-48-64"
 
     def test_artifact_name_larger_run(self):
@@ -935,18 +928,36 @@ class TestArtifactNameHelpers:
             epochs=50,
             batch_size=1024,
             lr=3e-4,
-            chan1=48,
-            chan2=48,
-            chan3=48,
+            layer1=48,
+            layer2=48,
+            layer3=48,
         )
-        assert _artifact_name(args) == "sft-s16-n200k-e50-bs1024-lr3e-4-c48"
+        assert _artifact_name(args) == "sft-s16-n200k-e50-bs1024-lr3e-4-c48-48-48"
+
+    def test_artifact_name_encodes_depth(self):
+        """Depth is part of the suffix: a 4-layer encoder of the same width
+        must not collide with a 3-layer one (else the deeper run would file
+        under the shallower run's artifact)."""
+        three = SFTArgs(layer1=48, layer2=48, layer3=48, layer4=0)
+        four = SFTArgs(layer1=48, layer2=48, layer3=48, layer4=48)
+        assert _artifact_name(three).endswith("-c48-48-48")
+        assert _artifact_name(four).endswith("-c48-48-48-48")
+        assert _artifact_name(three) != _artifact_name(four)
 
     def test_artifact_name_asymmetric_channels(self):
-        """When chan1/2/3 differ, the suffix expands rather than collapsing
-        to a single c{N} — so a c32-64-64 run can't accidentally be filed
-        under the same artifact as a c48 run."""
-        args = SFTArgs(chan1=32, chan2=64, chan3=64)
+        """Differing per-layer widths expand into the full list, so a
+        c32-64-64 run can't accidentally file under a c48-48-48 run."""
+        args = SFTArgs(layer1=32, layer2=64, layer3=64)
         assert _artifact_name(args) == "sft-s12-n300k-e30-bs512-lr2.5e-3-c32-64-64"
+
+    def test_artifact_name_kernel_size_suffix(self):
+        """A non-default kernel size appends -k{N} so two runs differing only
+        in receptive field get distinct artifacts; the default k=3 adds no
+        token (keeps existing names stable)."""
+        assert _artifact_name(SFTArgs()).endswith("-c48-48-64")
+        assert _artifact_name(SFTArgs(kernel_size=5)) == (
+            "sft-s12-n300k-e30-bs512-lr2.5e-3-c48-48-64-k5"
+        )
 
     def test_artifact_name_stable_across_runs(self):
         """Two SFTArgs with the same hyperparams must produce the same

--- a/tests/test_spatial_agent.py
+++ b/tests/test_spatial_agent.py
@@ -38,7 +38,7 @@ def envs(registered_env):
 @pytest.fixture()
 def agent(envs):
     """Create an AgentCNN with default params."""
-    return AgentCNN(envs, chan1=32, chan2=64, chan3=64)
+    return AgentCNN(envs, layers=(32, 64, 64))
 
 
 class TestForwardPass:
@@ -106,14 +106,10 @@ class TestLogProbConsistency:
         dir_B = action_out["direction"]
         item_B = action_out["item"]
         misc_B = action_out["misc"]
-        action_tensor = torch.stack(
-            [x_B, y_B, ent_B, dir_B, item_B, misc_B], dim=1
-        )
+        action_tensor = torch.stack([x_B, y_B, ent_B, dir_B, item_B, misc_B], dim=1)
 
         # Replay: pass the same obs and action tensor
-        _, logp_replay, _, _ = agent.get_action_and_value(
-            obs, action_tensor.long()
-        )
+        _, logp_replay, _, _ = agent.get_action_and_value(obs, action_tensor.long())
         torch.testing.assert_close(logp_B, logp_replay)
 
     def test_log_prob_is_negative(self, agent):
@@ -168,7 +164,8 @@ class TestGradientFlow:
         item_B = action_out["item"]
         misc_B = action_out["misc"]
         action_tensor = torch.stack(
-            [x_B, y_B, ent_B, dir_B, item_B, misc_B], dim=1,
+            [x_B, y_B, ent_B, dir_B, item_B, misc_B],
+            dim=1,
         )
 
         _, logp_B, entropy_B, value_B = agent.get_action_and_value(
@@ -177,7 +174,13 @@ class TestGradientFlow:
         loss = -(logp_B.mean()) + value_B.mean()
         loss.backward()
 
-        for head_name in ("tile_logits", "ent_head", "dir_head", "item_head", "misc_head"):
+        for head_name in (
+            "tile_logits",
+            "ent_head",
+            "dir_head",
+            "item_head",
+            "misc_head",
+        ):
             head = getattr(agent, head_name)
             assert head.weight.grad is not None, f"No grad for {head_name}"
 
@@ -203,8 +206,8 @@ class TestBatchConsistency:
 
         # One at a time
         for i in range(3):
-            _, logp_single, entropy_single, value_single = (
-                agent.get_action_and_value(obs[i : i + 1], action_tensor[i : i + 1])
+            _, logp_single, entropy_single, value_single = agent.get_action_and_value(
+                obs[i : i + 1], action_tensor[i : i + 1]
             )
             torch.testing.assert_close(logp_batch[i : i + 1], logp_single)
             torch.testing.assert_close(entropy_batch[i : i + 1], entropy_single)
@@ -237,7 +240,7 @@ class TestRegularisation:
     def test_dropout_active_varies_in_train(self, envs):
         """p>0 in train() mode resamples the mask each pass, so the only
         source of variation — dropout — makes two encodes differ."""
-        agent = AgentCNN(envs, chan1=32, chan2=64, chan3=64, dropout=0.5)
+        agent = AgentCNN(envs, layers=(32, 64, 64), dropout=0.5)
         agent.train()
         obs = torch.randn(2, NUM_CHANNELS, 5, 5)
         assert not torch.allclose(agent.encoder(obs), agent.encoder(obs))
@@ -245,7 +248,7 @@ class TestRegularisation:
     def test_dropout_inert_in_eval(self, envs):
         """Dropout is disabled in eval() regardless of p, so inference is
         deterministic even with a high drop probability."""
-        agent = AgentCNN(envs, chan1=32, chan2=64, chan3=64, dropout=0.5)
+        agent = AgentCNN(envs, layers=(32, 64, 64), dropout=0.5)
         agent.eval()
         obs = torch.randn(2, NUM_CHANNELS, 5, 5)
         torch.testing.assert_close(agent.encoder(obs), agent.encoder(obs))

--- a/tests/test_sweep_metric.py
+++ b/tests/test_sweep_metric.py
@@ -15,14 +15,33 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts", "ci"
 from wandb_metric import read_metric  # noqa: E402
 
 
-class SummarySubDict(dict):
+class SummarySubDict:
     """Stand-in for W&B's nested summary node.
 
-    Like the real thing, it is dict-like (supports ``.get``) and instances
-    are unorderable, so feeding one to ``sorted``/``list.sort`` raises.
-    ``.get`` does not traverse slash-separated keys — nested metrics live
-    under nested ``SummarySubDict`` values, exactly like W&B.
+    Mirrors the real ``wandb.apis.public.summary.SummarySubDict``: dict-LIKE
+    (``get``/``keys``/``[]``/``in``) but deliberately **not** a ``dict``
+    subclass — the real class isn't either, so ``isinstance(node, dict)`` is
+    ``False`` for it. That is the exact footgun ``read_metric`` must survive;
+    subclassing ``dict`` here would hide it. Instances are unorderable, so
+    feeding one to ``sorted``/``list.sort`` raises. ``.get`` does not traverse
+    slash-separated keys — nested metrics live under nested ``SummarySubDict``
+    values, exactly like W&B.
     """
+
+    def __init__(self, data):
+        self._d = dict(data)
+
+    def get(self, key, default=None):
+        return self._d.get(key, default)
+
+    def keys(self):
+        return self._d.keys()
+
+    def __getitem__(self, key):
+        return self._d[key]
+
+    def __contains__(self, key):
+        return key in self._d
 
 
 class TestReadMetric:
@@ -73,6 +92,35 @@ class TestReadMetric:
         # Should not raise, and missing values sort consistently.
         runs.sort(key=lambda s: read_metric(s, "throughput", missing), reverse=True)
         assert all(read_metric(s, "throughput", missing) == missing for s in runs)
+
+    def test_define_metric_max_dict_unwrapped(self):
+        # define_metric(summary="max") stores {"max": value}, not a bare
+        # scalar — the SFT throughput sweep's objective. Must unwrap to 0.04.
+        summary = SummarySubDict({"val/throughput": SummarySubDict({"max": 0.04})})
+        assert read_metric(summary, "val/throughput", float("-inf")) == 0.04
+
+    def test_define_metric_min_dict_unwrapped(self):
+        # A minimize objective records {"min": value}; with no "max" present
+        # the unwrap falls through to "min".
+        summary = SummarySubDict({"val/loss": SummarySubDict({"min": 1.2})})
+        assert read_metric(summary, "val/loss", float("inf")) == 1.2
+
+    def test_nested_slash_key_with_summary_stat_dict(self):
+        # Slash key misses AND the leaf is a define_metric dict: resolve the
+        # nested path, then unwrap the stat.
+        summary = SummarySubDict(
+            {"a": SummarySubDict({"b": SummarySubDict({"max": 0.5})})}
+        )
+        assert read_metric(summary, "a/b", float("-inf")) == 0.5
+
+    def test_multikey_namespace_without_stats_still_missing(self):
+        # A namespace dict whose keys are NOT summary stats must stay missing
+        # (we can't choose a metric for the caller) — guards the unwrap from
+        # over-firing.
+        summary = SummarySubDict(
+            {"val/throughput": SummarySubDict({"greedy": 0.5, "random": 0.1})}
+        )
+        assert read_metric(summary, "val/throughput", float("-inf")) == float("-inf")
 
     def test_mixed_present_and_missing_sort_order(self):
         runs = [

--- a/tests/test_torch_compile.py
+++ b/tests/test_torch_compile.py
@@ -41,7 +41,7 @@ def n_channels(envs):
 @pytest.fixture()
 def agent(envs):
     """Create an uncompiled AgentCNN."""
-    return AgentCNN(envs, chan1=32, chan2=64, chan3=64)
+    return AgentCNN(envs, layers=(32, 64, 64))
 
 
 @pytest.fixture()
@@ -54,7 +54,9 @@ class TestCompiledForwardPass:
     def test_output_shapes(self, compiled_agent, n_channels):
         """Verify compiled agent produces correct output shapes."""
         obs = torch.randn(2, n_channels, 5, 5)
-        action_out, logp_B, entropy_B, value_B = compiled_agent.get_action_and_value(obs)
+        action_out, logp_B, entropy_B, value_B = compiled_agent.get_action_and_value(
+            obs
+        )
 
         assert action_out["xy"].shape == (2, 2)
         assert action_out["entity"].shape == (2,)
@@ -94,9 +96,7 @@ class TestCompiledLogProbConsistency:
         dir_B = action_out["direction"]
         item_B = action_out["item"]
         misc_B = action_out["misc"]
-        action_tensor = torch.stack(
-            [x_B, y_B, ent_B, dir_B, item_B, misc_B], dim=1
-        )
+        action_tensor = torch.stack([x_B, y_B, ent_B, dir_B, item_B, misc_B], dim=1)
 
         _, logp_replay, _, _ = compiled_agent.get_action_and_value(
             obs, action_tensor.long()
@@ -108,13 +108,25 @@ class TestCompiledGradientFlow:
     def test_gradients_flow_through_compiled_model(self, compiled_agent, n_channels):
         """Verify gradients propagate through the compiled agent."""
         obs = torch.randn(4, n_channels, 5, 5)
-        action_out, logp_B, entropy_B, value_B = compiled_agent.get_action_and_value(obs)
+        action_out, logp_B, entropy_B, value_B = compiled_agent.get_action_and_value(
+            obs
+        )
         loss = -(logp_B.mean()) + value_B.mean()
         loss.backward()
 
         # Access underlying module's parameters through the compiled wrapper
-        underlying = compiled_agent._orig_mod if hasattr(compiled_agent, "_orig_mod") else compiled_agent
-        for head_name in ("tile_logits", "ent_head", "dir_head", "item_head", "misc_head"):
+        underlying = (
+            compiled_agent._orig_mod
+            if hasattr(compiled_agent, "_orig_mod")
+            else compiled_agent
+        )
+        for head_name in (
+            "tile_logits",
+            "ent_head",
+            "dir_head",
+            "item_head",
+            "misc_head",
+        ):
             head = getattr(underlying, head_name)
             assert head.weight.grad is not None, f"No grad for {head_name}"
 
@@ -146,8 +158,8 @@ class TestCompiledParity:
         # Compile the same agent (same weights)
         compiled = torch.compile(agent)
         with torch.no_grad():
-            _, logp_compiled, entropy_compiled, value_compiled = compiled.get_action_and_value(
-                obs, action_tensor
+            _, logp_compiled, entropy_compiled, value_compiled = (
+                compiled.get_action_and_value(obs, action_tensor)
             )
 
         torch.testing.assert_close(logp_orig, logp_compiled)
@@ -174,13 +186,17 @@ class TestCompileOptimizer:
         optimizer = torch.optim.Adam(compiled_agent.parameters(), lr=1e-3)
 
         obs = torch.randn(4, n_channels, 5, 5)
-        action_out, logp_B, entropy_B, value_B = compiled_agent.get_action_and_value(obs)
+        action_out, logp_B, entropy_B, value_B = compiled_agent.get_action_and_value(
+            obs
+        )
         loss = -(logp_B.mean()) + value_B.mean()
         loss.backward()
         optimizer.step()
         optimizer.zero_grad()
 
         # Second forward pass should still work after optimizer step
-        action_out2, logp_B2, entropy_B2, value_B2 = compiled_agent.get_action_and_value(obs)
+        action_out2, logp_B2, entropy_B2, value_B2 = (
+            compiled_agent.get_action_and_value(obs)
+        )
         assert logp_B2.shape == (4,)
         assert value_B2.shape == (4,)


### PR DESCRIPTION
## What

Makes the CNN encoder architecture **sweepable** so a W&B Bayesian sweep can search depth, per-layer width, and receptive field against the greedy-build metric `val/throughput` (the default since #139).

Replaces the fixed `chan1/chan2/chan3/flat_dim` knobs with:

- **`layer1..layer8`** — each is a conv layer's channel width; `0` drops that layer (slots compacted in order). Depth *and* width become **independent ordinal** sweep dimensions (`int_uniform`), instead of one opaque categorical `"64,64,64"` string the optimiser can't reason about.
- **`kernel_size`** — receptive-field knob. `RF = 1 + n_layers·(kernel_size−1)`. Padding is pinned to `kernel_size//2` ("same"), because the per-tile heads require the feature map to stay exactly grid-sized (one logit per cell). Padding is therefore *not* a free knob.

`AgentCNN` itself takes a clean `layers` sequence + `kernel_size`; the dataclass slots compact via `layers_from_args()`.

## Sweep config

`sft_sweep.yaml` now:
- targets `metric: val/throughput` (was `val/acc`),
- searches `layer1..8` + `kernel_size{3,5}` + `lr` (lr co-swept since it covaries with depth),
- **pins** size 11 / 300k pairs / 50 epochs to the **C7 high-throughput regime** (held-out greedy 0.947, deep 6-layer RF-13 encoder),
- leaves per-head loss weights / schedule / regularisation at their `SFTArgs` defaults (the prior sweep's winner) to keep the search within `run_cap`.

The CI harness already supports SFT sweeps end-to-end (jobs `sft-sweep-setup` → `sft-sweep` → `sft-sweep-report`, triggered by the `sft-sweep` label); only the param names needed updating.

## Also

- `scripts/factory_builder.py` infers encoder arch (any depth/kernel) from the checkpoint instead of hardcoding `encoder.0/2/4`.
- `factorion-mod/server/server.py` translates its sidecar chans to `layers=`.
- PPO `sweep.yaml` + both `apply_*_sweep_best.py` updated for the renamed params (PPO shares `AgentCNN`).

## Verification

- `ruff check .` ✓
- full `pytest` — 3395 passed, 77 skipped ✓ (added depth/kernel artifact-name coverage; verified compaction, odd-kernel guard, all-zero guard)
- SFT smoke (`--layer1/2/3`) ✓ · PPO smoke ✓ — both build the encoder dynamically

🤖 Generated with [Claude Code](https://claude.com/claude-code)