### PR TITLE
fix #87: split fan-out flow evenly among all successors

### DIFF
--- a/factorion_rs/src/throughput.rs
+++ b/factorion_rs/src/throughput.rs
@@ -157,13 +157,19 @@ pub fn calc_throughput(graph: &FactoryGraph) -> (Vec<SinkDelivery>, usize) {
                 node_outputs[node_idx] = entity.transform_flow(&accumulated_input);
             }
 
-            // For splitters, divide output evenly among successors
-            if entity_kind == Item::Splitter {
-                let num_successors = graph.successors[node_idx].len();
-                if num_successors > 1 {
-                    for rate in node_outputs[node_idx].values_mut() {
-                        *rate /= num_successors as f64;
-                    }
+            // A node hands its contents to its successors, so fanning out to
+            // k successors splits the flow k ways (each branch gets 1/k).
+            // Without this, every successor reads the node's *full* output and
+            // the same items are counted once per branch — the #87 fan-out
+            // double-count. Splitters are just the most visible case; a belt
+            // feeding two inserters splits exactly the same way. Sources are
+            // intentionally excluded: their output is pre-set to an infinite
+            // supply (so `is_empty()` skips this block) and feeds every branch
+            // fully, dividing INFINITY changes nothing downstream anyway.
+            let num_successors = graph.successors[node_idx].len();
+            if num_successors > 1 {
+                for rate in node_outputs[node_idx].values_mut() {
+                    *rate /= num_successors as f64;
                 }
             }
         }

--- a/factorion_rs/tests/factories/fanout_87.yaml
+++ b/factorion_rs/tests/factories/fanout_87.yaml
@@ -1,0 +1,20 @@
+description: |
+  Regression for #87 (fan-out double-counts throughput). A source is bottlenecked
+  to 0.86 i/s by one inserter, feeding belt B. B then fans out to two inserters
+  (one above, one below). B only has 0.86 to give, so the two inserters should
+  SPLIT it (0.43 each → each sink gets 0.43). The bug copies B's full 0.86 to
+  every successor, so each inserter pulls 0.86 and each sink wrongly gets 0.86
+  (1.72 total).
+items:
+- { x: 0, y: 2, item: copper_cable }
+- { x: 2, y: 0, item: copper_cable }
+- { x: 2, y: 4, item: copper_cable }
+throughput:
+- { item: copper_cable, per_second: 0.43 }
+- { item: copper_cable, per_second: 0.43 }
+factory: |
+  .. .. K^
+  .. .. i^
+  S> i> b>
+  .. .. iv
+  .. .. Kv


### PR DESCRIPTION
## Problem

The throughput engine (`calc_throughput` in `factorion_rs/src/throughput.rs`) only divided a node's output among its successors **for splitters**. Every other node — including a belt fanning out to two inserters — handed its *full* output to **each** successor, so the same flow was counted once per branch (issue #87).

Concretely: a source bottlenecked to `0.86` i/s feeds a belt `B`; `B` fans out to two inserter→sink branches. `B` only has `0.86` to give, so each branch should get `0.43`. The bug instead reported `0.86` at *each* of the two sinks (`1.72` total).

## Fix

Generalise the even-split to **every** computed node: a node with `k` successors gives each branch `1/k` of its flow. The previous splitter handling is now just an instance of this general rule.

Sources are correctly left exempt — their output is pre-set to an infinite supply, so the `is_empty()` guard skips this block and each branch is fed fully (an infinite source genuinely feeds every successor; dividing `INFINITY` changes nothing downstream).

## Regression test

Adds `factorion_rs/tests/factories/fanout_87.yaml`, picked up by the `test_all_yamls_in_factories_dir` directory sweep:

```
.. .. K^
.. .. i^
S> i> b>
.. .. iv
.. .. Kv
```

A source bottlenecked to `0.86` by one inserter, feeding a belt that fans out to two inserter→sink branches; each sink must receive `0.43`. Fails before the fix, passes after.

## Verification

Full pre-completion checklist passes: `cargo fmt --check`, `cargo clippy` (no-default-features), Rust tests (92 passed), `maturin develop --release`, Python tests (3446 passed / 77 skipped), `ruff check`, `ty check`, and the PPO + SFT smoke tests.

All existing splitter tests still pass — they're now covered by the generalised rule rather than a special case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)