### PR TITLE
chore: remove comment churn (stale/redundant comments + LLM scratch work)

### DIFF
--- a/factorion.py
+++ b/factorion.py
@@ -260,7 +260,6 @@ def item_str2b64img(item, base_path="factorio-icons"):
 
 def new_world(width=8, height=8):
     channels = len(Channel)
-    #     print(f"Making world w={width}, h={height}, c={channels}")
     world = np.zeros((width, height, channels), dtype=int)
     world[:, :, Channel.ENTITIES.value] = str2ent("empty").value
     world[:, :, Channel.DIRECTION.value] = Direction.NONE.value
@@ -292,8 +291,6 @@ def add_entity(
 
     world[x, y, Channel.ENTITIES.value] = proto.value
     world[x, y, Channel.DIRECTION.value] = direction.value
-    # world[x, y, Channel.ITEMS.value] = recipe_proto.value
-    # world[x, y, Channel.MISC.value] = misc.value
 
 
 def world2html(world_WHC, highlights=None):
@@ -317,9 +314,6 @@ def world2html(world_WHC, highlights=None):
         Direction.EAST.value: "→",
         Direction.SOUTH.value: "↓",
         Direction.WEST.value: "←",
-        # 0: "↘",
-        # 10: "↙",
-        # 14: "↖",
     }
     html = ["<table style='border-collapse: collapse;'>"]
     W, H, C = world_WHC.shape
@@ -405,7 +399,6 @@ def world2html(world_WHC, highlights=None):
                 else ""
             )
 
-            #             print(direction_arrow, direction)
             available = (
                 world_WHC[x, y, Channel.FOOTPRINT.value]
                 == Footprint.AVAILABLE.value
@@ -427,7 +420,6 @@ def world2html(world_WHC, highlights=None):
                 )
             else:
                 bg_style = ""
-            #             tint_style = "filter: brightness(1.5) sepia(1) hue-rotate(30deg);" if available else ""
 
             ghost_imgs = "\n".join(
                 [
@@ -948,10 +940,6 @@ def plot_flow_network(G):
         font_weight="bold",
     )
 
-    # Add throughput labels
-    #     labels = {node: G.nodes[node].get("throughput", {}) for node in G.nodes}
-    #     nx.draw_networkx_labels(G, pos, labels=labels, font_color="red")
-
     plt.show()
 
 
@@ -1040,19 +1028,8 @@ def normalise_world(world_T, og_world):
         empty_entity_value
     )
 
-    # # Ensure belts don't have recipes
-    # belt_entity_value = str2ent('transport_belt').value
-    # belt_entities = (world_T[:, :, Channel.ENTITIES.value] == belt_entity_value)
-    # world_T[:, :, Channel.ITEMS.value][belt_entities] = empty_entity_value
-
-    # # Ensure all empty entities have no recipe, no direction
-    # no_entity = (world_T[:, :, Channel.ENTITIES.value] == empty_entity_value)
-    # world_T[:, :, Channel.ITEMS.value][no_entity] = empty_entity_value
-    # world_T[:, :, Channel.DIRECTION.value][no_entity] = Direction.NONE.value
-
     # Ensure the model can't just overwrite existing factories with a simpler thing.
     tworld = og_world.clone().detach().to(torch.int64)
-    # tworld = torch.tensor(og_world, dtype=torch.int64)
     original_had_something = (
         tworld[:, :, Channel.ENTITIES.value] != empty_entity_value
     )
@@ -1140,9 +1117,6 @@ def get_new_world(seed, n=6, min_belts=None, source_item=None, sink_item=None):
         w[sink[0], sink[1], Channel.ENTITIES.value] = empty_value
     assert limit > 0, "Infinite loop blocked"
 
-    # Add the source + sink to the world
-    # w[source[0], source[1], Channel.ITEMS.value] = str2ent('electronic_circuit').value
-    # w[sink[0], sink[1], Channel.ITEMS.value] = str2ent('electronic_circuit').value
     if source_item is not None:
         w[source[0], source[1], Channel.ITEMS.value] = source_item
     if sink_item is not None:
@@ -1196,9 +1170,7 @@ def eval_model(actor, critic, pars, num_evaluations=1_000, pbar=False):
         normalised_world = normalise_world(
             sample_world(probabilities), original_world
         )
-        # value = critic(normalised_world)
         value = critic(normalised_world.to(torch.float))
-        # Maybe having throughput being calculated as a black box is the problem?
         # FIXME(#161): still the old fixed /15.0 normalization. This is the
         # legacy RL-from-scratch eval (no current callers) and its random
         # get_new_world() inputs have no reference factory to normalize by, so
@@ -1388,9 +1360,7 @@ def build_factory(
         # Choose a random source/sink
         original_count = max(500, size * size * 4)
         count = original_count
-        # print(f'count is {count}')
         while count > 0:
-            # print(f"{count} attmempting to place source/sink")
             count -= 1
             pos1 = torch.randint(0, H * W, (1,))
             pos2 = torch.randint(0, H * W, (1,))
@@ -1432,18 +1402,13 @@ def build_factory(
             world_CWH[Channel.DIRECTION.value, sink_WH[0], sink_WH[1]] = (
                 sink_dir.value
             )
-            # print(world_CWH)
-            # print(f"world so far: ")
-            # print(world_CWH[0])
 
             paths = find_belt_paths_with_source_sink_orient(
                 entities=world_CWH[Channel.ENTITIES.value],
                 directions=world_CWH[Channel.DIRECTION.value],
             )
             # Remove all paths that would require placing too many entities
-            # print('found paths', len(paths))
             paths = list(filter(lambda p: len(p) <= max_entities, paths))
-            # print('filtered paths', len(paths))
 
             if len(paths) == 0:
                 world_CWH = torch.tensor(

--- a/factorion_rs/src/entities.rs
+++ b/factorion_rs/src/entities.rs
@@ -211,10 +211,8 @@ impl FactoryEntity for AssemblingMachine {
                     || (other_dir == Direction::East && ddx > 0);
 
                 if assembler_outputs_to_entity {
-                    // Assembler → entity (entity takes from assembler)
                     edges.push((self_id.clone(), other_id));
                 } else {
-                    // Entity → Assembler (entity feeds into assembler)
                     edges.push((other_id, self_id.clone()));
                 }
             }
@@ -496,7 +494,6 @@ fn inserter_connections(
         let dx_u = dst_x as usize;
         let dy_u = dst_y as usize;
         if let Some(dst_entity) = world.entity_at(dx_u, dy_u) {
-            // Can only insert into belts or assembling machines
             let dst_is_insertable = matches!(
                 dst_entity,
                 Item::TransportBelt
@@ -887,21 +884,6 @@ mod tests {
         let edges = asm.connections((1, 1), Direction::None, &w);
 
         assert_eq!(edges.len(), 2);
-        // Inserter at (0,1) facing east, ddx=-1 → the inserter is to the left.
-        // other_d == East, ddx < 0 → matches condition for "assembler → inserter" (output).
-        // Wait, let me re-check: ddx = 0 - 1 = -1, ddy = 1 - 1 = 0.
-        // Condition: other_d == EAST and ddx > 0 → ddx = -1, not > 0 → NOT inserting into.
-        // other_d == WEST and ddx < 0 → East != West → not this.
-        // Actually let me re-derive from the assembler→inserter rule: when
-        //   (other_d == North and ddy < 0)
-        //     or (other_d == South and ddy > 0)
-        //     or (other_d == West and ddx < 0)
-        //     or (other_d == East and ddx > 0)
-        // the edge is assembler → inserter (the assembler outputs to it);
-        // otherwise it is inserter → assembler.
-        // So when inserter direction matches the offset direction from assembler → assembler outputs to inserter.
-        // For inserter at (0,1): ddx = -1, ddy = 0, dir = East. East and ddx > 0? No. So it's other → self = inserter → assembler.
-        // For inserter at (4,2): ddx = 3, ddy = 1, dir = East. East and ddx > 0? Yes. So it's self → other = assembler → inserter.
     }
 
     #[test]

--- a/factorion_rs/src/graph.rs
+++ b/factorion_rs/src/graph.rs
@@ -434,11 +434,6 @@ mod tests {
             .unwrap();
         assert!(g.successors[ug_down].contains(&ug_up));
 
-        // Belt(0,0) should NOT connect to underground_down (belt doesn't connect to
-        // underground_down because its src_is_beltish check excludes underground_down)
-        // Actually wait: Belt at (0,0) facing east, underground at (1,0) is ahead.
-        // The belt's connections check dst: is it a belt? UndergroundBelt is belt-ish → dst_is_belt = true.
-        // Not opposing direction → should connect.
         let belt0 = g
             .get_index(&NodeId::new(Item::TransportBelt, 0, 0))
             .unwrap();

--- a/factorion_rs/src/throughput.rs
+++ b/factorion_rs/src/throughput.rs
@@ -78,7 +78,6 @@ pub fn calc_throughput(graph: &FactoryGraph) -> (Vec<SinkDelivery>, usize) {
         return (Vec::new(), 0);
     }
 
-    // Identify sources and sinks
     let sources: Vec<usize> = (0..graph.node_count())
         .filter(|&i| graph.nodes[i].entity_kind == Item::Source)
         .collect();
@@ -110,13 +109,11 @@ pub fn calc_throughput(graph: &FactoryGraph) -> (Vec<SinkDelivery>, usize) {
     let mut queue: VecDeque<usize> = VecDeque::new();
     let mut in_queue: HashSet<usize> = HashSet::new();
 
-    // Initialize: enqueue all sources (in-degree 0 among reachable nodes)
     for &s in &sources {
         queue.push_back(s);
         in_queue.insert(s);
     }
 
-    // Clone the graph's nodes into a mutable working copy
     let mut node_inputs: Vec<HashMap<Item, f64>> =
         graph.nodes.iter().map(|n| n.input.clone()).collect();
     let mut node_outputs: Vec<HashMap<Item, f64>> =

--- a/factorion_rs/src/world.rs
+++ b/factorion_rs/src/world.rs
@@ -218,7 +218,6 @@ mod tests {
     use super::*;
 
     fn make_3x3_world() -> World {
-        // 3x3 world, NUM_CHANNELS channels, all zeros
         World::empty(3, 3)
     }
 
@@ -252,7 +251,6 @@ mod tests {
         assert_eq!(w.direction_at(1, 2), Direction::East);
         assert_eq!(w.item_at(1, 2), Some(Item::CopperCable));
 
-        // Other cells still empty
         assert_eq!(w.entity_at(0, 0), None);
     }
 
@@ -271,7 +269,6 @@ mod tests {
     fn test_set_entity_types() {
         let mut w = World::empty(5, 5);
 
-        // Place a source at (0,0) facing east
         w.place(
             0,
             0,
@@ -280,10 +277,8 @@ mod tests {
             Some(Item::ElectronicCircuit),
         );
 
-        // Place a belt at (1,0) facing east — no item carried
         w.place(1, 0, Item::TransportBelt, Direction::East, None);
 
-        // Place a sink at (2,0) facing east
         w.place(
             2,
             0,

--- a/ppo.py
+++ b/ppo.py
@@ -38,7 +38,6 @@ from factorion import (
 )
 from PIL import Image, ImageDraw, ImageFont
 
-# episodic_returns = deque(maxlen=100)
 moving_average_length = 500
 end_of_episode_thputs = deque(maxlen=moving_average_length)
 for _ in range(moving_average_length):
@@ -253,11 +252,9 @@ def make_env(env_id, idx, capture_video, size, run_name, throughput_reward_scale
         kwargs.update({'size': size, 'max_steps': size*size, 'idx': idx,
                        'throughput_reward_scale': throughput_reward_scale,
                        'step_penalty': step_penalty})
-        # kwargs.update({'size': size, 'max_steps': 6})
         env = gym.make(env_id, **kwargs)
         if capture_video:
             env = gym.wrappers.RecordVideo(env, f"videos/{run_name}/env_{idx}", episode_trigger=lambda e: (e+1) % 10 == 0)
-            # env = gym.wrappers.RecordVideo(env, f"videos/{run_name}/env_{idx}", episode_trigger=lambda _: True)
         env = gym.wrappers.RecordEpisodeStatistics(env)
         return env
     return thunk
@@ -289,11 +286,8 @@ def get_pretty_format(tensor, entity_dir_map):
     assert isinstance(tensor, torch.Tensor), f"Input must be a torch tensor but is {tensor}"
     assert tensor.ndim == 3 and tensor.shape[0] >= 2, f"Tensor must have shape (2+, W, H) but has shape {tensor.shape}"
     assert tensor.shape[1] == tensor.shape[2], f"Expected world to be square, but is of shape {tensor.shape}"
-    # assert torch.is_integral(tensor), "Tensor must contain integers"
 
     _, W, H = tensor.shape
-    # entities = tensor[Channel.ENTITIES.value]
-    # directions = tensor[Channel.DIRECTION.value]
     entities = tensor[0]
     directions = tensor[1]
 
@@ -377,7 +371,6 @@ class FactorioEnv(gym.Env):
 
     def _get_info(self):
         return {
-            # 'num_missing_entities': self.num_missing_entities,
             # thput_raw: raw items/second (reference-free). thput_normed:
             # raw / per-factory max, clamped to [0, 1] (1.0 == reproduced the
             # reference factory's throughput). See FIXME(#161) in step().
@@ -495,7 +488,6 @@ class FactorioEnv(gym.Env):
         return self._world_CWH.cpu().numpy(), self._get_info()
 
     def step(self, action):
-        # print(f"Stepping env with action {action}")
         x, y = action["xy"]
         entity_id = action["entity"]
         direc = action["direction"]
@@ -503,7 +495,6 @@ class FactorioEnv(gym.Env):
         misc = action["misc"]
 
 
-        # (x, y), entity_id, direc = action
         assert 0 <= x < self._world_CWH.shape[1], f"x={x} out of bounds [0, {self._world_CWH.shape[1]})"
         assert 0 <= y < self._world_CWH.shape[2], f"y={y} out of bounds [0, {self._world_CWH.shape[2]})"
         source_id = self._source_id
@@ -529,10 +520,8 @@ class FactorioEnv(gym.Env):
 
         # Check that the action is actually valid
         if not (0 <= entity_id < len(entities)):
-            # entity_id out of range
             action_is_invalid = True
         elif not (0 <= direc < len(Direction)):
-            # direction out of range
             action_is_invalid = True
         elif entity_id in (source_id, sink_id):
             # agent tried to place a source or sink
@@ -1114,7 +1103,6 @@ if __name__ == "__main__":
     args.batch_size = int(args.num_envs * args.num_steps)
     args.minibatch_size = int(args.batch_size // args.num_minibatches)
     args.num_iterations = args.total_timesteps // args.batch_size
-    # 16 * 256 * (50000/(16*256))
     num_gsteps = args.num_envs * args.num_steps * args.num_iterations
     print(f"batch_size: {args.batch_size}, minibatch_size: {args.minibatch_size}, num_iterations: {args.num_iterations}, num_gsteps: {num_gsteps}")
 
@@ -1191,7 +1179,6 @@ if __name__ == "__main__":
     print(f"running on {device}")
 
     print(f"Setting up envs with {args}")
-    # env setup
     envs = gym.vector.SyncVectorEnv(
         [make_env(args.env_id, i, args.capture_video, args.size, run_name, args.throughput_reward_scale, args.step_penalty) for i in range(args.num_envs)],
     )
@@ -1315,7 +1302,6 @@ if __name__ == "__main__":
     print(f"Starting {args.num_iterations} iterations")
     pbar = tqdm.trange(1, args.num_iterations + 1)
     for iteration in pbar:
-        # print(f"{iteration=}")
         # Critic warm-up: the actor stays frozen for the first
         # critic_warmup iterations (only the value head trains), then we
         # unfreeze once and run normal PPO from there.
@@ -1354,11 +1340,8 @@ if __name__ == "__main__":
                 # D for dictionary
                 action_ED, logprobs_E, _entropy_E, value_E = agent.get_action_and_value(next_obs_ECWH)
                 values_SE[step] = value_E
-                # Flatten action
-                # (xy_B2, direc_B1, entities_B1) = action_ED
 
-                # Unpack the action
-                x_B, y_B = action_ED["xy"].unbind(dim=1)  # Unbind xy into x and y
+                x_B, y_B = action_ED["xy"].unbind(dim=1)
                 ent_B = action_ED["entity"]
                 dir_B = action_ED["direction"]
                 item_B = action_ED["item"]
@@ -1410,11 +1393,6 @@ if __name__ == "__main__":
                     end_of_episode_thput = infos["thput_normed"][i]
                     end_of_episode_thput_raw = infos["thput_raw"][i]
                     final_frac_reachable = infos["frac_reachable"][i]
-                    # final_frac_hallucin = infos["frac_hallucin"][i]
-
-                    # episodic_returns.append(episode_return)
-                    # avg_return = sum(episodic_returns) / len(episodic_returns)
-                    # writer.add_scalar("old/charts/episodic_return_ma", avg_return, global_step)
 
                     end_of_episode_thputs.append(end_of_episode_thput)
 
@@ -1464,7 +1442,6 @@ if __name__ == "__main__":
                 advantages_SE[t] = lastgaelam
             returns_SE = advantages_SE + values_SE
 
-        # flatten the batch
         obs_B = obs_SECWH.reshape((-1,) + obs_shape)
         logprobs_B = logprobs_SE.reshape(-1)
         # NOTE: maybe have to convert back to tuple of batches
@@ -1472,8 +1449,6 @@ if __name__ == "__main__":
         advantages_B = advantages_SE.reshape(-1)
         returns_B = returns_SE.reshape(-1)
         values_B = values_SE.reshape(-1)
-
-        # print()
 
         # Optimizing the policy and value network
         idxs_B = np.arange(args.batch_size)
@@ -1543,7 +1518,6 @@ if __name__ == "__main__":
 
             if args.target_kl is not None and approx_kl > args.target_kl:
                 break
-        # print()
 
         y_pred, y_true = values_B.cpu().numpy(), returns_B.cpu().numpy()
         var_y = np.var(y_true)
@@ -1658,8 +1632,6 @@ if __name__ == "__main__":
         _append_run_tags(run, f"score:{curriculum_score:.2f}", f"thput:{final_thput*100:.0f}", f"duration:{format_duration(runtime)}")
     envs.close()
     if runtime > 60 * 5: # 5 minutes
-        # avg_throughput = 0 if len(final_throughputs) == 0 else float(sum(final_throughputs) / len(final_throughputs))
-        # Save the model to a file
         run_name_dir_safe = run_name.replace('/', '-').replace(':', '-').replace(' ', '_')
         agent_name = f"agent-{run_name_dir_safe}"
         print(f"Saving model to artifacts/{agent_name}.pt")

--- a/scripts/ci/apply_sft_sweep_best.py
+++ b/scripts/ci/apply_sft_sweep_best.py
@@ -132,7 +132,6 @@ def main():
     )
     args = parser.parse_args()
 
-    # ── Fetch best run from sweep ────────────────────────────────
     api = wandb.Api()
     try:
         sweep = api.sweep(args.sweep_path)
@@ -166,7 +165,6 @@ def main():
     print(f"Best run: {best_run.name} ({metric_name}={best_metric:.4f})")
     print(f"Sweep URL: {sweep_url}")
 
-    # ── Update sft.py ────────────────────────────────────────────
     print(f"\nUpdating {args.sft_file}...")
     changed = update_sft_defaults(args.sft_file, best_run.config, sweep_url)
 
@@ -180,7 +178,6 @@ def main():
         print("Dry run -- not creating branch or PR.")
         return
 
-    # ── Create branch, commit, push, open PR ─────────────────────
     branch_name = f"sft-sweep/apply-best-{sweep_id}"
 
     run(["git", "config", "user.name", "github-actions[bot]"])

--- a/scripts/ci/apply_sweep_best.py
+++ b/scripts/ci/apply_sweep_best.py
@@ -89,7 +89,6 @@ def update_ppo_defaults(ppo_path: str, best_config: dict, sweep_url: str) -> lis
         changed.append((param_name, old_val, formatted))
         print(f"  {param_name}: {old_val} -> {formatted}")
 
-    # Add sweep URL comment above the class if not already present
     sweep_comment = f"# Best hyperparameters from W&B sweep: {sweep_url}"
     # Replace existing sweep comment if present, otherwise insert before "class Args"
     existing_pattern = r"^# Best hyperparameters from W&B sweep: .+\n"
@@ -142,7 +141,6 @@ def main():
     )
     args = parser.parse_args()
 
-    # ── Fetch best run from sweep ────────────────────────────────
     api = wandb.Api()
     try:
         sweep = api.sweep(args.sweep_path)
@@ -176,7 +174,6 @@ def main():
     print(f"Best run: {best_run.name} ({metric_name}={best_metric:.4f})")
     print(f"Sweep URL: {sweep_url}")
 
-    # ── Update ppo.py ────────────────────────────────────────────
     print(f"\nUpdating {args.ppo_file}...")
     changed = update_ppo_defaults(args.ppo_file, best_run.config, sweep_url)
 
@@ -190,14 +187,11 @@ def main():
         print("Dry run — not creating branch or PR.")
         return
 
-    # ── Create branch, commit, push, open PR ─────────────────────
     branch_name = f"sweep/apply-best-{sweep_id}"
 
-    # Configure git for CI
     run(["git", "config", "user.name", "github-actions[bot]"])
     run(["git", "config", "user.email", "github-actions[bot]@users.noreply.github.com"])
 
-    # Create and switch to new branch from base
     result = run(["git", "checkout", "-b", branch_name], check=False)
     if result.returncode != 0:
         # Branch might already exist
@@ -205,7 +199,6 @@ def main():
 
     run(["git", "add", args.ppo_file])
 
-    # Build commit message
     commit_lines = [
         f"Update hyperparameters from sweep {sweep_id}",
         "",
@@ -223,7 +216,6 @@ def main():
     run(["git", "commit", "-m", commit_msg])
     run(["git", "push", "-u", "origin", branch_name])
 
-    # Build PR body
     pr_body_lines = [
         "## Apply best hyperparameters from sweep",
         "",

--- a/scripts/ci/check_wandb_metrics.py
+++ b/scripts/ci/check_wandb_metrics.py
@@ -97,7 +97,6 @@ def compare_metrics(
 
         value = metrics[metric_name]
 
-        # Check absolute bounds
         if "min" in constraint and value < constraint["min"]:
             failures.append(
                 f"{metric_name}: {value:.6g} < minimum threshold {constraint['min']:.6g}"
@@ -163,7 +162,6 @@ def main():
         print("ERROR: Must specify --run-id or --run-name")
         sys.exit(1)
 
-    # Find the run
     api = wandb.Api()
     if args.run_id:
         full_project = f"{args.entity}/{args.project}" if args.entity else args.project
@@ -174,15 +172,12 @@ def main():
     print(f"Found run: {run.name} (id={run.id}, state={run.state})")
     print(f"  URL: {run.url}")
 
-    # Check run completed
     if not check_run_completed(run):
         sys.exit(1)
 
-    # Load baseline
     with open(args.baseline_file) as f:
         baseline = json.load(f)
 
-    # Get run summary metrics
     metrics = dict(run.summary)
 
     print("\nMetrics vs baseline:")
@@ -209,7 +204,6 @@ def main():
 
         print(f"  {metric_name:<38} {value_str:>12} {threshold_str:>12} {status:>8}")
 
-    # Compare
     passed, failures, warnings = compare_metrics(metrics, baseline)
 
     if warnings:

--- a/scripts/ci/compare_runs.py
+++ b/scripts/ci/compare_runs.py
@@ -199,8 +199,6 @@ def cohens_d(a: list[float], b: list[float], paired: bool = False) -> float:
     return (mean(a) - mean(b)) / pooled_std
 
 
-# ── Metric extraction ─────────────────────────────────────────────
-
 METRICS_TO_COMPARE = [
     {
         "key": "curriculum_score",
@@ -256,7 +254,6 @@ def pair_by_seed(
     Returns (pr_vals, base_vals, is_paired).  When pairing succeeds, both
     lists are aligned so that index i corresponds to the same seed.
     """
-    # Build seed -> value maps
     pr_by_seed = {}
     for r in pr_results:
         seed = r.get("seed") or r.get("seed_file")
@@ -269,7 +266,6 @@ def pair_by_seed(
         if seed is not None and key in r:
             base_by_seed[int(seed)] = float(r[key])
 
-    # Find common seeds
     common = sorted(set(pr_by_seed) & set(base_by_seed))
 
     if len(common) >= 2:
@@ -277,7 +273,6 @@ def pair_by_seed(
         base_vals = [base_by_seed[s] for s in common]
         return pr_vals, base_vals, True
 
-    # Fallback: unpaired
     return extract_metric(pr_results, key), extract_metric(baseline_results, key), False
 
 
@@ -309,9 +304,6 @@ def verdict_icon(verdict: str) -> str:
         return "&#x274C;"  # red X
     else:
         return "&#x2796;"  # dash
-
-
-# ── Report generation ──────────────────────────────────────────────
 
 
 def generate_report(
@@ -349,7 +341,6 @@ def generate_report(
     lines.append(f"- Timesteps per seed: {timesteps:,}" if isinstance(timesteps, int) else f"- Timesteps per seed: {timesteps}")
     lines.append("")
 
-    # Summary table
     lines.append("### Comparison")
     lines.append("")
     lines.append(f"| Metric | main (n={n_base}) | PR (n={n_pr}) | Change | p-value | Verdict |")
@@ -405,12 +396,10 @@ def generate_report(
             "verdict": v,
         })
 
-    # Per-seed detail table
     lines.append("")
     lines.append("<details><summary>Per-seed details</summary>")
     lines.append("")
 
-    # Curriculum score per seed (paired by seed number)
     lines.append("#### Curriculum score per seed")
     lines.append("")
 
@@ -440,7 +429,6 @@ def generate_report(
             diff_str = "-"
         lines.append(f"| {seed} | {base_val} | {pr_val} | {diff_str} |")
 
-    # W&B links
     lines.append("")
     lines.append("#### W&B run links")
     lines.append("")
@@ -459,9 +447,6 @@ def generate_report(
     lines.append(f"<sub>Commit {commit_sha[:8]} | PR #{pr_number}</sub>")
 
     return "\n".join(lines)
-
-
-# ── CLI ────────────────────────────────────────────────────────────
 
 
 def main():

--- a/scripts/ci/runpod_create.py
+++ b/scripts/ci/runpod_create.py
@@ -19,7 +19,6 @@ import time
 
 import runpod
 
-# Ordered fallback list: try A100 first, then fall back to other GPUs
 GPU_FALLBACKS = [
     "NVIDIA GeForce RTX 4090",
     "NVIDIA RTX A6000",
@@ -75,7 +74,6 @@ def create_pod(gpu_type: str, name_prefix: str = "ci", timeout: int = POD_START_
 
     pod_id = pod["id"]
 
-    # Wait for pod to reach running state
     start_time = time.time()
     while time.time() - start_time < timeout:
         status = runpod.get_pod(pod_id)
@@ -84,7 +82,6 @@ def create_pod(gpu_type: str, name_prefix: str = "ci", timeout: int = POD_START_
         elapsed = int(time.time() - start_time)
 
         if desired == "RUNNING" and runtime:
-            # Extract public SSH IP and port from runtime ports
             ssh_host = None
             ssh_port = 22
             ports = runtime.get("ports", []) or []
@@ -110,7 +107,6 @@ def create_pod(gpu_type: str, name_prefix: str = "ci", timeout: int = POD_START_
         print(f"  Waiting... ({elapsed}s, desired={desired})", flush=True)
         time.sleep(10)
 
-    # Timeout - clean up the pod
     print(f"ERROR: Pod {pod_id} did not start within {timeout}s. Terminating.")
     try:
         runpod.terminate_pod(pod_id)

--- a/scripts/ci/sweep_report.py
+++ b/scripts/ci/sweep_report.py
@@ -60,7 +60,6 @@ def main():
     sweep_params = sweep.config.get("parameters", {})
     reverse = metric_goal == "maximize"
 
-    # Fetch all runs, keep only finished ones
     runs = [r for r in sweep.runs if r.state == "finished"]
 
     # sweep_path is entity/project/sweep_id — W&B URLs need /sweeps/ before the ID
@@ -80,7 +79,6 @@ def main():
         print(md)
         return
 
-    # Sort runs by the sweep metric
     missing = float("-inf") if reverse else float("inf")
 
     def get_metric(run):
@@ -94,7 +92,6 @@ def main():
 
     md_lines = []
 
-    # ── Header ────────────────────────────────────────────────────
     md_lines.append("## W&B Hyperparameter Sweep Results\n")
     md_lines.append("| | |")
     md_lines.append("|---|---|")
@@ -108,7 +105,6 @@ def main():
     md_lines.append(f"| **Best value** | **{best_metric:.4f}** |")
     md_lines.append("")
 
-    # ── Best hyperparameters ──────────────────────────────────────
     md_lines.append("### Best Hyperparameters\n")
     md_lines.append("| Parameter | Value |")
     md_lines.append("|-----------|-------|")
@@ -124,11 +120,9 @@ def main():
     best_run_url = best_run.url
     md_lines.append(f"\n[View best run on W&B]({best_run_url})\n")
 
-    # ── Top N runs table ──────────────────────────────────────────
     top_n = min(args.top_n, len(runs))
     md_lines.append(f"### Top {top_n} Runs\n")
 
-    # Build header row
     header_parts = ["Rank"]
     for p in param_names:
         header_parts.append(f"`{p}`")
@@ -158,7 +152,6 @@ def main():
 
     md_lines.append("")
 
-    # ── Parameter ranges (collapsed) ─────────────────────────────
     md_lines.append(
         "<details><summary>Sweep parameter ranges</summary>\n"
     )

--- a/scripts/spot_check.py
+++ b/scripts/spot_check.py
@@ -120,7 +120,6 @@ def run_scenario(kind: LessonKind, name: str, args: Args) -> dict:
                 f'</div>'
             )
 
-    # Write single HTML page per scenario
     tps = throughputs
     summary = (
         f"{passed}/{generated} passed"
@@ -173,7 +172,6 @@ def main():
         result = run_scenario(kind, name, args)
         results.append(result)
 
-    # Print summary
     print()
     print("=" * 60)
     print(f"{'Scenario':<20} {'Gen':>5} {'Pass':>5} {'Fail':>5} {'Min TP':>8} {'Max TP':>8} {'Avg TP':>8}")


### PR DESCRIPTION
## What

Removes comment churn across the Python and Rust sources — **deletions only, zero code changes.** This targets the recurring problem of comments going stale and creating diff noise.

`tokei` before/after (Python + Rust only) confirms code is byte-stable:

| Language | Code (before→after) | Comments (before→after) |
|---|---|---|
| Python | 16,451 → **16,451** | 1,480 → **1,382**  (−98) |
| Rust (`//`) | 4,352 → **4,352** | 444 → **413**  (−31) |

~129 comment lines removed; Rust `///`/`//!` doc comments left untouched.

## What was removed

- **Commented-out dead code** — debug `print()`s, alternative tensor assignments, stale dict entries.
- **Next-line narration** — comments that merely restated the following statement (`# flatten the batch`, `// Identify sources and sinks`, …).
- **Decorative banners** — `# ── Header ──` / `# ── CLI ──` separators in CI scripts.
- **Stale / inaccurate comments** — e.g. `// Can only insert into belts or assembling machines` (the `matches!` also accepts underground belts, Source, Sink); `# try A100 first` when the GPU list starts with an RTX 4090.
- **LLM chain-of-thought scratch work** — the `// Wait, let me re-check … // Actually let me re-derive …` arithmetic-derivation block in `entities.rs`, and a self-contradicting "should NOT connect / Actually wait…" block in `graph.rs` whose claim was the *opposite* of what the test asserts.

## What was kept

"Why" rationale, units / tensor shapes, external references (Factorio wiki, paper/issue links), real TODOs, cleanrl provenance markers, tyro CLI `--help` field docs, and the `textual.rs` DSL format documentation.

## Verification

`ruff` ✅ · `ty` ✅ · `cargo fmt` + 92 Rust tests ✅ · 3,275 Python tests ✅ · PPO + SFT smoke tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
