### PR TITLE
SFT: greedy rollout eval builds from an empty grid (size*size)

### DIFF
--- a/sft.py
+++ b/sft.py
@@ -466,7 +466,12 @@ def run_rollout_eval(
     was_training = agent.training
     agent.eval()
 
-    max_level = args.max_level if args.max_level > 0 else 2 * args.size
+    # Blank the WHOLE factory (size*size) so the greedy eval builds from an
+    # empty grid — the honest "can it build from scratch" test, not a partial
+    # 2*size blank that leaves most of the factory pre-placed. Matches the
+    # data-generation path (which already auto-blanks size*size) and the
+    # max_level docstring.
+    max_level = args.max_level if args.max_level > 0 else args.size * args.size
 
     # Deterministic, run-stable subsample of val seeds. Sorting first
     # makes the selection independent of dict iteration order, then we

--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -615,6 +615,42 @@ class TestRunRolloutEval:
         for kn, thp in per_kind.items():
             assert 0.0 <= thp <= 1.5, f"{kn}: throughput out of range: {thp}"
 
+    def test_default_max_level_evals_from_empty(self, registered_env):
+        """With the default max_level (0), the rollout eval auto-resolves to
+        size*size — blanking the WHOLE factory so the agent builds from an
+        empty grid. The from-empty path must run end-to-end on every seed and
+        return well-formed throughput (this is the only rollout test that
+        exercises the default; the others pass max_level explicitly)."""
+        size = 5
+        envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, size, "test")])
+        agent = AgentCNN(envs, chan1=16, chan2=16, chan3=16, flat_dim=64)
+        envs.close()
+
+        # max_level left at its 0 default -> size*size (25) >> 2*size (10),
+        # so the whole 5x5 factory is blanked.
+        args = SFTArgs(
+            seed=1,
+            size=size,
+            num_samples=50,
+            chan1=16,
+            chan2=16,
+            chan3=16,
+            flat_dim=64,
+        )
+        assert args.max_level == 0, "default must be the auto sentinel"
+        val_seeds_to_kind = self._build_val_seeds_to_kind(size=size, num_kinds=4)
+        assert len(val_seeds_to_kind) >= 1
+
+        roll = run_rollout_eval(
+            agent,
+            args,
+            val_seeds_to_kind,
+            device=torch.device("cpu"),
+            max_seeds=len(val_seeds_to_kind),
+        )
+        assert 0.0 <= roll["overall"] <= 1.5
+        assert sum(roll["per_kind_n"].values()) == len(val_seeds_to_kind)
+
     def test_max_seeds_caps_eval(self, registered_env):
         """max_seeds should bound the rollout count even when the val set
         is larger."""


### PR DESCRIPTION
## What

`run_rollout_eval` auto-resolved `max_level` to **`2*size`**, leaving most of the factory pre-placed. The agent only had to fill in a few tiles, so `val/throughput` overstated how well it can actually build. Resolve the auto default to **`size*size`** instead — blank the *whole* factory so the greedy eval is the honest "can it build from scratch" test.

## Why this is the right number

It aligns the rollout-eval default with:
- the **data-generation path**, which already auto-blanks `size*size` (`sft.py:298`), and
- the `max_level` **docstring** (`"0 = auto: size*size"`).

So this is really fixing a doc/code mismatch on the eval side.

## Tests

Existing rollout-eval tests pass `max_level` explicitly, so none relied on the old default (none break). Adds `test_default_max_level_evals_from_empty`, the only rollout test that exercises the default path — it asserts the from-empty eval runs end-to-end on every seed and returns well-formed throughput. `5 passed` locally; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)