### PR TITLE
sweep: RL-finetuning sweep targeting the SFT-policy collapse

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Historically the project did RL-from-scratch with heavy scaffolding (curriculum 
 - `scripts/factory_builder.py` — Local HTTP UI to hand-build factories and query a checkpoint's predictions. Shares `_resolve_wandb_checkpoint` with `ppo.py`.
 - `scripts/ci/` — CI/training automation: `ppo_train.sh` & `sft_train.sh` (in-pod RunPod training), `create_sweep.py`/`apply_sweep_best.py`/`apply_sft_sweep_best.py` (W&B sweeps → PR), `runpod_create.py`/`runpod_destroy.py`.
 - `.github/workflows/` — `ppo-train.yml` & `sft-train.yml` (manual `workflow_dispatch` GPU runs on RunPod), `ci.yml`, `claude.yml`.
-- `sweep.yaml` — Weights & Biases Bayesian hyperparameter sweep config (PPO; metric `curriculum/score`).
+- `sweep.yaml` — W&B Bayesian sweep config: PPO RL-finetuning from the SFT base, maximising `eval/throughput_eot`. Pins the SFT checkpoint/architecture/timesteps in `command`; sweeps the RL levers (step_penalty, ent_coef, lr, throughput_reward_scale, target_kl, gamma, gae_lambda).
 - `b64-to-json.py` / `json-to-b64.py` — Blueprint encoding/decoding utilities.
 - `factorio-data/` — Git submodule with Factorio game data.
 - `factorio-icons/` — Entity icon PNGs.

--- a/sweep.yaml
+++ b/sweep.yaml
@@ -1,77 +1,82 @@
-# sweep.yaml — PPO hyperparameter sweep
+# sweep.yaml — PPO RL-finetuning sweep (from the SFT base j0s5y2mc)
+#
+# Goal: find hyperparameters under which PPO *exceeds* the SFT base's
+# eval/throughput_eot (~0.11) instead of degrading it. A baseline run
+# (isq08ia3) started at the SFT level and collapsed to ~0.05: the agent learned
+# to declare end-of-turn almost immediately (rollout/length 58 -> 5, eot_rate
+# -> 1.0) and the policy went deterministic (ent_coef=0). So this sweep targets
+# the levers behind that collapse, not the architecture.
+#
+# Fixed (NOT swept): the run continues a specific SFT checkpoint, so the
+# architecture (layers/kernel) and grid size MUST match it — sweeping them would
+# break load_state_dict. --start-from / --size / --total-timesteps /
+# --critic-warmup / --eval-every are pinned in `command` below.
 
 method: bayes
-run_cap: 20
+run_cap: 30
 metric:
-  name: "eval/throughput_eot"
+  name: "eval/throughput_eot"   # greedy held-out, EOT-respecting; beat ~0.11
   goal: maximize
 
 parameters:
+  # ── Stop the immediate-EOT collapse ──────────────────────────────────
+  # step_penalty rewards declaring "done" early; 0.01 drove length->5. Test
+  # all the way down to 0 (no early-stop pressure).
+  step_penalty:
+    values: [0.0, 0.002, 0.005, 0.01]
+
+  # Make the terminal throughput reward dominate any per-step cost, so there's
+  # a real incentive to keep building.
+  throughput_reward_scale:
+    values: [1.0, 3.0, 5.0]
+
+  # ── Keep exploring instead of collapsing deterministically ───────────
+  # ent_coef=0 let the SFT policy's build attempts collapse before earning
+  # reward; give it some entropy (annealed start -> end).
   ent_coef_start:
     distribution: log_uniform_values
-    min: 0.005
-    max: 0.2
-
+    min: 5e-4
+    max: 5e-2
   ent_coef_end:
     distribution: log_uniform_values
-    min: 1e-4
-    max: 0.01
+    min: 1e-5
+    max: 5e-3
 
+  # ── Move the policy enough (updates were ~zero by the end) ───────────
   learning_rate:
     distribution: log_uniform_values
-    min: 5e-5
-    max: 1e-3
+    min: 2e-5
+    max: 5e-4
+  target_kl:
+    values: [0.02, 0.05, 0.15]   # bigger trust region = more movement/rollout
 
-  chan1:
-    values: [32, 48, 64]
-
-  chan2:
-    values: [48, 64]
-
-  chan3:
-    values: [48, 64]
-
-  clip_coef:
-    distribution: uniform
-    min: 0.18
-    max: 0.32
-
+  # ── Credit assignment for the sparse terminal throughput reward ──────
+  # ~100-step episodes: the default gamma 0.986 discounts the terminal reward
+  # to ~0.24 at step 0, and gae_lambda 0.80 is a short horizon. Push both up so
+  # the end-of-episode throughput propagates back to early placements.
   gamma:
     distribution: uniform
-    min: 0.95
+    min: 0.985
     max: 0.999
-
   gae_lambda:
     distribution: uniform
-    min: 0.8
-    max: 0.975
-
-  tile_head_std:
-    distribution: log_uniform_values
-    min: 0.001
-    max: 0.1
-
-  vf_coef:
-    distribution: uniform
-    min: 0.5
-    max: 0.9
-
-  max_grad_norm:
-    distribution: uniform
-    min: 0.75
-    max: 2.5
-
-  adam_epsilon:
-    distribution: log_uniform_values
-    min: 1e-6
-    max: 2e-4
+    min: 0.9
+    max: 0.99
 
 program: ppo.py
 
 command:
   - bash
   - run_sweep.sh
+  - --start-from
+  - j0s5y2mc          # existing SFT base; pins architecture + grid size
+  - --size
+  - "11"
   - --total-timesteps
-  - 250_000
+  - "500000"          # plenty per the baseline run
+  - --critic-warmup
+  - "10"
+  - --eval-every
+  - "7"               # dense eval/* so the bayes metric has resolution
   - --track
   - ${args}

--- a/sweep.yaml
+++ b/sweep.yaml
@@ -67,7 +67,7 @@ command:
   - --size
   - "11"
   - --total-timesteps
-  - "2500000"          # plenty per the baseline run
+  - "5000000"          # 2x: n67gnq05 was still creeping up at 2.5M; reach the plateau
   - --critic-warmup
   - "10"
   - --eval-every

--- a/sweep.yaml
+++ b/sweep.yaml
@@ -19,17 +19,6 @@ metric:
   goal: maximize
 
 parameters:
-  # ── Stop the immediate-EOT collapse ──────────────────────────────────
-  # step_penalty rewards declaring "done" early; 0.01 drove length->5. Test
-  # all the way down to 0 (no early-stop pressure).
-  step_penalty:
-    values: [0.0, 0.002, 0.005, 0.01]
-
-  # Make the terminal throughput reward dominate any per-step cost, so there's
-  # a real incentive to keep building.
-  throughput_reward_scale:
-    values: [1.0, 3.0, 5.0]
-
   # ── Keep exploring instead of collapsing deterministically ───────────
   # ent_coef=0 let the SFT policy's build attempts collapse before earning
   # reward; give it some entropy (annealed start -> end).

--- a/sweep.yaml
+++ b/sweep.yaml
@@ -21,21 +21,26 @@ metric:
 parameters:
   # ── Keep exploring instead of collapsing deterministically ───────────
   # ent_coef=0 let the SFT policy's build attempts collapse before earning
-  # reward; give it some entropy (annealed start -> end).
+  # reward; give it some entropy (annealed start -> end). BUT the first sweep
+  # (n67gnq05) showed a hard cliff: every run with ent_coef_start >= 0.022
+  # failed (rollout/thput <= 0.1) — too much entropy melts the SFT prior —
+  # while the best runs clustered at 1e-3..7e-3. Upper bound kept well below
+  # the cliff. ent_coef_start is the single strongest predictor of success.
   ent_coef_start:
     distribution: log_uniform_values
-    min: 5e-4
-    max: 5e-2
+    min: 7e-4
+    max: 8e-3
   ent_coef_end:
     distribution: log_uniform_values
     min: 1e-5
-    max: 5e-3
+    max: 3e-3
 
   # ── Move the policy enough (updates were ~zero by the end) ───────────
+  # n67gnq05: no good run exceeded ~2.1e-4; the upper range was wasted.
   learning_rate:
     distribution: log_uniform_values
-    min: 2e-5
-    max: 5e-4
+    min: 3e-5
+    max: 2.2e-4
   target_kl:
     values: [0.02, 0.05, 0.15]   # bigger trust region = more movement/rollout
 
@@ -50,7 +55,7 @@ parameters:
   gae_lambda:
     distribution: uniform
     min: 0.9
-    max: 0.99
+    max: 0.96   # n67gnq05: no good run sampled above ~0.96
 
 program: ppo.py
 

--- a/sweep.yaml
+++ b/sweep.yaml
@@ -15,7 +15,7 @@
 method: bayes
 run_cap: 30
 metric:
-  name: "eval/throughput_eot"   # greedy held-out, EOT-respecting; beat ~0.11
+  name: "rollout/reward"
   goal: maximize
 
 parameters:
@@ -73,7 +73,7 @@ command:
   - --size
   - "11"
   - --total-timesteps
-  - "500000"          # plenty per the baseline run
+  - "2500000"          # plenty per the baseline run
   - --critic-warmup
   - "10"
   - --eval-every


### PR DESCRIPTION
## Why
The baseline PPO-from-SFT run ([isq08ia3](https://wandb.ai/beyarkay/factorion/runs/isq08ia3)) **degraded** the SFT policy: `eval/throughput_eot` started at the SFT level (~0.11) and fell to ~0.05. The agent collapsed to declaring end-of-turn almost immediately (`rollout/length` 58→5, `eot_rate`→1.0) with the policy going deterministic (`ent_coef=0`, entropy 2.4→1.0). This sweep searches the levers behind that collapse.

## What changed in `sweep.yaml`
The old config swept **architecture** (`chan1/2/3`, `tile_head_std`) and never passed `--start-from` — both wrong for finetuning a *fixed* SFT checkpoint. Now:

**Pinned in `command`** (must match the checkpoint / per your constraints): `--start-from j0s5y2mc`, `--size 11`, `--total-timesteps 500000`, `--critic-warmup 10`, `--eval-every 7`.

**Swept** (the diagnostic levers), maximising `eval/throughput_eot`:
| param | range | rationale |
|---|---|---|
| `step_penalty` | `{0, 0.002, 0.005, 0.01}` | 0.01 drove the early-EOT collapse; test down to 0 |
| `throughput_reward_scale` | `{1, 3, 5}` | make the build reward dominate per-step cost |
| `ent_coef_start` | `5e-4 … 5e-2` (log) | keep exploring (0 collapsed deterministically) |
| `ent_coef_end` | `1e-5 … 5e-3` (log) | exploration floor |
| `learning_rate` | `2e-5 … 5e-4` (log) | updates went to ~0 by the end |
| `target_kl` | `{0.02, 0.05, 0.15}` | bigger trust region = more movement/rollout |
| `gamma` | `0.985 … 0.999` | terminal reward was discounted to ~0.24 at step 0 |
| `gae_lambda` | `0.9 … 0.99` | propagate end-of-episode throughput to early placements |

`method: bayes`, `run_cap: 30`, 500k timesteps each (per your "plenty"), existing SFT base.

## Verification
`sweep.yaml` parses and a representative trial's fixed+swept args resolve cleanly through tyro into `Args`. Also de-staled the `sweep.yaml` line in CLAUDE.md.

> Note: the sweep explores existing knobs. If none clear ~0.11, the more fundamental fix is a KL-to-frozen-SFT anchor (a code change, separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
