### PR TITLE
factory UI: default to the canonical kkcv6xe3 checkpoint

### DIFF
--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -111,10 +111,11 @@ class Args:
     checkpoint: Optional[str] = None
     """path to a trained SFT/PPO checkpoint (.pt). If set, the UI shows
     the model's predicted next placement and exposes an Apply button."""
-    wandb_run: Optional[str] = "xlnqmtzt"
+    wandb_run: Optional[str] = "kkcv6xe3"
     """W&B run id (or full path 'entity/project/run_id'). The run's most
     recent model-type artifact is downloaded to /tmp/factorion-checkpoints
-    and loaded. Mutually exclusive with --checkpoint."""
+    and loaded. Mutually exclusive with --checkpoint. Defaults to the
+    canonical SFT run kkcv6xe3 (sft-11x11, best_val_throughput 0.335)."""
     wandb_project: str = "factorion"
     """W&B project to look in when --wandb-run is a bare id."""
     wandb_entity: Optional[str] = None

--- a/tests/test_factory_builder.py
+++ b/tests/test_factory_builder.py
@@ -75,6 +75,14 @@ def _empty_grid(size: int) -> list[list[dict]]:
 
 # ── Pure helpers ────────────────────────────────────────────────────────────
 
+class TestDefaultCheckpoint:
+    def test_default_wandb_run_is_canonical_kkcv6xe3(self):
+        """The UI auto-loads the canonical SFT checkpoint (run kkcv6xe3) when
+        launched with no --checkpoint/--wandb-run. Pins that default so it
+        isn't silently changed."""
+        assert fb.Args().wandb_run == "kkcv6xe3"
+
+
 class TestTopP:
     def test_top_p_named_includes_until_mass_reached(self):
         # 50/30/15/5 split — top-p=0.95 should include 50+30+15=95, then


### PR DESCRIPTION
## What

The factory-builder UI (`scripts/factory_builder.py`) auto-loads a W&B checkpoint at launch when neither `--checkpoint` nor `--wandb-run` is given. Point that default (`Args.wandb_run`) at run **kkcv6xe3** (sft-11x11, best_val_throughput 0.335) — the SFT checkpoint we're standardising on — instead of the older `xlnqmtzt`. The UI resolves the run id to its newest `type=model` artifact, which kkcv6xe3 has (`sft-s11-n1m-e45-bs512-lr3.2e-3-c93-69-96:v0`).

Pinned with `TestDefaultCheckpoint` so the canonical default can't drift silently.

Companion to #157 (which makes the *training* defaults reproduce kkcv6xe3). Independent — separate file, can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)