### PR TITLE
ci: bump SFT sweep default run count 20 → 30

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -821,7 +821,7 @@ jobs:
           SWEEP_URL="${{ steps.create.outputs.sweep_url }}"
           SWEEP_PODS="${{ inputs.sweep_agents || '1' }}"
           AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '5' }}"
-          SWEEP_COUNT="${{ inputs.sweep_count || '20' }}"
+          SWEEP_COUNT="${{ inputs.sweep_count || '30' }}"
           TOTAL_AGENTS=$(( SWEEP_PODS * AGENTS_PER_POD ))
           gh pr comment "${{ github.event.pull_request.number }}" --body "$(cat <<EOF
           **SFT W&B Sweep started** — ${SWEEP_COUNT} iterations across ${SWEEP_PODS} pod(s) x ${AGENTS_PER_POD} agents/pod (${TOTAL_AGENTS} total agents)
@@ -835,7 +835,7 @@ jobs:
         run: |
           NUM_PODS="${{ inputs.sweep_agents || '1' }}"
           AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '5' }}"
-          TOTAL_COUNT="${{ inputs.sweep_count || '20' }}"
+          TOTAL_COUNT="${{ inputs.sweep_count || '30' }}"
           TOTAL_AGENTS=$(( NUM_PODS * AGENTS_PER_POD ))
           COUNT_PER=$(( TOTAL_COUNT / TOTAL_AGENTS ))
 


### PR DESCRIPTION
## What

Bump the SFT W&B sweep's default `sweep_count` fallback from **20 → 30**.

20 Bayesian iterations was too few — the search bottomed out before exploring enough of the space, so the "best" run couldn't be trusted. Two fallback sites change (the PR-comment step and the per-agent `COUNT_PER` calculation); the explicit `sweep_count` workflow input still overrides.

Only the **SFT** sweep path changes — the PPO sweep count is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)