### PR TITLE
fix: name SFT W&B runs by their hyperparameter signature

### DIFF
--- a/sft.py
+++ b/sft.py
@@ -972,9 +972,6 @@ def train_sft(args: SFTArgs):
             project=args.wandb_project_name,
             entity=args.wandb_entity,
             config=vars(args),
-            # Name the run by its full hyperparameter signature (the same
-            # string used for the model artifact) so runs are distinguishable
-            # in the W&B table — previously every run was "sft-{size}x{size}".
             name=_artifact_name(args),
             group=args.wandb_group,
             tags=sft_tags,

--- a/sft.py
+++ b/sft.py
@@ -972,7 +972,10 @@ def train_sft(args: SFTArgs):
             project=args.wandb_project_name,
             entity=args.wandb_entity,
             config=vars(args),
-            name=f"sft-{args.size}x{args.size}",
+            # Name the run by its full hyperparameter signature (the same
+            # string used for the model artifact) so runs are distinguishable
+            # in the W&B table — previously every run was "sft-{size}x{size}".
+            name=_artifact_name(args),
             group=args.wandb_group,
             tags=sft_tags,
         )

--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -632,6 +632,43 @@ class TestTrackedArtifact:
         assert meta["kernel_size"] == 3
         assert "chan1" not in meta
 
+    def test_run_named_by_artifact_name(self, monkeypatch, tmp_path):
+        """The W&B run name is the full hyperparameter signature (== the model
+        artifact name) so runs are distinguishable in the table — not all
+        "sft-{size}x{size}"."""
+        import wandb
+        from unittest.mock import MagicMock
+
+        captured = {}
+
+        def fake_init(*a, **k):
+            captured["name"] = k.get("name")
+            run = MagicMock()
+            run.url = "http://test/run"
+            run.summary = {}
+            return run
+
+        monkeypatch.setattr(wandb, "init", fake_init)
+        monkeypatch.setattr(wandb, "Artifact", lambda *a, **k: MagicMock())
+
+        args = SFTArgs(
+            seed=1,
+            size=5,
+            num_samples=200,
+            max_level=2,
+            epochs=1,
+            batch_size=32,
+            layer1=16,
+            layer2=16,
+            layer3=16,
+            track=True,
+            eval_rollouts_every_n_epochs=0,
+            checkpoint_path=str(tmp_path / "k.pt"),
+            summary_path=str(tmp_path / "k.json"),
+        )
+        train_sft(args)
+        assert captured["name"] == _artifact_name(args)
+
 
 class TestRunRolloutEval:
     """End-to-end coverage of greedy rollout eval on held-out val factories."""


### PR DESCRIPTION
## The bug

`_artifact_name` only names the **model artifact**. The W&B **run name** was separately hardcoded to `f"sft-{size}x{size}"` — so every run shows up as `sft-11x11` in the runs table, indistinguishable by config (which is what you hit).

## Fix

Name the run with `_artifact_name(args)` too — the same descriptive signature already used for the artifact (e.g. `sft-s11-n1m-e45-bs512-lr3.2e-3-c93-69-96`). Now runs are distinguishable in the table, and the run name matches its uploaded artifact name.

## Test

`test_run_named_by_artifact_name` captures the `name=` passed to `wandb.init` (via a mock run) and asserts it equals `_artifact_name(args)` — behavioural, no hardcoded string, so it won't need updating when defaults change.

Independent of #157 (touches `wandb.init`, not SFTArgs) — merges in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)