### PR TITLE
Add MOVE_ONE_ITEM_CHAOS lesson

### DIFF
--- a/factorion.py
+++ b/factorion.py
@@ -154,6 +154,7 @@ class LessonKind(Enum):
     MOVE_VIA_UG_BELT = 6
     ASSEMBLE_2IN_1OUT = 7
     FROM_BLUEPRINT = 8
+    MOVE_ONE_ITEM_CHAOS = 9
 
 
 @dataclass(frozen=True)
@@ -1451,6 +1452,139 @@ def build_factory(
                 continue
 
             total_entities = len(chosen_path)
+            break
+        if count == 0:
+            return None
+    elif kind.value == LessonKind.MOVE_ONE_ITEM_CHAOS.value:
+        # Like MOVE_ONE_ITEM, but the belt run is deliberately routed
+        # through a random intermediate waypoint, so the source→sink
+        # route is suboptimal. Crucially, only the intermediate→sink
+        # belts are left removable (via ``protected_positions``); the
+        # source→intermediate belts (up to and including the
+        # intermediate tile) are protected and survive even a full
+        # (``inf``) blank. The model therefore always starts from this
+        # bad partial layout — a suboptimal stub already laid out from
+        # the source — and must still complete the route to the sink.
+        # This trains robustness to suboptimal upstream placement.
+        original_count = max(500, size * size * 4)
+        count = original_count
+        while count > 0:
+            count -= 1
+            world_CWH = torch.tensor(
+                new_world(width=size, height=size)
+            ).permute(2, 0, 1)
+            C, W, H = world_CWH.shape
+
+            pos1 = torch.randint(0, H * W, (1,))
+            pos2 = torch.randint(0, H * W, (1,))
+            if pos1 == pos2:
+                continue
+            source_WH = divmod(pos1.item(), W)
+            sink_WH = divmod(pos2.item(), W)
+
+            source_dir = random.choice(
+                [d for d in Direction if d != Direction.NONE]
+            )
+            sink_dir = random.choice(
+                [d for d in Direction if d != Direction.NONE]
+            )
+
+            if random_item:
+                item_value = random.choice(
+                    [v.value for k, v in items.items() if v.name != "empty"]
+                )
+            else:
+                item_value = str2item("electronic_circuit").value
+
+            # The belt run starts at the source's output cell and ends at
+            # the sink's input cell (one step ahead of / behind each,
+            # respectively, in its facing direction).
+            ds = DIR_TO_DELTA[source_dir]
+            dk = DIR_TO_DELTA[sink_dir]
+            start = (source_WH[0] + ds[0], source_WH[1] + ds[1])
+            end = (sink_WH[0] - dk[0], sink_WH[1] - dk[1])
+
+            fixed = {source_WH, sink_WH}
+            if not (0 <= start[0] < W and 0 <= start[1] < H):
+                continue
+            if not (0 <= end[0] < W and 0 <= end[1] < H):
+                continue
+            if start in fixed or end in fixed or start == end:
+                continue
+
+            # Pick a random intermediate waypoint distinct from the
+            # source/sink and from the belt-run endpoints.
+            reserved = fixed | {start, end}
+            mid_candidates = [
+                (x, y)
+                for x in range(W)
+                for y in range(H)
+                if (x, y) not in reserved
+            ]
+            if not mid_candidates:
+                continue
+            mid = random.choice(mid_candidates)
+
+            # Segment A: source output → intermediate (protected later).
+            # Block the source/sink and the sink-input cell so the two
+            # segments stay disjoint and the chain is single-threaded.
+            belts_a = find_belt_path(W, H, start, mid, source_dir, fixed | {end})
+            if belts_a is None:
+                continue
+            cells_a = [(x, y) for x, y, _ in belts_a]
+
+            # Segment B: intermediate → sink input (removable). Block all
+            # of segment A except the shared ``mid`` start so B can't
+            # double back through the protected stub.
+            blocked_b = fixed | (set(cells_a) - {mid})
+            belts_b = find_belt_path(W, H, mid, end, sink_dir, blocked_b)
+            if belts_b is None:
+                continue
+            cells_b = [(x, y) for x, y, _ in belts_b]
+
+            # Stitch the two cell runs (``mid`` is shared) and recompute
+            # belt directions over the whole chain so the junction belt at
+            # ``mid`` points along the flow into segment B.
+            full_cells = cells_a + cells_b[1:]
+            full_belts = _path_to_belts(full_cells, sink_dir)
+            if len(full_belts) > max_entities:
+                continue
+
+            world_CWH[Channel.ENTITIES.value, source_WH[0], source_WH[1]] = (
+                str2ent("source").value
+            )
+            world_CWH[Channel.ENTITIES.value, sink_WH[0], sink_WH[1]] = (
+                str2ent("sink").value
+            )
+            world_CWH[Channel.ITEMS.value, source_WH[0], source_WH[1]] = (
+                item_value
+            )
+            world_CWH[Channel.ITEMS.value, sink_WH[0], sink_WH[1]] = item_value
+            world_CWH[Channel.DIRECTION.value, source_WH[0], source_WH[1]] = (
+                source_dir.value
+            )
+            world_CWH[Channel.DIRECTION.value, sink_WH[0], sink_WH[1]] = (
+                sink_dir.value
+            )
+
+            for x, y, d in full_belts:
+                world_CWH[Channel.ENTITIES.value, x, y] = str2ent(
+                    "transport_belt"
+                ).value
+                world_CWH[Channel.DIRECTION.value, x, y] = d.value
+
+            tp, _ = factorion_rs.simulate_throughput(
+                world_CWH.permute(1, 2, 0).to(torch.int64).numpy()
+            )
+            if tp <= 0:
+                continue
+
+            total_entities = len(full_belts)
+            # Protect the source→intermediate stub: every belt from the
+            # source output up to and including the intermediate tile is
+            # never blanked, so even a full blank only strips the
+            # intermediate→sink belts.
+            protected_positions = frozenset(cells_a)
             break
         if count == 0:
             return None

--- a/tests/test_lesson_generation.py
+++ b/tests/test_lesson_generation.py
@@ -2413,3 +2413,228 @@ class TestFullBlankActuallyEmptiesWorld:
         assert int(inf_world[Channel.ENTITIES.value].count_nonzero()) == int(
             fin_world[Channel.ENTITIES.value].count_nonzero()
         )
+
+
+# ── MOVE_ONE_ITEM_CHAOS ──────────────────────────────────────────────────────
+#
+# MOVE_ONE_ITEM_CHAOS is like MOVE_ONE_ITEM, but the belt run is routed
+# through a random intermediate waypoint (a deliberately suboptimal path),
+# and only the intermediate→sink belts are removable. The source→intermediate
+# stub is protected and survives even a full (`inf`) blank, so the model
+# always starts from a bad partial layout and must finish the route to the
+# sink.
+
+
+class TestMoveOneItemChaosBasic:
+    """Basic sanity checks for MOVE_ONE_ITEM_CHAOS lesson generation."""
+
+    def test_generates_without_error(self):
+        factory = build_factory(
+            size=11, kind=LessonKind.MOVE_ONE_ITEM_CHAOS, seed=42
+        )
+        assert factory is not None
+        world, min_ent = blank_entities(factory, num_missing_entities=0)
+        assert world is not None
+        assert min_ent is not None
+
+    def test_returns_cwh_tensor(self):
+        size = 11
+        factory = build_factory(
+            size=size, kind=LessonKind.MOVE_ONE_ITEM_CHAOS, seed=42
+        )
+        assert factory is not None
+        world, _ = blank_entities(factory, num_missing_entities=0)
+        assert world.shape[0] == len(Channel)
+        assert world.shape[1] == size
+        assert world.shape[2] == size
+
+    def test_has_one_source_one_sink(self):
+        factory = build_factory(
+            size=11, kind=LessonKind.MOVE_ONE_ITEM_CHAOS, seed=42
+        )
+        assert factory is not None
+        world, _ = blank_entities(factory, num_missing_entities=0)
+        ent_layer = world[Channel.ENTITIES.value]
+        assert (ent_layer == str2ent("source").value).sum().item() == 1
+        assert (ent_layer == str2ent("sink").value).sum().item() == 1
+
+    def test_has_belts(self):
+        factory = build_factory(
+            size=11, kind=LessonKind.MOVE_ONE_ITEM_CHAOS, seed=42
+        )
+        assert factory is not None
+        world, _ = blank_entities(factory, num_missing_entities=0)
+        ent_layer = world[Channel.ENTITIES.value]
+        belt_count = (ent_layer == str2ent("transport_belt").value).sum().item()
+        assert belt_count >= 2, f"Expected at least 2 belts, got {belt_count}"
+
+    def test_source_sink_items_match(self):
+        factory = build_factory(
+            size=11, kind=LessonKind.MOVE_ONE_ITEM_CHAOS, seed=42
+        )
+        assert factory is not None
+        world, _ = blank_entities(factory, num_missing_entities=0)
+        ent_layer = world[Channel.ENTITIES.value]
+        item_layer = world[Channel.ITEMS.value]
+        src = (ent_layer == str2ent("source").value).nonzero(as_tuple=False)[0]
+        snk = (ent_layer == str2ent("sink").value).nonzero(as_tuple=False)[0]
+        src_item = item_layer[src[0], src[1]].item()
+        snk_item = item_layer[snk[0], snk[1]].item()
+        assert src_item != str2item("empty").value
+        assert src_item == snk_item
+
+
+class TestMoveOneItemChaosManySeeds:
+    """Generate many lessons with different seeds and verify all are valid."""
+
+    @pytest.mark.parametrize("seed", range(50))
+    def test_size_11_seed(self, seed):
+        factory = build_factory(
+            size=11, kind=LessonKind.MOVE_ONE_ITEM_CHAOS, seed=seed
+        )
+        assert factory is not None
+        world, _ = blank_entities(factory, num_missing_entities=0)
+        tp, _ = rs_throughput(world.permute(1, 2, 0))
+        assert tp > 0, f"seed={seed}: throughput is {tp}"
+
+    @pytest.mark.parametrize("size", [8, 10, 12, 15])
+    def test_grid_sizes(self, size):
+        factory = build_factory(
+            size=size, kind=LessonKind.MOVE_ONE_ITEM_CHAOS, seed=7
+        )
+        assert factory is not None
+        world, _ = blank_entities(factory, num_missing_entities=0)
+        tp, _ = rs_throughput(world.permute(1, 2, 0))
+        assert tp > 0
+
+
+class TestMoveOneItemChaosEntityDirections:
+    """All placed entities must have a non-NONE direction."""
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_all_entities_have_directions(self, seed):
+        factory = build_factory(
+            size=11, kind=LessonKind.MOVE_ONE_ITEM_CHAOS, seed=seed
+        )
+        assert factory is not None
+        world, _ = blank_entities(factory, num_missing_entities=0)
+        ent_layer = world[Channel.ENTITIES.value]
+        dir_layer = world[Channel.DIRECTION.value]
+        for x in range(world.shape[1]):
+            for y in range(world.shape[2]):
+                ent_val = ent_layer[x, y].item()
+                if ent_val != str2ent("empty").value:
+                    assert dir_layer[x, y].item() != Direction.NONE.value, (
+                        f"seed={seed}: entity {entities[ent_val].name} at "
+                        f"({x},{y}) has NONE direction"
+                    )
+
+
+class TestMoveOneItemChaosNoOverlaps:
+    """Verify no entity overlaps in generated factories."""
+
+    @pytest.mark.parametrize("seed", range(30))
+    def test_no_double_placement(self, seed):
+        factory = build_factory(
+            size=11, kind=LessonKind.MOVE_ONE_ITEM_CHAOS, seed=seed
+        )
+        assert factory is not None
+        world, _ = blank_entities(factory, num_missing_entities=0)
+        ent_layer = world[Channel.ENTITIES.value]
+        occupied = []
+        for x in range(world.shape[1]):
+            for y in range(world.shape[2]):
+                if ent_layer[x, y].item() != str2ent("empty").value:
+                    occupied.append((x, y))
+        assert len(occupied) == len(set(occupied)), (
+            f"seed={seed}: duplicate positions"
+        )
+
+
+class TestMoveOneItemChaosDeterminism:
+    """Same seed produces identical results."""
+
+    @pytest.mark.parametrize("seed", [0, 1, 42, 99])
+    def test_deterministic(self, seed):
+        f1 = build_factory(
+            size=11, kind=LessonKind.MOVE_ONE_ITEM_CHAOS, seed=seed
+        )
+        f2 = build_factory(
+            size=11, kind=LessonKind.MOVE_ONE_ITEM_CHAOS, seed=seed
+        )
+        assert f1 is not None and f2 is not None
+        w1, m1 = blank_entities(f1, num_missing_entities=0)
+        w2, m2 = blank_entities(f2, num_missing_entities=0)
+        assert torch.equal(w1, w2), f"seed={seed}: not deterministic"
+        assert m1 == m2
+
+
+class TestMoveOneItemChaosProtectedStub:
+    """The defining property of MOVE_ONE_ITEM_CHAOS: only the
+    intermediate→sink belts are removable. The source→intermediate stub is
+    protected and survives even a full (`inf`) blank, so the model always
+    starts from a suboptimal partial layout with real work left to do."""
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_protected_positions_nonempty(self, seed):
+        """A chaos lesson always has a protected source→intermediate stub."""
+        factory = build_factory(
+            size=11, kind=LessonKind.MOVE_ONE_ITEM_CHAOS, seed=seed
+        )
+        assert factory is not None
+        assert len(factory.protected_positions) > 0, (
+            f"seed={seed}: no protected stub — nothing distinguishes this "
+            f"from MOVE_ONE_ITEM"
+        )
+
+    @pytest.mark.parametrize("seed", range(20))
+    @pytest.mark.parametrize("num_missing", [1, 5, 100, float("inf")])
+    def test_protected_stub_never_blanked(self, seed, num_missing):
+        """The protected source→intermediate belts must remain at every
+        removal count, including a full blank."""
+        factory = build_factory(
+            size=11, kind=LessonKind.MOVE_ONE_ITEM_CHAOS, seed=seed
+        )
+        assert factory is not None
+        world, _ = blank_entities(factory, num_missing_entities=num_missing)
+        ent_layer = world[Channel.ENTITIES.value]
+        belt_val = str2ent("transport_belt").value
+        for (x, y) in factory.protected_positions:
+            assert ent_layer[x, y].item() == belt_val, (
+                f"seed={seed}, num_missing={num_missing}: protected stub "
+                f"belt at ({x},{y}) was blanked"
+            )
+
+    @pytest.mark.parametrize("seed", range(20))
+    def test_full_blank_leaves_only_protected_stub(self, seed):
+        """A full (`inf`) blank strips exactly the intermediate→sink belts,
+        leaving source, sink, and the protected stub. The remaining belts
+        must equal the protected set, and the partial must carry zero
+        throughput (the model has a route to finish)."""
+        factory = build_factory(
+            size=11, kind=LessonKind.MOVE_ONE_ITEM_CHAOS, seed=seed
+        )
+        assert factory is not None
+        solved_belts = (
+            factory.world_CWH[Channel.ENTITIES.value]
+            == str2ent("transport_belt").value
+        ).sum().item()
+
+        partial, removed = blank_entities(
+            factory, num_missing_entities=float("inf")
+        )
+        ent_layer = partial[Channel.ENTITIES.value]
+        belts_left = (ent_layer == str2ent("transport_belt").value).sum().item()
+        assert (ent_layer == str2ent("source").value).sum().item() == 1
+        assert (ent_layer == str2ent("sink").value).sum().item() == 1
+        # Only the protected stub remains; the rest was removed.
+        assert belts_left == len(factory.protected_positions)
+        assert removed > 0
+        assert removed == solved_belts - belts_left
+        # The stub goes source→intermediate but stops short of the sink,
+        # so the partial cannot deliver anything.
+        tp, _ = rs_throughput(partial.permute(1, 2, 0))
+        assert tp == 0.0, (
+            f"seed={seed}: partial still carries throughput {tp} — the "
+            f"protected stub should not reach the sink"
+        )


### PR DESCRIPTION
Like MOVE_ONE_ITEM, but the belt run is deliberately routed through a
random intermediate waypoint, making the source->sink path suboptimal.
Only the intermediate->sink belts are removable: the source->intermediate
stub (up to and including the intermediate tile) is protected via
protected_positions and survives even a full (inf) blank.

The model therefore always starts from a bad partial layout -- a
suboptimal stub already laid from the source -- and must still complete
the route to the sink, training robustness to suboptimal upstream
placement. SFT and PPO pick the new kind up automatically (both
enumerate LessonKind).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SebASH4S84uoeRuHxjo1d5