### PR TITLE
fix: sink only counts its configured item (stop assembler-bypass reward hack)

### DIFF
--- a/factorion_rs/src/throughput.rs
+++ b/factorion_rs/src/throughput.rs
@@ -130,11 +130,21 @@ pub fn calc_throughput(graph: &FactoryGraph) -> (HashMap<Item, f64>, usize) {
         }
     }
 
-    // 3. Collect output at sinks
+    // 3. Collect output at sinks. A sink only scores the item it is
+    //    configured to receive — its tile's ITEMS channel, surfaced as
+    //    `node.item`. Without this filter the engine counts *any* item that
+    //    reaches a sink, which lets a policy reward-hack assemble lessons:
+    //    route the raw input item straight to the sink at belt speed and
+    //    never build the assembler. The raw input is not the crafted output
+    //    the sink expects, so a bypass now scores 0 and only a genuine craft
+    //    delivers the recipe rate.
     let mut total_output: HashMap<Item, f64> = HashMap::new();
     for &sink_idx in &sinks {
+        let expected = graph.nodes[sink_idx].item;
         for (&item, &rate) in &node_outputs[sink_idx] {
-            *total_output.entry(item).or_insert(0.0) += rate;
+            if Some(item) == expected {
+                *total_output.entry(item).or_insert(0.0) += rate;
+            }
         }
     }
 
@@ -463,5 +473,85 @@ mod tests {
         let g = build_graph(&w);
         let (output, _) = calc_throughput(&g);
         assert!(output.is_empty());
+    }
+
+    #[test]
+    fn test_assemble_bypass_scores_zero() {
+        // Reward-hack regression: a sink only counts the item it is
+        // configured to receive. Here the sink expects CopperCable (the
+        // crafted output), but the policy "cheats" by laying a straight
+        // belt that runs the raw CopperPlate input from source to sink at
+        // belt speed, never building the assembler. The raw input is not
+        // the expected output, so this must score 0 — not 15.
+        let mut w = World::empty(4, 1);
+        w.place(0, 0, Item::Source, Direction::East, Some(Item::CopperPlate));
+        w.place(1, 0, Item::TransportBelt, Direction::East, None);
+        w.place(2, 0, Item::TransportBelt, Direction::East, None);
+        w.place(3, 0, Item::Sink, Direction::East, Some(Item::CopperCable));
+
+        let g = build_graph(&w);
+        let (output, unreachable) = calc_throughput(&g);
+
+        // The raw passthrough item must NOT be counted toward throughput,
+        // and the expected crafted output never arrives → zero throughput.
+        assert!(
+            !output.contains_key(&Item::CopperPlate),
+            "Raw input leaked into throughput: {:?}",
+            output
+        );
+        assert_eq!(
+            output.get(&Item::CopperCable).copied().unwrap_or(0.0),
+            0.0,
+            "Bypass should yield 0 CopperCable, got {:?}",
+            output
+        );
+        assert_eq!(unreachable, 0);
+    }
+
+    #[test]
+    fn test_assemble_genuine_craft_scores_recipe_rate() {
+        // The complement to the bypass test: a real craft scores. The
+        // assembler (recipe CopperPlate → 2× CopperCable) is fed raw
+        // CopperPlate via an inserter and hands CopperCable to the sink via
+        // an output inserter + belt. The sink expects CopperCable, so the
+        // crafted output is counted. Throughput is inserter-limited (0.86).
+        //
+        //   Source(CopperPlate) → Inserter → Assembler(→CopperCable)
+        //                                  → Inserter → Belt → Sink(CopperCable)
+        let mut w = World::empty(9, 5);
+        w.place(0, 2, Item::Source, Direction::East, Some(Item::CopperPlate));
+        w.place(1, 2, Item::Inserter, Direction::East, None);
+        // 3x3 assembler, anchor (2,1), recipe keyed by its output item.
+        w.place_multi_tile(
+            2,
+            1,
+            Item::AssemblingMachine1,
+            Direction::East,
+            Some(Item::CopperCable),
+            3,
+            3,
+        );
+        w.place(5, 2, Item::Inserter, Direction::East, None);
+        w.place(6, 2, Item::TransportBelt, Direction::East, None);
+        w.place(7, 2, Item::Sink, Direction::East, Some(Item::CopperCable));
+
+        let g = build_graph(&w);
+        let (output, unreachable) = calc_throughput(&g);
+
+        // Only the crafted CopperCable is counted (inserter-limited to 0.86),
+        // and no raw CopperPlate leaks through.
+        assert!(
+            !output.contains_key(&Item::CopperPlate),
+            "Raw input leaked into throughput: {:?}",
+            output
+        );
+        let throughput = output.get(&Item::CopperCable).copied().unwrap_or(0.0);
+        assert!(
+            (throughput - 0.86).abs() < 1e-9,
+            "Expected inserter-limited 0.86 CopperCable, got {} ({:?})",
+            throughput,
+            output
+        );
+        assert_eq!(unreachable, 0);
     }
 }


### PR DESCRIPTION
## Problem

The throughput engine scored a factory by the rate of the *fastest-arriving* item at any sink, regardless of whether that item was the one the sink was configured to receive. On assemble lessons (`ASSEMBLE_1IN_1OUT`, `ASSEMBLE_2IN_1OUT`, `FROM_BLUEPRINT`) a policy could get a perfect score **without building the assembler at all** — just laying a transport belt that runs the raw input item straight from source to sink at belt speed (15/s). The crafted output is never produced, but the raw passthrough wins the score.

This made `val/<LESSON>/throughput` (e.g. ~0.33) a measure of "fraction of seeds where the policy found a belt-speed bypass," not crafting skill.

## Root cause

- `Sink::transform_flow` passed through every item type.
- `calc_throughput` collected *all* items arriving at every sink into `total_output` with no filter.
- `simulate_throughput` then reduced the per-item map to a scalar via `max`, so a 15/s raw passthrough beat a 0.17/s correct craft.

## Fix

In `calc_throughput`, filter each sink's collected flow to only the item stored on its tile (`GraphNode.item`, which `build_factory` sets to the crafted output). A bypass now scores 0 (raw input ≠ expected output); only a genuine craft delivers the recipe rate. `MOVE_ONE_ITEM` is unaffected — its source and sink carry the same item, so the moved item still matches.

Verified first that assemble sinks are configured with the crafted output (`iron_plate` → `iron_gear_wheel`), while `MOVE_ONE_ITEM` source==sink — so the filter bites bypasses without touching move lessons. No sink is ever configured with `item == None`.

## Tests

- `test_assemble_bypass_scores_zero` — raw input → belt → sink-expecting-craft scores 0 (was belt speed).
- `test_assemble_genuine_craft_scores_recipe_rate` — source → assembler → sink scores the inserter-limited recipe rate (0.86), proving the filter isn't over-zealous.

## Impact on the canonical checkpoint

Greedy-evaluated `kkcv6xe3` (sft-11x11) on assemble lessons with the fix in place (48 seeds each):

| Lesson | `val/throughput` before | after | raw items/s (max) |
|---|---|---|---|
| `ASSEMBLE_1IN_1OUT` | ~0.335 | **0.0000** | 0.00 |
| `ASSEMBLE_2IN_1OUT` | — | **0.0000** | 0.00 |

The inflated score collapses to exactly zero: every prior "success" was a bypass. (The policy does place ~6 assemblers on half the seeds, but never wires a working craft — so the fix reveals it has no genuine crafting skill on these lessons, rather than the engine being too strict.)

## Checklist

cargo fmt ✓ · 50 Rust tests (`--no-default-features`) ✓ · maturin develop ✓ · 3426 pytest / 77 skipped ✓ · ruff ✓ · ty ✓ · PPO + SFT smoke ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)