### PR TITLE
fix: blank_entities(inf) actually fully blanks the factory

### DIFF
--- a/factorion.py
+++ b/factorion.py
@@ -1254,7 +1254,7 @@ def build_graph_nx(world_WHC):
 
 
 def _remove_entities(
-    world_CWH, num_missing_entities, total_entities, protected_positions=None
+    world_CWH, num_missing_entities, protected_positions=None
 ):
     """Remove entities from a completed lesson, respecting multi-tile units.
 
@@ -1275,12 +1275,10 @@ def _remove_entities(
 
     Returns min_entities_required (number of entity units removed).
     For multi-tile entities (e.g. splitters), all tiles are removed together
-    as a single unit.
+    as a single unit. ``num_missing_entities=inf`` removes every removable
+    unit (a full blank down to the protected source/sink).
     """
     protected_positions = protected_positions or set()
-
-    if num_missing_entities == float("inf"):
-        return total_entities
 
     C, W, H = world_CWH.shape
     skip = {str2ent("source").value, str2ent("sink").value, str2ent("empty").value}
@@ -2739,7 +2737,6 @@ def blank_entities(
     min_entities_required = _remove_entities(
         partial,
         num_missing_entities,
-        factory.total_entities,
         protected_positions=set(factory.protected_positions),
     )
     return partial, min_entities_required

--- a/tests/test_lesson_generation.py
+++ b/tests/test_lesson_generation.py
@@ -1060,9 +1060,9 @@ class TestAssemble1In1OutMissingEntities:
     def test_assembler_can_be_removed(self):
         """With a generous num_missing, the assembler must occasionally be
         blanked — otherwise the item head never sees a non-zero recipe
-        target during SFT (see issue #107). `inf` short-circuits removal
-        in _remove_entities, so we use a large finite value matching the
-        SFT default (max_level = size*size)."""
+        target during SFT (see issue #107). We use a finite value (not `inf`,
+        which removes everything every time) so removal stays probabilistic
+        and we can assert it happens at least sometimes."""
         removed_count = 0
         for seed in range(60):
             factory = build_factory(
@@ -1830,8 +1830,11 @@ class TestMoveViaUgBeltMissingEntities:
         were blanked)."""
         factory = build_factory(size=8, kind=LessonKind.MOVE_VIA_UG_BELT, seed=seed)
         assert factory is not None
+        # Read the wall from the solved layout: a full blank removes the UG
+        # belts, so the wall can't be inferred from the blanked world's
+        # entities. Blanking never touches FOOTPRINT, so the wall must survive.
+        info = _ug_layout_info(factory.world_CWH)
         world, _ = blank_entities(factory, num_missing_entities=float("inf"))
-        info = _ug_layout_info(world)
         # The wall spans full perpendicular; any non-wall tile must be
         # AVAILABLE (already covered by other tests for num_missing=0;
         # here we just re-assert it survives blanking).
@@ -2358,4 +2361,55 @@ class TestAssemble2In1OutRecipeSelection:
         assert len(seen_names) >= expected_distinct, (
             f"Expected ≥ {expected_distinct} distinct recipes across 200 "
             f"seeds, only saw {len(seen_names)}: {seen_names}"
+        )
+
+
+class TestFullBlankActuallyEmptiesWorld:
+    """Regression for the `num_missing_entities=inf` early-return bug.
+
+    `_remove_entities` used to short-circuit on `inf` and return the entity
+    count WITHOUT mutating the world tensor, so a "full blank" handed back the
+    fully-built factory. The PPO env always resets with `inf`, so every episode
+    started from a complete factory: the agent learned to declare end-of-turn on
+    step 1 and bank throughput 1.0 for building nothing. A full blank must
+    actually empty the grid down to the protected source/sink.
+    """
+
+    @pytest.mark.parametrize("seed", range(8))
+    def test_inf_blank_removes_entities_and_kills_throughput(self, seed):
+        f = build_factory(size=11, kind=LessonKind.MOVE_ONE_ITEM, seed=seed)
+        assert f is not None
+        solved_ents = int(f.world_CWH[Channel.ENTITIES.value].count_nonzero())
+        max_tp, _ = rs_throughput(f.world_CWH.permute(1, 2, 0))
+        assert max_tp > 0  # a real factory to blank
+
+        partial, removed = blank_entities(f, num_missing_entities=float("inf"))
+        partial_ents = int(partial[Channel.ENTITIES.value].count_nonzero())
+        partial_tp, _ = rs_throughput(partial.permute(1, 2, 0))
+
+        # The world must actually shrink — the bug left it == solved_ents.
+        assert partial_ents < solved_ents, (
+            f"seed={seed}: inf blank left the world unchanged "
+            f"({partial_ents} entities, solved had {solved_ents})"
+        )
+        assert removed > 0
+        # MOVE_ONE_ITEM has only the source + sink protected, so a full blank
+        # strips the whole belt path and throughput collapses to zero.
+        assert partial_ents == 2  # source + sink remain
+        assert partial_tp == 0.0, (
+            f"seed={seed}: fully-blanked factory still carries throughput "
+            f"{partial_tp} — the agent would have nothing to build"
+        )
+
+    @pytest.mark.parametrize("seed", range(8))
+    def test_inf_blank_matches_size_squared_blank(self, seed):
+        """`inf` should be equivalent to a finite blank ≥ the entity count
+        (what the SFT pipeline passes as `size*size`)."""
+        f = build_factory(size=11, kind=LessonKind.MOVE_ONE_ITEM, seed=seed)
+        assert f is not None
+        inf_world, inf_removed = blank_entities(f, num_missing_entities=float("inf"))
+        fin_world, fin_removed = blank_entities(f, num_missing_entities=11 * 11)
+        assert inf_removed == fin_removed
+        assert int(inf_world[Channel.ENTITIES.value].count_nonzero()) == int(
+            fin_world[Channel.ENTITIES.value].count_nonzero()
         )


### PR DESCRIPTION
## Problem

PPO-from-SFT run [`8zqsz82i`](https://wandb.ai/beyarkay/factorion/runs/8zqsz82i) showed `curriculum/throughput_avg = 1.0` with `episode/length = 1` — the agent appeared to "solve" every fully-blanked factory in a single step. It wasn't learning; the factory was never actually blanked.

`_remove_entities` short-circuited on `num_missing_entities == inf`:

```python
if num_missing_entities == float("inf"):
    return total_entities      # returns the count, never mutates world_CWH
```

It returned the *count* of entities it would remove but **never mutated the world tensor**. The PPO env always resets with `inf`, so every episode started from the **fully-built** factory. The optimal policy: declare end-of-turn on step 1 and bank `thput_normed = 1.0` for building nothing.

### Why it was dormant
- RL historically ran a finite **curriculum** (`max_missing_entities`), so `inf` was never on the training path.
- **PR #166** switched the env to full-blank (`inf`) episodes — surfacing the no-op.
- SFT always dodged it by passing a finite `size*size`; the existing lesson tests only asserted the removal *count*, never that the tensor actually emptied (e.g. `assert asm_count in (0, 9)` passes when the assembler is never removed).

## Fix

Drop the early-return so `inf` flows through the normal loop (`num_samples = min(inf, len(groups))` = all removable units). Remove the now-dead `total_entities` param from `_remove_entities`.

## Verification

- **New `TestFullBlankActuallyEmptiesWorld`** (confirmed to fail before the fix): a full blank strips the world down to the protected source/sink and collapses throughput to 0, and `inf` matches a `size*size` blank.
- **Env level:** `reset(num_missing_entities=inf)` now yields 2 entities (source+sink); an immediate EOT scores `thput_normed=0.0, reward=-0.010` instead of 1.0.
- Updated the UG-belt wall test to read its layout from the solved world (a real full blank removes the UG belts it used to infer the wall from).
- Full suite: 3151 passed, ruff + ty clean.

## Follow-up (not in this PR)
The legacy curriculum scaffolding (`start_curriculum_level`, `max_missing_entities`, `curriculum/level`, `curriculum/score`) is now vestigial — separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
