### PR TITLE
SFT: adopt sweep #3 winner as default hyperparameters

### DIFF
--- a/sft.py
+++ b/sft.py
@@ -158,10 +158,20 @@ def extract_expert_actions(solved_CWH, task_CWH):
 
 @dataclass
 class SFTArgs:
-    # Defaults below are the rank-1 result from the first SFT sweep
-    # (wandb sweep ncqdnvmt, PR #104) — val/acc=0.901 on size=11. The
-    # `size` default is set to 12 to match the project-wide default;
-    # all other hyperparameters are from the sweep. Override any
+    # Encoder architecture (layer1..5 widths + depth), lr, dropout and
+    # weight_decay are the rank-1 result from SFT sweep #3 (wandb sweep
+    # ui3v0gn8, run 13b1ltnx) — val/throughput=0.265, the narrowest of a
+    # series of sweeps. kernel_size=3 is pinned because the earlier
+    # architecture sweeps (k13mwoj8, yxvpjz1f) tested k=5/k=7 and found k=3
+    # dominant, so #3 fixed it and refined the rest. The per-head loss weights
+    # (lw_*), LR-schedule shape (warmup/min_lr) and tile_head_std were last
+    # tuned by the first (val/acc) sweep (ncqdnvmt, PR #104) and carry over
+    # unchanged. size / num_samples / epochs are the production defaults
+    # (12 / 300k / 30), NOT the sweep's reduced budget (11 / 200k / 10).
+    #
+    # CAVEAT: this architecture only won at the 10-epoch budget; a full
+    # 30-epoch run at the production scale should confirm it beats the previous
+    # ([48,48,64], lr 2.542e-3) defaults before we fully trust it. Override any
     # individual flag at the command line.
     seed: int = 1
     """random seed"""
@@ -175,15 +185,15 @@ class SFTArgs:
     """number of training epochs"""
     batch_size: int = 512
     """training batch size"""
-    lr: float = 2.542e-3
+    lr: float = 3.242e-3
     """peak learning rate (after warmup, before cosine decay)"""
     warmup_frac: float = 0.0
     """fraction of total steps for linear warmup from lr*1e-3 up to lr. 0 disables warmup."""
     min_lr_ratio: float = 0.02869
     """cosine decay floor as a fraction of lr (final LR = lr * min_lr_ratio)"""
-    weight_decay: float = 2.902e-4
+    weight_decay: float = 1.661e-3
     """AdamW weight decay"""
-    dropout: float = 0.0
+    dropout: float = 0.1827
     """spatial dropout (Dropout2d) after each encoder conv. 0.0 = off (no-op)."""
     max_grad_norm: float = 2.104
     """grad L2-norm clip (0 disables clipping)"""
@@ -214,9 +224,9 @@ class SFTArgs:
     # CNN encoder width per layer slot (see ppo.layers_from_args). A slot of 0
     # drops that layer; layer1..3 default to a 3-conv encoder.
     # RF = 1 + n_layers * (kernel_size - 1).
-    layer1: int = 48
-    layer2: int = 48
-    layer3: int = 64
+    layer1: int = 93
+    layer2: int = 69
+    layer3: int = 96
     layer4: int = 0
     layer5: int = 0
     layer6: int = 0

--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -543,12 +543,15 @@ class TestTrainSFTEndToEnd:
 
 
 class TestSFTDropout:
-    """The SFT dropout knob is inert by default and, when set, must reach the
-    encoder via AgentCNN — mirrors ppo.Args' regularisation contract."""
+    """The SFT dropout knob carries the sweep-tuned default and, when set,
+    must reach the encoder via AgentCNN — mirrors ppo.Args' regularisation
+    contract."""
 
-    def test_dropout_default_is_noop(self):
-        """Default leaves training unchanged (Dropout2d at p=0 is identity)."""
-        assert SFTArgs().dropout == 0.0
+    def test_dropout_default_matches_sweep_winner(self):
+        """The default dropout is the sweep #3 winner (ui3v0gn8) — non-zero, so
+        regularisation is on out of the box. Pins it against an accidental
+        reset to 0."""
+        assert SFTArgs().dropout == 0.1827
 
     def test_train_sft_threads_dropout_into_agent(self, monkeypatch, tmp_path):
         """train_sft must pass args.dropout through to AgentCNN. Spy on the
@@ -1038,9 +1041,10 @@ class TestArtifactNameHelpers:
         assert _humanize_lr(0) == "0"
 
     def test_artifact_name_default(self):
-        # SFTArgs defaults (layers 48,48,64) expand into a per-layer channel
-        # suffix; size is the project default of 12.
-        assert _artifact_name(SFTArgs()) == "sft-s12-n300k-e30-bs512-lr2.5e-3-c48-48-64"
+        # SFTArgs defaults (sweep #3 winner: layers 93,69,96, lr 3.242e-3)
+        # expand into a per-layer channel suffix; size is the project default
+        # of 12.
+        assert _artifact_name(SFTArgs()) == "sft-s12-n300k-e30-bs512-lr3.2e-3-c93-69-96"
 
     def test_artifact_name_larger_run(self):
         args = SFTArgs(
@@ -1069,15 +1073,15 @@ class TestArtifactNameHelpers:
         """Differing per-layer widths expand into the full list, so a
         c32-64-64 run can't accidentally file under a c48-48-48 run."""
         args = SFTArgs(layer1=32, layer2=64, layer3=64)
-        assert _artifact_name(args) == "sft-s12-n300k-e30-bs512-lr2.5e-3-c32-64-64"
+        assert _artifact_name(args) == "sft-s12-n300k-e30-bs512-lr3.2e-3-c32-64-64"
 
     def test_artifact_name_kernel_size_suffix(self):
         """A non-default kernel size appends -k{N} so two runs differing only
         in receptive field get distinct artifacts; the default k=3 adds no
         token (keeps existing names stable)."""
-        assert _artifact_name(SFTArgs()).endswith("-c48-48-64")
+        assert _artifact_name(SFTArgs()).endswith("-c93-69-96")
         assert _artifact_name(SFTArgs(kernel_size=5)) == (
-            "sft-s12-n300k-e30-bs512-lr2.5e-3-c48-48-64-k5"
+            "sft-s12-n300k-e30-bs512-lr3.2e-3-c93-69-96-k5"
         )
 
     def test_artifact_name_stable_across_runs(self):


### PR DESCRIPTION
## What

Set the SFTArgs defaults to the rank-1 run of **SFT sweep #3** (wandb sweep [`ui3v0gn8`](https://wandb.ai/beyarkay/factorion/sweeps/ui3v0gn8), run `13b1ltnx`, `val/throughput=0.265`):

| param | old | new |
|---|---|---|
| layer1/2/3 | 48 / 48 / 64 | **93 / 69 / 96** |
| lr | 2.542e-3 | **3.242e-3** |
| dropout | 0.0 | **0.1827** |
| weight_decay | 2.902e-4 | **1.661e-3** |

`ui3v0gn8` swept encoder widths+depth (`layer1..5`), `lr`, `dropout`, `weight_decay`. `kernel_size=3` stays pinned (the earlier architecture sweeps tested k=5/k=7 and found k=3 dominant). Per-head loss weights, the LR-schedule shape and `tile_head_std` carry over from the first (val/acc) sweep. `size`/`num_samples`/`epochs` stay at the **production** defaults (12 / 300k / 30), not the sweep's reduced 11 / 200k / 10 budget.

## ⚠️ Pending full-scale verification — do not merge yet

This architecture only won at the sweep's **10-epoch** budget. Before merging, a full **30-epoch** run at production scale should confirm it beats the previous (`[48,48,64]`, lr 2.542e-3) defaults — short-horizon sweep winners don't always stay winners (fast-early ≠ best-final; the regularization knobs barely bite at 10 epochs). That verification run is the next step. The caveat is also in the SFTArgs code comment.

## Stacked on #150

Branched on `fix-eval-test-encoder-api` (#150, the main-is-red hotfix), since both touch `tests/test_sft.py` and PR7 can't be green on the currently-red `main`. **Merge #150 first**; GitHub will auto-retarget this to `main`.

Updates the artifact-name and dropout-default tests for the new values. Full suite green locally (pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)