### PR TITLE
Normalize throughput by per-factory max instead of fixed /15

### DIFF
--- a/factorion.py
+++ b/factorion.py
@@ -1199,6 +1199,10 @@ def eval_model(actor, critic, pars, num_evaluations=1_000, pbar=False):
         # value = critic(normalised_world)
         value = critic(normalised_world.to(torch.float))
         # Maybe having throughput being calculated as a black box is the problem?
+        # FIXME(#161): still the old fixed /15.0 normalization. This is the
+        # legacy RL-from-scratch eval (no current callers) and its random
+        # get_new_world() inputs have no reference factory to normalize by, so
+        # there's no per-factory max to use here — left as-is intentionally.
         throughput = torch.tensor(
             funge_throughput(normalised_world)[0] / 15.0,
             dtype=value.dtype,

--- a/ppo.py
+++ b/ppo.py
@@ -299,7 +299,11 @@ class FactorioEnv(gym.Env):
     def _get_info(self):
         return {
             # 'num_missing_entities': self.num_missing_entities,
-            'throughput': self._throughput,
+            # thput_raw: raw items/second (reference-free). thput_normed:
+            # raw / per-factory max, clamped to [0, 1] (1.0 == reproduced the
+            # reference factory's throughput). See FIXME(#161) in step().
+            'thput_raw': self._thput_raw,
+            'thput_normed': self._thput_normed,
             'frac_reachable': self._frac_reachable,
             'frac_hallucin': self._frac_hallucin,
             'final_dir_reward': self._final_dir_reward,
@@ -337,7 +341,8 @@ class FactorioEnv(gym.Env):
         self._cum_reward = 0
 
         self.invalid_actions = 0
-        self._throughput = 0
+        self._thput_raw = 0.0
+        self._thput_normed = 0.0
         self._frac_reachable = 0
         self._frac_hallucin = 0
         self._final_dir_reward = 0
@@ -388,6 +393,18 @@ class FactorioEnv(gym.Env):
                     f"seed={self._seed}"
                 )
         self._solved_world_CWH = factory.world_CWH
+        # Per-factory maximum throughput: the raw items/second the complete,
+        # correct factory carries. We normalize the agent's raw throughput by
+        # this so a perfectly-rebuilt factory scores 1.0 regardless of its
+        # absolute speed (different lessons/layouts have very different maxima;
+        # the old fixed /15.0 mislabeled any factory whose max was < 15).
+        # FIXME(#161): this depends on having the full scripted solution to
+        # compute the max. Fine while every episode is a scripted lesson, but
+        # arbitrary RL rollouts won't have a reference factory — see GH #161.
+        max_tp, _ = factorion_rs.simulate_throughput(
+            self._solved_world_CWH.permute(1, 2, 0).to(torch.int64).numpy()
+        )
+        self._max_throughput = float(max_tp)
         self._world_CWH, min_entities_required = blank_entities(
             factory, num_missing_entities=self._num_missing_entities
         )
@@ -524,9 +541,20 @@ class FactorioEnv(gym.Env):
 
         self.invalid_actions += 1 if action_is_invalid else 0
 
-        throughput, num_unreachable = factorion_rs.simulate_throughput(self._world_CWH.permute(1, 2, 0).to(torch.int64).numpy())
-        # TODO don't always divide by 15
-        throughput /= 15.0
+        thput_raw, num_unreachable = factorion_rs.simulate_throughput(self._world_CWH.permute(1, 2, 0).to(torch.int64).numpy())
+        # thput_raw is items/second — the reference-free signal arbitrary RL
+        # should ultimately optimize. thput_normed in [0, 1] is raw / per-factory
+        # max, so a perfectly-rebuilt factory scores 1.0 no matter its absolute
+        # speed (the old fixed /15.0 scored a perfect sub-15 factory as e.g. 0.33).
+        # FIXME(#161): thput_normed, the termination check, and the reward below
+        # all depend on self._max_throughput, which we only know because the
+        # lesson is scripted and we have the full solution. Arbitrary RL rollouts
+        # won't have that reference; this must move to a reference-free signal.
+        thput_normed = (
+            min(1.0, thput_raw / self._max_throughput)
+            if self._max_throughput > 0
+            else 0.0
+        )
 
         # Calculate a "reachable" fraction that penalises the model for leaving
         # entities disconnected from the graph (almost certainly useless)
@@ -580,7 +608,11 @@ class FactorioEnv(gym.Env):
         reward_components = {
             'throughput': {
                 'coeff': Args.coeff_throughput if 'args' not in locals() else args.coeff_throughput,
-                'value': throughput,
+                # thput_normed is in [0, 1] (raw / per-factory max), the direct
+                # analog of the old raw/15 value — so coeff_throughput keeps its
+                # tuned meaning. The RL reward redesign (raw items/s, terminal
+                # throughput − step penalty) lives on the rl-from-chkpt branch.
+                'value': thput_normed,
             },
             'validity': {
                 'coeff': Args.coeff_validity if 'args' not in locals() else args.coeff_validity,
@@ -611,9 +643,11 @@ class FactorioEnv(gym.Env):
         pre_reward += coeff_ent * ent_delta
         pre_reward += coeff_dir * dir_delta
 
-        # Terminate early when the agent connects source to sink
-        # Terminate early when the agent connects source to sink
-        terminated = throughput >= 1.0
+        # Terminate early when the agent reaches the reference factory's max
+        # throughput (thput_normed == 1.0). This is the existing throughput
+        # auto-terminal, carried over unchanged via the normalized value; the
+        # EOT-driven termination redesign lives on the rl-from-chkpt branch.
+        terminated = thput_normed >= 1.0
         # Halt the run if the agent runs out of steps (only if not already solved)
         truncated = (not terminated) and (self.steps > self.max_steps)
 
@@ -623,7 +657,8 @@ class FactorioEnv(gym.Env):
         else:
             reward = pre_reward
 
-        self._throughput = throughput
+        self._thput_raw = thput_raw
+        self._thput_normed = thput_normed
         self._frac_reachable = frac_reachable
         self._frac_hallucin = frac_hallucin
         self._final_dir_reward = final_dir_reward
@@ -640,7 +675,8 @@ class FactorioEnv(gym.Env):
         num_placed_entities = len([a for a in self.actions if a is not None and a['entity'] != 'empty'])
 
         info.update({
-            'throughput': throughput,
+            'thput_raw': thput_raw,
+            'thput_normed': thput_normed,
             'frac_reachable': frac_reachable,
             'frac_hallucin': frac_hallucin,
             'final_dir_reward': final_dir_reward,
@@ -786,13 +822,14 @@ class FactorioEnv(gym.Env):
         info = self._get_info() or {}
         unreach = info.get("frac_reachable", "?")
         cum_reward = info.get("cum_reward", 0)
-        throughput = info.get("throughput", "?")
+        thput_raw = info.get("thput_raw", "?")
+        thput_normed = info.get("thput_normed", "?")
         reward = info.get("reward", "?")
 
         lines = [
             f"Step {self.steps}/{self.max_steps}",
             f"SumReward: {cum_reward:.3f}  |  Reward: {reward:.3f}",
-            f"thrput: {throughput}  |  Unreachable: {unreach:.3f}",
+            f"thrput: {thput_normed} ({thput_raw}/s)  |  Unreachable: {unreach:.3f}",
         ]
         if self.actions and self.actions[-1] is not None:
             lines.append(f"Placing {self.actions[-1]['entity']}")
@@ -1071,7 +1108,7 @@ if __name__ == "__main__":
 
         # Define metric axes and summary aggregation
         wandb.define_metric("*", step_metric="global_step")
-        for m in ["throughput", "reward", "length", "invalid_frac",
+        for m in ["throughput", "thput_raw", "reward", "length", "invalid_frac",
                    "num_entities", "entity_efficiency", "frac_reachable"]:
             wandb.define_metric(f"episode/{m}", summary="last")
         for m in ["tile_location", "tile_entity", "tile_direction",
@@ -1265,7 +1302,11 @@ if __name__ == "__main__":
                     # This environment finished, extract its stats
                     episode_return = infos["episode"]["r"][i]
                     episode_len = infos["episode"]["l"][i]
-                    end_of_episode_thput = infos["throughput"][i]
+                    # Curriculum score relies on throughput ∈ [0, 1] (level
+                    # advance must dominate within-level gain), so track the
+                    # normalized value; also log raw items/sec for visibility.
+                    end_of_episode_thput = infos["thput_normed"][i]
+                    end_of_episode_thput_raw = infos["thput_raw"][i]
                     final_frac_reachable = infos["frac_reachable"][i]
                     # final_frac_hallucin = infos["frac_hallucin"][i]
 
@@ -1277,6 +1318,7 @@ if __name__ == "__main__":
 
                     _record_episode({
                         "episode/throughput": float(end_of_episode_thput),
+                        "episode/thput_raw": float(end_of_episode_thput_raw),
                         "episode/reward": float(episode_return),
                         "episode/length": float(episode_len),
                         "episode/invalid_frac": float(infos['frac_invalid_actions'][i]),

--- a/sft.py
+++ b/sft.py
@@ -466,8 +466,10 @@ def run_rollout_eval(
 
     For each held-out (seed, kind) we greedy-argmax every head and step
     until the env finishes (throughput==1.0 or max_steps) — we do NOT
-    let the EOT head stop us. Throughput is the last `info['throughput']`
-    the env reported (the env already calls the Rust solver every step,
+    let the EOT head stop us. Throughput is the last `info['thput_normed']`
+    the env reported: raw items/sec divided by the per-factory max, in
+    [0, 1], so a perfectly-rebuilt factory scores 1.0 regardless of its
+    absolute belt speed (the env already calls the Rust solver every step,
     so we don't re-run it). This `overall` number is the model's true
     build skill independent of its stop head.
 
@@ -556,7 +558,7 @@ def run_rollout_eval(
                 "kind": k,
             },
         )
-        current[i] = (s, k, float(info.get("throughput", 0.0)))
+        current[i] = (s, k, float(info.get("thput_normed", 0.0)))
         obs_stack.append(obs)
 
     obs_batch = torch.as_tensor(np.stack(obs_stack), dtype=torch.float32, device=device)
@@ -603,7 +605,7 @@ def run_rollout_eval(
                     "misc": int(misc_K[i]),
                 }
                 next_obs, _r, terminated, truncated, info = envs[i].step(action)
-                current[i] = (s, k, float(info.get("throughput", 0.0)))
+                current[i] = (s, k, float(info.get("thput_normed", 0.0)))
                 if not (terminated or truncated):
                     obs_batch[i] = torch.as_tensor(
                         next_obs,
@@ -632,7 +634,7 @@ def run_rollout_eval(
                             "kind": k,
                         },
                     )
-                    current[i] = (s, k, float(info.get("throughput", 0.0)))
+                    current[i] = (s, k, float(info.get("thput_normed", 0.0)))
                     eot_fired[i] = False
                     eot_thp[i] = 0.0
                     obs_batch[i] = torch.as_tensor(

--- a/tests/test_early_termination.py
+++ b/tests/test_early_termination.py
@@ -45,7 +45,9 @@ class TestEarlyTermination:
 
         assert terminated is True, f"Expected terminated=True, got {terminated}"
         assert truncated is False, f"Expected truncated=False, got {truncated}"
-        assert info["throughput"] >= 1.0
+        # A fully-solved factory reaches its per-factory max → normed == 1.0
+        # (regardless of the factory's absolute belt speed).
+        assert info["thput_normed"] >= 1.0
 
     def test_truncation_without_solving(self):
         """With many missing entities the factory can't be solved by no-ops.
@@ -66,7 +68,7 @@ class TestEarlyTermination:
 
         assert truncated is True, f"Expected truncated=True, got {truncated}"
         assert terminated is False, f"Expected terminated=False, got {terminated}"
-        assert info["throughput"] < 1.0
+        assert info["thput_normed"] < 1.0
 
     def test_terminated_and_truncated_are_mutually_exclusive(self):
         """terminated and truncated should never both be True."""

--- a/tests/test_throughput_normalization.py
+++ b/tests/test_throughput_normalization.py
@@ -1,0 +1,157 @@
+"""Throughput is normalized by each factory's own max, not a fixed 15.
+
+The env used to divide raw throughput by a hardcoded 15.0. That only made
+sense for the simplest belt factory (max == 15 items/s). Lessons like
+ASSEMBLE_1IN_1OUT have a max throughput far below 15 (~0.86 items/s, recipe
+rate-limited), so a *perfectly* built factory scored ~0.057 under the old
+scheme — and, because termination required normalized throughput to reach
+1.0, such a factory could never terminate.
+
+Now the env reports two values in `info`:
+
+- ``thput_raw``   — raw items/second (reference-free; what RL optimizes).
+- ``thput_normed``— ``thput_raw / per_factory_max`` clamped to [0, 1], so a
+  perfectly-rebuilt factory scores exactly 1.0 regardless of absolute speed.
+
+See GH issue #161 for why the per-factory max (which needs the scripted
+solution) is fine now but must change for arbitrary RL rollouts.
+"""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+import torch
+
+os.environ["WANDB_MODE"] = "disabled"
+os.environ["WANDB_DISABLED"] = "true"
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import factorion_rs  # noqa: E402
+from factorion import LessonKind, build_factory  # noqa: E402
+from ppo import FactorioEnv  # noqa: E402
+
+
+def _noop_action():
+    """Place ``empty`` at (0,0) — a no-op on tiles that are already empty."""
+    return {
+        "xy": np.array([0, 0]),
+        "entity": 0,
+        "direction": 0,
+        "item": 0,
+        "misc": 0,
+    }
+
+
+def _solved_max(size, kind, seed):
+    """Raw items/s of the complete, correct factory for (size, kind, seed)."""
+    factory = build_factory(size=size, kind=kind, seed=seed)
+    assert factory is not None
+    tp, _ = factorion_rs.simulate_throughput(
+        factory.world_CWH.permute(1, 2, 0).to(torch.int64).numpy()
+    )
+    return float(tp)
+
+
+# A factory whose max throughput is FAR below 15 (recipe rate-limited). Chosen
+# deterministically; (0,0) is empty in its solved layout so the noop is safe.
+SUB15_KIND = LessonKind.ASSEMBLE_1IN_1OUT
+SUB15_SIZE = 7
+SUB15_SEED = 0
+
+
+def test_sub15_factory_max_is_well_below_15():
+    """Guard the premise: this lesson's perfect throughput is nowhere near 15."""
+    mx = _solved_max(SUB15_SIZE, SUB15_KIND, SUB15_SEED)
+    assert 0.0 < mx < 1.0, f"expected a sub-15 max, got {mx}"
+
+
+def test_solved_sub15_factory_scores_one_not_a_fraction():
+    """A perfectly-built sub-15 factory scores 1.0 — the headline fix.
+
+    Under the old fixed /15.0 it would have scored max/15 (~0.057) and could
+    never terminate.
+    """
+    env = FactorioEnv(size=SUB15_SIZE, idx=0)
+    env.reset(
+        seed=SUB15_SEED,
+        options={"num_missing_entities": 0, "kind": SUB15_KIND},
+    )
+    _, _, terminated, truncated, info = env.step(_noop_action())
+
+    mx = _solved_max(SUB15_SIZE, SUB15_KIND, SUB15_SEED)
+
+    assert info["thput_normed"] == pytest.approx(1.0)
+    assert terminated is True
+    assert truncated is False
+    # The old scheme would have produced this fraction instead of 1.0.
+    assert mx / 15.0 < 0.1
+    assert info["thput_normed"] != pytest.approx(mx / 15.0)
+
+
+def test_thput_raw_is_items_per_second():
+    """thput_raw is the unnormalized rate, equal to the solved factory's max."""
+    env = FactorioEnv(size=SUB15_SIZE, idx=0)
+    env.reset(
+        seed=SUB15_SEED,
+        options={"num_missing_entities": 0, "kind": SUB15_KIND},
+    )
+    _, _, _, _, info = env.step(_noop_action())
+
+    mx = _solved_max(SUB15_SIZE, SUB15_KIND, SUB15_SEED)
+    # Raw is in items/s (well below 1.0 here), NOT divided by 15.
+    assert info["thput_raw"] == pytest.approx(mx)
+    assert info["thput_normed"] == pytest.approx(info["thput_raw"] / mx)
+
+
+def test_info_exposes_new_keys_only():
+    """The env exposes thput_raw + thput_normed and no longer a 'throughput' key."""
+    env = FactorioEnv(size=SUB15_SIZE, idx=0)
+    _, reset_info = env.reset(
+        seed=SUB15_SEED,
+        options={"num_missing_entities": 0, "kind": SUB15_KIND},
+    )
+    assert "thput_raw" in reset_info and "thput_normed" in reset_info
+    assert "throughput" not in reset_info
+
+    _, _, _, _, step_info = env.step(_noop_action())
+    assert "thput_raw" in step_info and "thput_normed" in step_info
+    assert "throughput" not in step_info
+
+
+def test_blanked_factory_scores_below_one():
+    """A heavily-blanked factory (nothing rebuilt) scores < 1.0 and >= 0."""
+    env = FactorioEnv(size=SUB15_SIZE, idx=0)
+    env.reset(
+        seed=SUB15_SEED,
+        options={"num_missing_entities": 99, "kind": SUB15_KIND},
+    )
+    _, _, terminated, _, info = env.step(_noop_action())
+    assert 0.0 <= info["thput_normed"] < 1.0
+    assert terminated is False
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        LessonKind.MOVE_ONE_ITEM,
+        LessonKind.ASSEMBLE_1IN_1OUT,
+        LessonKind.ASSEMBLE_2IN_1OUT,
+    ],
+)
+def test_normed_stays_in_unit_interval(kind):
+    """thput_normed is always in [0, 1] regardless of the factory's abs speed."""
+    size = 7
+    for seed in range(6):
+        if build_factory(size=size, kind=kind, seed=seed) is None:
+            continue
+        env = FactorioEnv(size=size, idx=0)
+        env.reset(
+            seed=seed,
+            options={"num_missing_entities": 0, "kind": kind},
+        )
+        _, _, _, _, info = env.step(_noop_action())
+        assert 0.0 <= info["thput_normed"] <= 1.0
+        assert info["thput_raw"] >= 0.0


### PR DESCRIPTION
## Problem

The env divided raw throughput by a hardcoded `15.0`, which only made sense for the simplest single-belt factory (max 15 items/s). Recipe-limited lessons have far lower maxima — e.g. `ASSEMBLE_1IN_1OUT` tops out around **0.86 items/s** — so a *perfectly built* factory of that kind scored ~**0.057** instead of 1.0. Per-lesson `val/throughput` was effectively unreadable across lesson kinds.

## Fix

Normalize each factory's throughput by **its own maximum**, computed once in `reset()` from the known-correct solved factory (`simulate_throughput(self._solved_world_CWH)`). `step()` now reports two values in `info`:

- **`thput_raw`** — raw items/second (reference-free).
- **`thput_normed`** — `raw / per_factory_max`, clamped to `[0, 1]`, so a perfectly-rebuilt factory scores **1.0** regardless of its absolute belt/craft speed.

Consumers:
- **SFT** `val/throughput` (and per-lesson `val/<KIND>/throughput`) now read `thput_normed` — directly comparable across lesson kinds.
- **PPO** reward/termination consume `thput_normed` (same structure as before, just fed the correctly-normalized value instead of `raw/15`); PPO additionally logs `episode/thput_raw`.

## Scope

This PR is **only** the normalization layer. It deliberately does **not** touch the termination/EOT/reward redesign — that lives on `rl-from-chkpt`. When that branch rebases on top of this, the integration is small: its terminal reward `scale × throughput` and its SFT rollout `info["throughput"]` should read `thput_normed`.

## Forward-looking (#161)

`thput_normed` depends on having the scripted solution to compute the per-factory max. That's fine while every episode is a scripted lesson, but arbitrary RL rollouts won't have a reference factory — tracked in #161, with `FIXME(#161)` markers at each max-dependent site (including the dead `eval_model`'s leftover `/15`).

## Verification

Full checklist green: `cargo fmt`, `cargo test --no-default-features` (50), `maturin develop`, `pytest` (3434 passed, 77 skipped), `ruff`, `ty check .`, PPO + SFT smoke. New `tests/test_throughput_normalization.py` proves a sub-15-max factory scores 1.0 when solved (and still holds against the #165 sink-counts-item engine change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)