### PR TITLE
fix: main is red — eval-from-empty test uses pre-encoder AgentCNN API

### DIFF
--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -662,7 +662,7 @@ class TestRunRolloutEval:
         exercises the default; the others pass max_level explicitly)."""
         size = 5
         envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, size, "test")])
-        agent = AgentCNN(envs, chan1=16, chan2=16, chan3=16, flat_dim=64)
+        agent = AgentCNN(envs, layers=(16, 16, 16))
         envs.close()
 
         # max_level left at its 0 default -> size*size (25) >> 2*size (10),
@@ -671,10 +671,9 @@ class TestRunRolloutEval:
             seed=1,
             size=size,
             num_samples=50,
-            chan1=16,
-            chan2=16,
-            chan3=16,
-            flat_dim=64,
+            layer1=16,
+            layer2=16,
+            layer3=16,
         )
         assert args.max_level == 0, "default must be the auto sentinel"
         val_seeds_to_kind = self._build_val_seeds_to_kind(size=size, num_kinds=4)


### PR DESCRIPTION
## main is currently red 🔴

`tests/test_sft.py::TestRunRolloutEval::test_default_max_level_evals_from_empty` fails on `main` with:

```
TypeError: AgentCNN.__init__() got an unexpected keyword argument 'chan1'
```

## Why it slipped in

The test was added in #148, which was branched off `main` **before** #146 (the dynamic encoder) replaced `AgentCNN(chan1=,chan2=,chan3=,flat_dim=)` with `layers=/layer1..8`. #146 merged first, then #148 merged on top — so the stale constructor API landed on `main`. Neither guard caught it:
- **git** — #146 and #148 edit different lines, so no textual conflict.
- **#148's CI** — ran against the pre-#146 base, where `chan1=` was still valid.

A classic semantic merge break from stacked-ish PRs merging out of creation order.

## Fix

Port the test to the current API — `AgentCNN(envs, layers=(16, 16, 16))` / `SFTArgs(layer1=16, layer2=16, layer3=16)`. Same tiny encoder, same assertions, no behaviour change. Full suite green locally (pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)