### PR TITLE
SFT: adopt run kkcv6xe3 as the canonical default (config + checkpoint + CI)

### DIFF
--- a/.github/workflows/sft-train.yml
+++ b/.github/workflows/sft-train.yml
@@ -11,12 +11,12 @@ on:
       num_samples:
         description: "Number of SFT samples"
         required: true
-        default: "100000"
+        default: "1000000"
         type: string
       epochs:
         description: "Number of training epochs"
         required: true
-        default: "30"
+        default: "45"
         type: string
       ref:
         description: "Git ref to train (branch / SHA / tag)"

--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -111,10 +111,11 @@ class Args:
     checkpoint: Optional[str] = None
     """path to a trained SFT/PPO checkpoint (.pt). If set, the UI shows
     the model's predicted next placement and exposes an Apply button."""
-    wandb_run: Optional[str] = "xlnqmtzt"
+    wandb_run: Optional[str] = "kkcv6xe3"
     """W&B run id (or full path 'entity/project/run_id'). The run's most
     recent model-type artifact is downloaded to /tmp/factorion-checkpoints
-    and loaded. Mutually exclusive with --checkpoint."""
+    and loaded. Mutually exclusive with --checkpoint. Defaults to the
+    canonical SFT run kkcv6xe3 (sft-11x11, best_val_throughput 0.335)."""
     wandb_project: str = "factorion"
     """W&B project to look in when --wandb-run is a bare id."""
     wandb_entity: Optional[str] = None

--- a/sft.py
+++ b/sft.py
@@ -160,32 +160,36 @@ def extract_expert_actions(solved_CWH, task_CWH):
 
 @dataclass
 class SFTArgs:
-    # Defaults below are the rank-1 result from the first SFT sweep
-    # (wandb sweep ncqdnvmt, PR #104) — val/acc=0.901 on size=11. The
-    # `size` default is set to 12 to match the project-wide default;
-    # all other hyperparameters are from the sweep. Override any
-    # individual flag at the command line.
+    # Defaults reproduce run kkcv6xe3 (wandb "sft-11x11"), the canonical SFT
+    # config + checkpoint going forward: the sweep #3 architecture (ui3v0gn8 —
+    # layers 93-69-96, lr 3.242e-3, dropout 0.1827, weight_decay 1.661e-3)
+    # trained at scale (size 11, 1M samples, 45 epochs; best_val_throughput
+    # 0.335, val_acc 0.838). size is 11 (not the old 12) so the default config
+    # matches that checkpoint. Running sft.py with no flags reproduces the run.
+    # NB: greedy throughput plateaued early (~epoch 3) in kkcv6xe3 — the long
+    # 1M x 45 schedule mainly drives per-step loss/acc, not throughput, so the
+    # epoch/sample counts are generous. Override any flag at the command line.
     seed: int = 1
     """random seed"""
-    size: int = 12
+    size: int = 11
     """grid size (width and height)"""
-    num_samples: int = 300000
+    num_samples: int = 1000000
     """number of (state, action) pairs to generate"""
     max_level: int = 0
     """max curriculum level (0 = auto: size*size)"""
-    epochs: int = 30
+    epochs: int = 45
     """number of training epochs"""
     batch_size: int = 512
     """training batch size"""
-    lr: float = 2.542e-3
+    lr: float = 3.242e-3
     """peak learning rate (after warmup, before cosine decay)"""
     warmup_frac: float = 0.0
     """fraction of total steps for linear warmup from lr*1e-3 up to lr. 0 disables warmup."""
     min_lr_ratio: float = 0.02869
     """cosine decay floor as a fraction of lr (final LR = lr * min_lr_ratio)"""
-    weight_decay: float = 2.902e-4
+    weight_decay: float = 1.661e-3
     """AdamW weight decay"""
-    dropout: float = 0.0
+    dropout: float = 0.1827
     """spatial dropout (Dropout2d) after each encoder conv. 0.0 = off (no-op)."""
     max_grad_norm: float = 2.104
     """grad L2-norm clip (0 disables clipping)"""
@@ -216,9 +220,9 @@ class SFTArgs:
     # CNN encoder width per layer slot (see ppo.layers_from_args). A slot of 0
     # drops that layer; layer1..3 default to a 3-conv encoder.
     # RF = 1 + n_layers * (kernel_size - 1).
-    layer1: int = 48
-    layer2: int = 48
-    layer3: int = 64
+    layer1: int = 93
+    layer2: int = 69
+    layer3: int = 96
     layer4: int = 0
     layer5: int = 0
     layer6: int = 0

--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -548,12 +548,8 @@ class TestTrainSFTEndToEnd:
 
 
 class TestSFTDropout:
-    """The SFT dropout knob is inert by default and, when set, must reach the
-    encoder via AgentCNN — mirrors ppo.Args' regularisation contract."""
-
-    def test_dropout_default_is_noop(self):
-        """Default leaves training unchanged (Dropout2d at p=0 is identity)."""
-        assert SFTArgs().dropout == 0.0
+    """The SFT dropout knob, when set, must reach the encoder via AgentCNN —
+    mirrors ppo.Args' regularisation contract."""
 
     def test_train_sft_threads_dropout_into_agent(self, monkeypatch, tmp_path):
         """train_sft must pass args.dropout through to AgentCNN. Spy on the
@@ -1187,11 +1183,6 @@ class TestArtifactNameHelpers:
     def test_humanize_lr_zero(self):
         assert _humanize_lr(0) == "0"
 
-    def test_artifact_name_default(self):
-        # SFTArgs defaults (layers 48,48,64) expand into a per-layer channel
-        # suffix; size is the project default of 12.
-        assert _artifact_name(SFTArgs()) == "sft-s12-n300k-e30-bs512-lr2.5e-3-c48-48-64"
-
     def test_artifact_name_larger_run(self):
         args = SFTArgs(
             size=16,
@@ -1219,16 +1210,19 @@ class TestArtifactNameHelpers:
         """Differing per-layer widths expand into the full list, so a
         c32-64-64 run can't accidentally file under a c48-48-48 run."""
         args = SFTArgs(layer1=32, layer2=64, layer3=64)
-        assert _artifact_name(args) == "sft-s12-n300k-e30-bs512-lr2.5e-3-c32-64-64"
+        # Assert only the channel suffix (the behaviour under test) so this
+        # doesn't break when the default size/samples/epochs/lr change.
+        assert _artifact_name(args).endswith("-c32-64-64")
 
     def test_artifact_name_kernel_size_suffix(self):
         """A non-default kernel size appends -k{N} so two runs differing only
         in receptive field get distinct artifacts; the default k=3 adds no
         token (keeps existing names stable)."""
-        assert _artifact_name(SFTArgs()).endswith("-c48-48-64")
-        assert _artifact_name(SFTArgs(kernel_size=5)) == (
-            "sft-s12-n300k-e30-bs512-lr2.5e-3-c48-48-64-k5"
-        )
+        # Default kernel (3) adds no suffix; a non-default kernel appends
+        # -k{N}. Derive from the default name so this survives default changes.
+        base = _artifact_name(SFTArgs())
+        assert not base.endswith(("-k3", "-k5", "-k7"))
+        assert _artifact_name(SFTArgs(kernel_size=5)) == base + "-k5"
 
     def test_artifact_name_stable_across_runs(self):
         """Two SFTArgs with the same hyperparams must produce the same


### PR DESCRIPTION
## What

Standardise on run **[kkcv6xe3](https://wandb.ai/beyarkay/factorion/runs/kkcv6xe3)** (sft-11x11, best_val_throughput 0.335) as the canonical SFT config + checkpoint, in three places:

**1. SFTArgs defaults** reproduce kkcv6xe3:

| param | old | new |
|---|---|---|
| size | 12 | **11** |
| num_samples | 300000 | **1000000** |
| epochs | 30 | **45** |
| lr | 2.542e-3 | **3.242e-3** |
| dropout | 0.0 | **0.1827** |
| weight_decay | 2.902e-4 | **1.661e-3** |
| layer1/2/3 | 48/48/64 | **93/69/96** |

`python sft.py` (no flags) reproduces the run. **size is 11** so the default *config* matches the default *checkpoint* (say so if you'd rather keep 12).

**2. factory-builder UI** — default `wandb_run` `xlnqmtzt` → `kkcv6xe3`, so the UI auto-loads the canonical checkpoint (folds in the closed #158).

**3. `sft-train.yml` manual workflow** — default `num_samples` 100k → 1M, `epochs` 30 → 45, so a manual launch reproduces kkcv6xe3. (The per-PR `sft_smoke_test` fallback stays 300k/30 — already `--size 11` — since 1M×45 would blow the 6h CI cap.)

## Tests

Dropped the magic-number default pins (`test_artifact_name_default`, `test_dropout_default_matches_kkcv6xe3`) so we don't re-edit a test on every default change — dropout plumbing is still covered by the explicit-value threading test, and the artifact-name *format* by `test_artifact_name_larger_run` (explicit values). Made the asymmetric / kernel-suffix tests assert only the behaviour under test (channel suffix, `-k{N}`), independent of the default hparams.

## Supersedes #151

#151 set only arch/lr/reg at the old 12/300k/30 scale (pending verification). kkcv6xe3 is that verification — **recommend closing #151** once this merges.

## Caveat

Greedy throughput plateaued ~epoch 3 in kkcv6xe3, so the 1M×45 schedule mainly buys per-step loss/acc, not throughput — the default epoch/sample counts are generous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)