### PR TITLE
ppo: run the greedy eval ~3x more often (--eval-every 7)

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -146,7 +146,7 @@ class Args:
     """Tags to apply to the wandb run."""
     critic_warmup: int = 0
     """Freeze the actor (encoder + all policy heads) for this many PPO iterations and train only the critic head, then unfreeze. An SFT checkpoint loads a trained actor but a random critic; without a warm-up the random critic's garbage advantages wreck the SFT policy in the first updates. 0 disables (default, preserves from-scratch behaviour). LR + entropy annealing start at unfreeze."""
-    eval_every: int = 20
+    eval_every: int = 7
     """Run the greedy held-out eval (eval/throughput, eval/throughput_eot, per-lesson) every N PPO iterations (and on the final iteration). Mirrors the SFT rollout eval so the curves overlay the SFT baseline. 0 disables."""
     eval_seeds_per_kind: int = 12
     """Held-out factories per LessonKind in the greedy eval set."""


### PR DESCRIPTION
The `eval/*` curves were too sparse at the default `--eval-every 20`. This drops the default to **7** (≈3× more eval points: ~20/7 = 2.86×) so `eval/throughput` / `eval/throughput_eot` and the per-lesson breakdowns are tracked more densely against the SFT baseline.

One-line change to the `Args.eval_every` default; still overridable per run. Follow-up to #185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)