### PR TITLE
ci: default PPO sweep to 5 agents/pod (was 20) so bayes can optimise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,9 @@ on:
         default: "1"
         type: string
       sweep_agents_per_pod:
-        description: "Parallel wandb agents per pod (GPU time-slicing)"
+        description: "Parallel wandb agents per pod (GPU time-slicing). Keep below sweep_count so the bayes controller sees finished runs before suggesting more (else it's random search)."
         required: false
-        default: "20"
+        default: "5"
         type: string
 
 permissions:
@@ -434,7 +434,7 @@ jobs:
           SWEEP_URL="${{ steps.create.outputs.sweep_url }}"
           SWEEP_COUNT="${{ inputs.sweep_count || '20' }}"
           SWEEP_PODS="${{ inputs.sweep_agents || '1' }}"
-          AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '20' }}"
+          AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '5' }}"
           TOTAL_AGENTS=$(( SWEEP_PODS * AGENTS_PER_POD ))
           gh pr comment "${{ github.event.pull_request.number }}" --body "$(cat <<EOF
           **W&B Sweep started** — ${SWEEP_COUNT} iterations across ${SWEEP_PODS} pod(s) x ${AGENTS_PER_POD} agents/pod (${TOTAL_AGENTS} total agents)
@@ -447,7 +447,7 @@ jobs:
         id: matrix
         run: |
           NUM_PODS="${{ inputs.sweep_agents || '1' }}"
-          AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '20' }}"
+          AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '5' }}"
           TOTAL_COUNT="${{ inputs.sweep_count || '20' }}"
           TOTAL_AGENTS=$(( NUM_PODS * AGENTS_PER_POD ))
           COUNT_PER=$(( TOTAL_COUNT / TOTAL_AGENTS ))


### PR DESCRIPTION
## Problem
The PPO sweep defaults (`sweep_agents_per_pod=20`, `sweep_count=20`) made the matrix compute `count_per_agent = 20 / (1×20) = 1`: **20 agents fire at once, each doing a single run**. The W&B bayes controller never sees a finished run before handing out the next config, so every suggestion is ~random — it's **random search in a single round** (and 20-way GPU time-slicing overloads the pod). A `sweep` PR label can't pass inputs, so it silently hits these defaults.

## Fix
Lower the default `sweep_agents_per_pod` `20 → 5` (matching the SFT sweep, which already uses 5). Now `count_per_agent = 20/5 = 4` → **5 parallel agents × 4 sequential rounds**, so the controller re-optimises after each round. Still overridable via the `workflow_dispatch` input.

Touches only the PPO sweep defaults in `ci.yml` (3 spots: the input default + two `|| '20'` fallbacks); the SFT sweep path was already on 5. YAML validated.

> Doesn't affect the currently-running random sweep (per request) — applies to the next one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)