### PR TITLE
test(textual): allow `ignored: true` fixtures and empty YAML files

### DIFF
--- a/factorion_rs/src/textual.rs
+++ b/factorion_rs/src/textual.rs
@@ -20,6 +20,12 @@
 //! documents with `---` (YAML's native document separator) and parse with
 //! [`parse_many`].
 //!
+//! A document may carry `ignored: true` to keep a fixture in the file while the
+//! directory sweep skips its assertions — the textual analogue of Rust's
+//! `#[ignore]`. The grid and header must still parse; only the
+//! `throughput:`/`graph:` checks are skipped. An empty file (or one of only
+//! comments / `---` separators) holds zero factories and the sweep skips it.
+//!
 //! ## Grid encoding
 //!
 //! Every tile is exactly **two characters**, and tiles are separated by one
@@ -396,6 +402,12 @@ struct Header {
     /// it documents intent as real content rather than a throwaway comment.
     #[serde(default)]
     description: Option<String>,
+    /// When `true`, the directory sweep parses this factory (so its grid and
+    /// header must still be valid) but skips its `throughput:`/`graph:`
+    /// assertions — the textual analogue of Rust's `#[ignore]`. Use it to park
+    /// a known-failing fixture without deleting it.
+    #[serde(default)]
+    ignored: bool,
     /// Per-coordinate item bindings. For a source this is what it emits, for a
     /// sink what it counts, for an assembler the recipe (product). The `(x, y)`
     /// may be any tile of a multi-tile entity — it resolves to the whole
@@ -433,6 +445,9 @@ pub(crate) struct FactorySpec {
     pub expected_throughput: Vec<DeliverySpec>,
     /// Free-text description from the header, if any.
     pub description: Option<String>,
+    /// When `true`, the directory sweep skips this factory's assertions (see
+    /// [`Header::ignored`]).
+    pub ignored: bool,
     /// Expected directed edges from the `graph:` block, if any — each a
     /// `(source, destination)` referenced by `<char>@x,y` (multi-tile entities
     /// by their anchor). Asserted by [`check_graph`].
@@ -490,6 +505,7 @@ fn header_to_spec(header: Header) -> Result<FactorySpec, String> {
         world: parsed.world,
         expected_throughput,
         description: header.description,
+        ignored: header.ignored,
         expected_graph,
     })
 }
@@ -1090,6 +1106,30 @@ factory: |
         assert!(spec.expected_throughput.is_empty());
         assert!(spec.description.is_none());
         assert!(spec.expected_graph.is_none());
+        // `ignored` defaults to false when the key is absent.
+        assert!(!spec.ignored);
+    }
+
+    #[test]
+    fn test_ignored_field_parsed() {
+        // `ignored: true` is captured on the spec; the grid still parses so the
+        // sweep can park (but not delete) the fixture.
+        let spec = parse("ignored: true\nfactory: |\n  S> b> K>").unwrap();
+        assert!(spec.ignored);
+        assert_eq!(spec.world.width(), 3);
+        // Explicit `ignored: false` round-trips to the default.
+        let spec = parse("ignored: false\nfactory: |\n  S> b> K>").unwrap();
+        assert!(!spec.ignored);
+    }
+
+    #[test]
+    fn test_empty_yaml_yields_no_factories() {
+        // An empty file, a comment-only file, and a lone separator each hold
+        // zero factories rather than erroring — the directory sweep skips them.
+        assert!(parse_many("").unwrap().is_empty());
+        assert!(parse_many("\n\n  \n").unwrap().is_empty());
+        assert!(parse_many("# only a comment\n").unwrap().is_empty());
+        assert!(parse_many("---\n").unwrap().is_empty());
     }
 
     #[test]
@@ -1505,9 +1545,18 @@ factory: |
                 parsed.err().unwrap_or_default()
             );
             let specs = parsed.unwrap();
-            assert!(!specs.is_empty(), "{display}: no factories found");
+            // An empty file (or one of only comments / `---` separators) holds
+            // no factories — that is allowed; there is simply nothing to assert.
+            if specs.is_empty() {
+                continue;
+            }
 
             for (i, spec) in specs.iter().enumerate() {
+                // `ignored: true` parks a fixture in the file without running
+                // its assertions — the textual analogue of Rust's `#[ignore]`.
+                if spec.ignored {
+                    continue;
+                }
                 // A clickable, descriptive banner prepended to any failure so
                 // the output says exactly which file/factory and what it is.
                 let mut banner = format!("\n===== FAILED: {display} =====\n");

--- a/factorion_rs/tests/factories/belt_junction.yaml
+++ b/factorion_rs/tests/factories/belt_junction.yaml
@@ -1,0 +1,25 @@
+description: |
+  A 4-way junction: three sources (north, west, south) feed a central belt that
+  carries the merged flow east into a sink. A transport belt tops out at
+  15 items/s, so that is what the sink receives.
+items:
+- { x: 1, y: 0, item: copper_cable }   # north source
+- { x: 0, y: 2, item: copper_cable }   # west source
+- { x: 1, y: 4, item: copper_cable }   # south source
+- { x: 3, y: 2, item: copper_cable }   # sink
+throughput:
+- { item: copper_cable, per_second: 15 }
+graph: |
+  S@1,0 -> b@1,1
+  S@0,2 -> b@1,2
+  S@1,4 -> b@1,3
+  b@1,1 -> b@1,2
+  b@1,3 -> b@1,2
+  b@1,2 -> b@2,2
+  b@2,2 -> K@3,2
+factory: |
+  .. Sv .. ..
+  .. bv .. ..
+  S> b> b> K>
+  .. b^ .. ..
+  .. S^ .. ..

--- a/factorion_rs/tests/factories/belt_loop.yaml
+++ b/factorion_rs/tests/factories/belt_loop.yaml
@@ -1,0 +1,11 @@
+description: |
+  A 2x2 ring of belts, each feeding the next. Every belt connects to exactly
+  one downstream belt, so the four form a single closed loop.
+graph: |
+  b@0,0 -> b@1,0
+  b@1,0 -> b@1,1
+  b@1,1 -> b@0,1
+  b@0,1 -> b@0,0
+factory: |
+  b> bv
+  b^ b<

--- a/factorion_rs/tests/factories/ignored.yaml
+++ b/factorion_rs/tests/factories/ignored.yaml
@@ -1,0 +1,14 @@
+description: |
+  Regression fixture for `ignored: true`. The expected throughput below is
+  deliberately wrong (a belt delivers 15 i/s, not 999); `ignored: true` parks
+  the fixture so the directory sweep parses it but does not assert it. Do NOT
+  "fix" the number — removing the `ignored:` line should make the sweep fail,
+  which is exactly the regression this fixture guards against.
+ignored: true
+items:
+- { x: 0, y: 0, item: copper_cable }
+- { x: 3, y: 0, item: copper_cable }
+throughput:
+- { item: copper_cable, per_second: 999 }
+factory: |
+  S> b> b> K> ..

--- a/factorion_rs/tests/factories/inserter_into_source.yaml
+++ b/factorion_rs/tests/factories/inserter_into_source.yaml
@@ -1,0 +1,33 @@
+# An inserter must not be able to insert *into* a Source. A Source is an
+# infinite producer, not a container, so an inserter pointed at one should make
+# no connection — every case below expects an empty graph.
+#
+# `ignored: true` on each: the engine is currently WRONG here, producing a
+# spurious `inserter -> source` edge. Once the engine stops connecting inserters
+# to sources, drop the `ignored:` lines and these become live regression tests.
+
+description: inserter below the source, facing up into it
+ignored: true
+graph: ""
+factory: |
+  S>
+  i^
+---
+description: inserter above the source, facing down into it
+ignored: true
+graph: ""
+factory: |
+  iv
+  S>
+---
+description: inserter right of the source, facing left into it
+ignored: true
+graph: ""
+factory: |
+  S> i<
+---
+description: inserter left of the source, facing right into it
+ignored: true
+graph: ""
+factory: |
+  i> S>

--- a/factorion_rs/tests/factories/inserter_splitter.yaml
+++ b/factorion_rs/tests/factories/inserter_splitter.yaml
@@ -1,0 +1,22 @@
+# How inserters connect (or don't) to a Splitter.
+
+description: |
+  Inserters flanking a splitter's lateral sides do not connect to it — they sit
+  beside the splitter's body, not at its input or output ends, so no edge is
+  produced.
+graph: ""
+factory: |
+  i< YvvvY i>
+---
+description: |
+  A splitter's output should feed an inserter directly below it
+  (Y@0,1 -> i@0,2). `ignored: true`: the engine is currently WRONG here — it
+  produces the source->splitter edge but omits the splitter->inserter edge.
+ignored: true
+graph: |
+  S@0,0 -> Y@0,1
+  Y@0,1 -> i@0,2
+factory: |
+  Sv ..
+  YvvvY
+  iv ..


### PR DESCRIPTION
## What

Two escape hatches for the factorion_rs textual fixture sweep (`test_all_yamls_in_factories_dir`):

- **`ignored: true`** on a factory document parks it. The grid and header must still parse, but the sweep skips its `throughput:`/`graph:` assertions — the textual analogue of Rust's `#[ignore]`. Lets a known-failing fixture stay in the tree without turning CI red.
- **Empty YAML files** (or files with only comments / `---` separators) now hold zero factories and are skipped, instead of tripping the old `no factories found` assertion.

## How

- `Header` gains an `#[serde(default)] ignored: bool`, threaded onto `FactorySpec`; the directory sweep `continue`s past `ignored` specs.
- The sweep `continue`s when a file parses to zero factories rather than asserting non-empty.

## Tests

- `test_ignored_field_parsed` / updated `test_minimal_factory_only` — the parsed `ignored` field (true / explicit-false / default-false).
- `test_empty_yaml_yields_no_factories` — empty string, whitespace, comment-only, and lone-`---` streams all parse to zero factories.
- End-to-end fixtures exercised by the sweep: `ignored.yaml` (deliberately-wrong throughput, `ignored: true` — removing the `ignored:` line would turn the sweep red) and a 0-byte `empty.yaml`.

All changes live in the `#[cfg(test)]`-only `textual` module, so the Python extension wheel and the PPO/SFT paths are untouched.

Local checklist: `cargo fmt`/`clippy`/`test --no-default-features` (94 passed), `ruff`, `ty`, and `pytest` (3291 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)