### PR TITLE
read_metric: unwrap define_metric(summary=...) single-stat dicts

### DIFF
--- a/scripts/ci/wandb_metric.py
+++ b/scripts/ci/wandb_metric.py
@@ -1,17 +1,29 @@
 """Read a sweep metric out of a W&B run summary as a sortable scalar.
 
-W&B stores slash-namespaced metrics (e.g. ``curriculum/throughput_avg``)
-as *nested* dicts in a run's summary. A plain ``summary.get("a/b")`` can
-therefore return a nested ``SummarySubDict`` node — either because the
-full slash key misses (the value lives at ``summary["a"]["b"]``) or
-because the metric name points at a namespace rather than a leaf. Those
-nodes are unorderable, so feeding them to ``sorted()``/``list.sort()``
-raises ``TypeError: '<' not supported between instances of
-'SummarySubDict'``.
+Two W&B summary representations defeat a naive ``float(summary.get("a/b"))``:
 
-``read_metric`` resolves the slash path and only ever returns a float (or
-the caller's ``missing`` sentinel), so runs can be sorted safely.
+1. **Slash-namespaced metrics** (e.g. ``curriculum/throughput_avg``) can be
+   stored as *nested* dicts, so the full ``"a/b"`` key misses and the value
+   lives at ``summary["a"]["b"]``. A metric name pointing at a namespace
+   rather than a leaf yields a nested ``SummarySubDict`` node.
+
+2. **``define_metric(summary="max"|"min"|...)`` metrics** are stored as a
+   single-stat dict — ``val/throughput`` becomes ``{"max": 0.04}`` rather
+   than a bare ``0.04``. ``define_metric`` is exactly how the SFT greedy
+   throughput sweep records its objective, so this is the common case, not
+   an edge one.
+
+Both yield a non-scalar (a dict / ``SummarySubDict``) where the caller wants
+a number; ``float(dict)`` raises ``TypeError`` and unorderable nodes break
+``sorted()``/``list.sort()``. ``read_metric`` resolves the slash path,
+unwraps a summary-stat dict, and only ever returns a float (or the caller's
+``missing`` sentinel), so runs can be sorted safely.
 """
+
+# define_metric(summary=...) stores the chosen statistic under one of these
+# keys. Ordered by preference so a maximize objective unwraps to its "max"
+# and a minimize objective (no "max" present) falls through to "min".
+_SUMMARY_STAT_KEYS = ("max", "min", "last", "mean", "value")
 
 
 def read_metric(summary, metric_name, missing):
@@ -38,6 +50,19 @@ def read_metric(summary, metric_name, missing):
             if node is None:
                 break
         val = node
+    # A define_metric(summary="max"|...) value is a single-stat mapping
+    # ({"max": 0.04}); unwrap it to the underlying scalar. W&B's SummarySubDict
+    # is dict-LIKE but does NOT subclass dict, so duck-type on `.keys()` rather
+    # than isinstance(dict) (which silently misses the real object). A namespace
+    # mapping with no stat keys (e.g. {"greedy": .., "random": ..}) is left
+    # alone and falls through to `missing` below — we can't pick one for the
+    # caller.
+    if val is not None and hasattr(val, "keys"):
+        keys = set(val.keys())
+        for stat in _SUMMARY_STAT_KEYS:
+            if stat in keys:
+                val = val[stat]
+                break
     try:
         return float(val)
     except (TypeError, ValueError):

--- a/tests/test_sweep_metric.py
+++ b/tests/test_sweep_metric.py
@@ -15,14 +15,33 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts", "ci"
 from wandb_metric import read_metric  # noqa: E402
 
 
-class SummarySubDict(dict):
+class SummarySubDict:
     """Stand-in for W&B's nested summary node.
 
-    Like the real thing, it is dict-like (supports ``.get``) and instances
-    are unorderable, so feeding one to ``sorted``/``list.sort`` raises.
-    ``.get`` does not traverse slash-separated keys — nested metrics live
-    under nested ``SummarySubDict`` values, exactly like W&B.
+    Mirrors the real ``wandb.apis.public.summary.SummarySubDict``: dict-LIKE
+    (``get``/``keys``/``[]``/``in``) but deliberately **not** a ``dict``
+    subclass — the real class isn't either, so ``isinstance(node, dict)`` is
+    ``False`` for it. That is the exact footgun ``read_metric`` must survive;
+    subclassing ``dict`` here would hide it. Instances are unorderable, so
+    feeding one to ``sorted``/``list.sort`` raises. ``.get`` does not traverse
+    slash-separated keys — nested metrics live under nested ``SummarySubDict``
+    values, exactly like W&B.
     """
+
+    def __init__(self, data):
+        self._d = dict(data)
+
+    def get(self, key, default=None):
+        return self._d.get(key, default)
+
+    def keys(self):
+        return self._d.keys()
+
+    def __getitem__(self, key):
+        return self._d[key]
+
+    def __contains__(self, key):
+        return key in self._d
 
 
 class TestReadMetric:
@@ -73,6 +92,35 @@ class TestReadMetric:
         # Should not raise, and missing values sort consistently.
         runs.sort(key=lambda s: read_metric(s, "throughput", missing), reverse=True)
         assert all(read_metric(s, "throughput", missing) == missing for s in runs)
+
+    def test_define_metric_max_dict_unwrapped(self):
+        # define_metric(summary="max") stores {"max": value}, not a bare
+        # scalar — the SFT throughput sweep's objective. Must unwrap to 0.04.
+        summary = SummarySubDict({"val/throughput": SummarySubDict({"max": 0.04})})
+        assert read_metric(summary, "val/throughput", float("-inf")) == 0.04
+
+    def test_define_metric_min_dict_unwrapped(self):
+        # A minimize objective records {"min": value}; with no "max" present
+        # the unwrap falls through to "min".
+        summary = SummarySubDict({"val/loss": SummarySubDict({"min": 1.2})})
+        assert read_metric(summary, "val/loss", float("inf")) == 1.2
+
+    def test_nested_slash_key_with_summary_stat_dict(self):
+        # Slash key misses AND the leaf is a define_metric dict: resolve the
+        # nested path, then unwrap the stat.
+        summary = SummarySubDict(
+            {"a": SummarySubDict({"b": SummarySubDict({"max": 0.5})})}
+        )
+        assert read_metric(summary, "a/b", float("-inf")) == 0.5
+
+    def test_multikey_namespace_without_stats_still_missing(self):
+        # A namespace dict whose keys are NOT summary stats must stay missing
+        # (we can't choose a metric for the caller) — guards the unwrap from
+        # over-firing.
+        summary = SummarySubDict(
+            {"val/throughput": SummarySubDict({"greedy": 0.5, "random": 0.1})}
+        )
+        assert read_metric(summary, "val/throughput", float("-inf")) == float("-inf")
 
     def test_mixed_present_and_missing_sort_order(self):
         runs = [


### PR DESCRIPTION
## What

Extends `read_metric()` (added in #142) to unwrap **`define_metric(summary="max"|"min"|...)`** values.

#142 taught `read_metric` to resolve slash-namespaced metrics that W&B stores as nested `SummarySubDict` nodes. But a metric declared with `define_metric(summary="max")` is stored as a **single-stat mapping** — `{"max": 0.04}` rather than a bare `0.04`. That's exactly how the SFT greedy-throughput sweep records its objective, so `float({"max": 0.04})` raises `TypeError`, those runs sort to `missing`, and the best run is never picked.

## How

- Unwrap a summary-stat dict to its scalar, preferring `max > min > last > mean > value` (a maximize objective takes `"max"`; a minimize objective with no `"max"` falls through to `"min"`).
- A namespace mapping with **no** stat keys (e.g. `{"greedy": .., "random": ..}`) is left alone → falls through to `missing` (we can't pick a metric for the caller).
- Duck-type on `.keys()` — `SummarySubDict` is dict-**like** but does not subclass `dict`.

## Tests

`tests/test_sweep_metric.py` gains: max-unwrap, min-unwrap, nested-slash + stat-dict combined, and a multi-key-namespace guard against the unwrap over-firing. `12 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)