### PR TITLE
fix: silence dead-code lint under `cargo clippy --no-default-features`

### DIFF
--- a/factorion_rs/src/lib.rs
+++ b/factorion_rs/src/lib.rs
@@ -6,6 +6,15 @@
 // Forbid unwrap/expect in non-test code (tests use #[allow] where needed)
 #![deny(clippy::unwrap_used)]
 #![deny(clippy::expect_used)]
+// Without the `pyo3-bindings` feature this crate has no non-test entry points:
+// every root (`simulate_throughput`, `build_graph`, `entity_tiles`, the `py_*`
+// functions, …) is gated behind that feature, so a non-test `--no-default-features`
+// build leaves dead-code analysis with nothing to anchor on and flags the entire
+// throughput engine. That configuration is only used to run `cargo test
+// --no-default-features` (the default extension-module build can't link libpython
+// under `cargo test`), so suppress dead-code there. The shipping default build
+// still gets full dead-code checks.
+#![cfg_attr(not(feature = "pyo3-bindings"), allow(dead_code))]
 
 // `nonempty::nonempty![...]` expands to a path through `::alloc::vec`, which
 // requires `alloc` to be visible at the crate root.


### PR DESCRIPTION
## Problem

`cargo clippy --no-default-features -- -D warnings` failed with **31 dead-code errors** spanning the entire throughput engine (`entities`, `graph`, `throughput`, `types`, `world`):

```
error: enum `EntityEnum` is never used
error: struct `TransportBelt` is never constructed
error: function `build_graph` is never used
... (31 total)
```

This is the exact command the pre-push hook runs at `[2/7]`, so it blocked pushes.

## Why these aren't actually dead

I checked whether these were leftovers from removed Python code — they aren't. Every flagged item is reachable from the PyO3 entry points (`simulate_throughput`, `build_graph`, `entity_tiles`, `py_items`, `py_recipes`), **all of which are still called from Python** (`factorion.py`, `ppo.py`, `sft.py`, scripts, and tests). Clippy on the default (shipping) build is clean, confirming nothing is orphaned.

They only *look* dead because every non-test root is gated behind the `pyo3-bindings` feature. In a non-test `--no-default-features` build that feature is off, so dead-code analysis has **no roots to anchor on** and flags the whole engine. That configuration exists solely so `cargo test --no-default-features` can run without PyO3's libpython linker errors.

## Fix

Scope the suppression to exactly that configuration:

```rust
#![cfg_attr(not(feature = "pyo3-bindings"), allow(dead_code))]
```

The default (shipping) build keeps **full dead-code detection** — this only relaxes the analysis in the binding-less config where it has nothing to work from.

## Verification

- `cargo clippy --no-default-features -- -D warnings` ✅ (was failing)
- `cargo clippy -- -D warnings` (default) ✅ still clean — proves no real dead code is hidden
- `cargo fmt --check` ✅
- `cargo test --no-default-features` ✅ (48 tests)
- Full pre-push hook (ruff, ty check, 3426 Python tests) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)