### PR TITLE
Fix sweep-report crash on nested W&B summary metrics

### DIFF
--- a/scripts/ci/apply_sft_sweep_best.py
+++ b/scripts/ci/apply_sft_sweep_best.py
@@ -22,6 +22,8 @@ import sys
 
 import wandb
 
+from wandb_metric import read_metric
+
 # Hyperparameters in SFTArgs that sweeps can tune.
 # Maps sweep param name -> python type formatter.
 TUNABLE_PARAMS = {
@@ -142,11 +144,10 @@ def main():
         print("No finished runs in sweep. Skipping.")
         sys.exit(0)
 
+    missing = float("-inf") if reverse else float("inf")
+
     def get_metric(run):
-        val = run.summary.get(metric_name)
-        if val is None:
-            return float("-inf") if reverse else float("inf")
-        return val
+        return read_metric(run.summary, metric_name, missing)
 
     runs.sort(key=get_metric, reverse=reverse)
     best_run = runs[0]

--- a/scripts/ci/apply_sweep_best.py
+++ b/scripts/ci/apply_sweep_best.py
@@ -22,6 +22,8 @@ import sys
 
 import wandb
 
+from wandb_metric import read_metric
+
 # Hyperparameters in the Args dataclass that sweeps can tune.
 # Maps sweep param name -> (python type formatter).
 # Only these will be updated; other sweep config keys are ignored.
@@ -157,11 +159,10 @@ def main():
         print("No finished runs in sweep. Skipping.")
         sys.exit(0)
 
+    missing = float("-inf") if reverse else float("inf")
+
     def get_metric(run):
-        val = run.summary.get(metric_name)
-        if val is None:
-            return float("-inf") if reverse else float("inf")
-        return val
+        return read_metric(run.summary, metric_name, missing)
 
     runs.sort(key=get_metric, reverse=reverse)
     best_run = runs[0]

--- a/scripts/ci/sweep_report.py
+++ b/scripts/ci/sweep_report.py
@@ -20,6 +20,8 @@ import sys
 
 import wandb
 
+from wandb_metric import read_metric
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -79,11 +81,10 @@ def main():
         return
 
     # Sort runs by the sweep metric
+    missing = float("-inf") if reverse else float("inf")
+
     def get_metric(run):
-        val = run.summary.get(metric_name)
-        if val is None:
-            return float("-inf") if reverse else float("inf")
-        return val
+        return read_metric(run.summary, metric_name, missing)
 
     runs.sort(key=get_metric, reverse=reverse)
 

--- a/scripts/ci/wandb_metric.py
+++ b/scripts/ci/wandb_metric.py
@@ -1,0 +1,44 @@
+"""Read a sweep metric out of a W&B run summary as a sortable scalar.
+
+W&B stores slash-namespaced metrics (e.g. ``curriculum/throughput_avg``)
+as *nested* dicts in a run's summary. A plain ``summary.get("a/b")`` can
+therefore return a nested ``SummarySubDict`` node — either because the
+full slash key misses (the value lives at ``summary["a"]["b"]``) or
+because the metric name points at a namespace rather than a leaf. Those
+nodes are unorderable, so feeding them to ``sorted()``/``list.sort()``
+raises ``TypeError: '<' not supported between instances of
+'SummarySubDict'``.
+
+``read_metric`` resolves the slash path and only ever returns a float (or
+the caller's ``missing`` sentinel), so runs can be sorted safely.
+"""
+
+
+def read_metric(summary, metric_name, missing):
+    """Return ``metric_name`` from a W&B run summary as a float.
+
+    Falls back to ``missing`` when the metric is absent, non-scalar, or
+    resolves to a nested namespace rather than a leaf value.
+
+    Args:
+        summary: A run's ``summary`` (dict-like, supports ``.get``).
+        metric_name: Metric key, possibly slash-namespaced ("a/b").
+        missing: Value to return when no scalar can be resolved (e.g.
+            ``float("-inf")`` so missing runs sort last when maximizing).
+    """
+    val = summary.get(metric_name)
+    # The full slash key missed but the value may be nested under it.
+    if val is None and "/" in metric_name:
+        node = summary
+        for part in metric_name.split("/"):
+            try:
+                node = node.get(part)
+            except AttributeError:
+                node = None
+            if node is None:
+                break
+        val = node
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return missing

--- a/tests/test_sweep_metric.py
+++ b/tests/test_sweep_metric.py
@@ -1,0 +1,88 @@
+"""Tests for read_metric in scripts/ci/wandb_metric.py.
+
+Regression coverage for the W&B sweep-report crash where a metric resolved
+to a nested ``SummarySubDict`` and ``runs.sort`` raised
+``TypeError: '<' not supported between instances of 'SummarySubDict'``.
+"""
+
+import math
+import os
+import sys
+
+# Add scripts/ci to sys.path so we can import the module
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts", "ci"))
+
+from wandb_metric import read_metric  # noqa: E402
+
+
+class SummarySubDict(dict):
+    """Stand-in for W&B's nested summary node.
+
+    Like the real thing, it is dict-like (supports ``.get``) and instances
+    are unorderable, so feeding one to ``sorted``/``list.sort`` raises.
+    ``.get`` does not traverse slash-separated keys — nested metrics live
+    under nested ``SummarySubDict`` values, exactly like W&B.
+    """
+
+
+class TestReadMetric:
+    def test_flat_scalar(self):
+        summary = SummarySubDict({"val/acc": 0.9})
+        assert read_metric(summary, "val/acc", float("-inf")) == 0.9
+
+    def test_int_coerced_to_float(self):
+        summary = SummarySubDict({"steps": 5})
+        result = read_metric(summary, "steps", float("-inf"))
+        assert result == 5.0
+        assert isinstance(result, float)
+
+    def test_nested_slash_key_resolves_leaf(self):
+        # Full "a/b" key misses; the value lives under nested dicts.
+        summary = SummarySubDict(
+            {"curriculum": SummarySubDict({"throughput_avg": 0.5})}
+        )
+        assert read_metric(summary, "curriculum/throughput_avg", float("-inf")) == 0.5
+
+    def test_metric_pointing_at_namespace_is_missing(self):
+        # Metric name resolves to a namespace node, not a scalar leaf.
+        summary = SummarySubDict(
+            {"throughput": SummarySubDict({"greedy": 0.5, "random": 0.1})}
+        )
+        assert read_metric(summary, "throughput", float("-inf")) == float("-inf")
+
+    def test_absent_metric_returns_missing(self):
+        summary = SummarySubDict({"other": 1.0})
+        assert read_metric(summary, "val/acc", float("-inf")) == float("-inf")
+        assert read_metric(summary, "val/acc", float("inf")) == float("inf")
+
+    def test_partial_nested_path_is_missing(self):
+        # First hop exists, second does not.
+        summary = SummarySubDict({"curriculum": SummarySubDict({"score": 1.0})})
+        assert read_metric(summary, "curriculum/throughput_avg", float("inf")) == float(
+            "inf"
+        )
+
+    def test_sorting_runs_with_nonscalar_metric_does_not_raise(self):
+        # The original bug: two runs whose metric resolves to SummarySubDicts
+        # made list.sort compare unorderable nodes and raise TypeError.
+        runs = [
+            SummarySubDict({"throughput": SummarySubDict({"greedy": 0.5})}),
+            SummarySubDict({"throughput": SummarySubDict({"greedy": 0.9})}),
+        ]
+        missing = float("-inf")
+        # Should not raise, and missing values sort consistently.
+        runs.sort(key=lambda s: read_metric(s, "throughput", missing), reverse=True)
+        assert all(read_metric(s, "throughput", missing) == missing for s in runs)
+
+    def test_mixed_present_and_missing_sort_order(self):
+        runs = [
+            SummarySubDict({"val/acc": 0.3}),
+            SummarySubDict({"other": 1.0}),  # missing -> -inf
+            SummarySubDict({"val/acc": 0.8}),
+        ]
+        missing = float("-inf")
+        runs.sort(key=lambda s: read_metric(s, "val/acc", missing), reverse=True)
+        vals = [read_metric(s, "val/acc", missing) for s in runs]
+        assert vals[0] == 0.8
+        assert vals[1] == 0.3
+        assert math.isinf(vals[2]) and vals[2] < 0


### PR DESCRIPTION
## Problem

The `sweep_report` CI step crashed sorting runs by the sweep metric:

```
TypeError: '<' not supported between instances of 'SummarySubDict' and 'SummarySubDict'
```

(see [failing run](https://github.com/beyarkay/factorion/actions/runs/27549954246/job/81473610601?pr=140))

`get_metric` returned `run.summary.get(metric_name)` directly. W&B stores slash-namespaced metrics (e.g. `curriculum/throughput_avg`) as **nested dicts**, so the lookup can return a `SummarySubDict` node instead of a scalar. Two such nodes are unorderable, so `runs.sort(...)` raised.

The identical buggy `get_metric` was copy-pasted into `apply_sweep_best.py` and `apply_sft_sweep_best.py` too — both one real sweep away from the same crash.

## Fix

- **`scripts/ci/wandb_metric.py`** (new) — shared `read_metric(summary, metric_name, missing)` helper. Resolves the slash path (walking nested nodes when the flat key misses) and only ever returns a `float`, falling back to the caller's `missing` sentinel for absent / non-scalar / namespace values. Sorting can never see an unorderable node.
- Routed all three `get_metric` copies (`sweep_report.py`, `apply_sweep_best.py`, `apply_sft_sweep_best.py`) through it.
- **`tests/test_sweep_metric.py`** (new) — 8 tests, including one that reproduces the original sort crash, plus nested-leaf / namespace / absent / partial-path / mixed-ordering cases.

## Verification

- New test: 8 passed
- `ruff check` on touched files: clean (CI runs `ruff check .`, not `ruff format`)
- `py_compile` on all three scripts: OK
- Simulated CI invocation: nested key → `0.5`, namespace key → `-inf`

The full Rust/ppo/sft checklist was not run locally — this change only touches CI helper scripts and a self-contained test, none of which can affect the Rust engine or training code. CI will run the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)