### PR TITLE
ci(sweeps): let run_cap + 6h timeout govern sweep size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,18 +41,13 @@ on:
         required: false
         default: false
         type: boolean
-      sweep_count:
-        description: "Total number of sweep iterations"
-        required: false
-        default: "20"
-        type: string
       sweep_agents:
         description: "Number of parallel sweep agents (RunPod pods)"
         required: false
         default: "1"
         type: string
       sweep_agents_per_pod:
-        description: "Parallel wandb agents per pod (GPU time-slicing). Keep below sweep_count so the bayes controller sees finished runs before suggesting more (else it's random search)."
+        description: "Parallel wandb agents per pod (GPU time-slicing). The total run count is set by run_cap in the sweep YAML, not here. Keep well below run_cap so the bayes controller sees finished runs before suggesting more (else it's random search)."
         required: false
         default: "5"
         type: string
@@ -394,7 +389,6 @@ jobs:
       sweep_path: ${{ steps.create.outputs.sweep_path }}
       sweep_url: ${{ steps.create.outputs.sweep_url }}
       matrix: ${{ steps.matrix.outputs.matrix }}
-      count_per_agent: ${{ steps.matrix.outputs.count_per_agent }}
       agents_per_pod: ${{ steps.matrix.outputs.agents_per_pod }}
     steps:
       - uses: actions/checkout@v4
@@ -432,12 +426,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           SWEEP_URL="${{ steps.create.outputs.sweep_url }}"
-          SWEEP_COUNT="${{ inputs.sweep_count || '20' }}"
+          RUN_CAP=$(python3 -c "import yaml; print(yaml.safe_load(open('sweep.yaml')).get('run_cap', 'unset'))")
           SWEEP_PODS="${{ inputs.sweep_agents || '1' }}"
           AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '5' }}"
           TOTAL_AGENTS=$(( SWEEP_PODS * AGENTS_PER_POD ))
           gh pr comment "${{ github.event.pull_request.number }}" --body "$(cat <<EOF
-          **W&B Sweep started** — ${SWEEP_COUNT} iterations across ${SWEEP_PODS} pod(s) x ${AGENTS_PER_POD} agents/pod (${TOTAL_AGENTS} total agents)
+          **W&B Sweep started** — running until run_cap (${RUN_CAP}, from sweep.yaml) or the 6h job timeout, across ${SWEEP_PODS} pod(s) x ${AGENTS_PER_POD} agents/pod (${TOTAL_AGENTS} total agents)
 
           [View sweep on W&B](${SWEEP_URL})
           EOF
@@ -448,15 +442,10 @@ jobs:
         run: |
           NUM_PODS="${{ inputs.sweep_agents || '1' }}"
           AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '5' }}"
-          TOTAL_COUNT="${{ inputs.sweep_count || '20' }}"
-          TOTAL_AGENTS=$(( NUM_PODS * AGENTS_PER_POD ))
-          COUNT_PER=$(( TOTAL_COUNT / TOTAL_AGENTS ))
 
-          # Ensure at least 1 iteration per agent process
-          if [ "$COUNT_PER" -lt 1 ]; then
-            COUNT_PER=1
-          fi
-
+          # No per-agent run count: each of the AGENTS_PER_POD `wandb agent`
+          # processes runs unbounded, draining the sweep until run_cap (set in
+          # sweep.yaml) is hit or the job times out. run_cap is the only cap.
           MATRIX=$(python3 -c "
           import json
           n = int('$NUM_PODS')
@@ -464,10 +453,8 @@ jobs:
           ")
 
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
-          echo "count_per_agent=$COUNT_PER" >> "$GITHUB_OUTPUT"
           echo "agents_per_pod=$AGENTS_PER_POD" >> "$GITHUB_OUTPUT"
           echo "Matrix: $MATRIX"
-          echo "Count per agent process: $COUNT_PER"
           echo "Agents per pod: $AGENTS_PER_POD"
 
   # ──────────────────────────────────────────────
@@ -479,7 +466,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.sweep-setup.outputs.matrix) }}
     runs-on: ubuntu-latest
-    timeout-minutes: 240
+    timeout-minutes: 350
     steps:
       - uses: actions/checkout@v4
         with:
@@ -504,7 +491,6 @@ jobs:
           POD_ID="${{ steps.runpod.outputs.pod_id }}"
           PR_NUMBER="${{ github.event.pull_request.number || 'manual' }}"
           SWEEP_PATH="${{ needs.sweep-setup.outputs.sweep_path }}"
-          COUNT_PER_AGENT="${{ needs.sweep-setup.outputs.count_per_agent }}"
           AGENTS_PER_POD="${{ needs.sweep-setup.outputs.agents_per_pod }}"
           AGENT_ID="${{ matrix.agent_id }}"
 
@@ -516,7 +502,6 @@ jobs:
             WANDB_API_KEY="$WANDB_API_KEY" \
             WANDB_PROJECT="${{ env.WANDB_CI_PROJECT }}" \
             SWEEP_ID="$SWEEP_PATH" \
-            SWEEP_COUNT="$COUNT_PER_AGENT" \
             AGENTS_PER_POD="$AGENTS_PER_POD" \
             AGENT_ID="$AGENT_ID" \
             PR_NUMBER="$PR_NUMBER" \
@@ -781,7 +766,6 @@ jobs:
       sweep_path: ${{ steps.create.outputs.sweep_path }}
       sweep_url: ${{ steps.create.outputs.sweep_url }}
       matrix: ${{ steps.matrix.outputs.matrix }}
-      count_per_agent: ${{ steps.matrix.outputs.count_per_agent }}
       agents_per_pod: ${{ steps.matrix.outputs.agents_per_pod }}
     steps:
       - uses: actions/checkout@v4
@@ -819,12 +803,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           SWEEP_URL="${{ steps.create.outputs.sweep_url }}"
+          RUN_CAP=$(python3 -c "import yaml; print(yaml.safe_load(open('sft_sweep.yaml')).get('run_cap', 'unset'))")
           SWEEP_PODS="${{ inputs.sweep_agents || '1' }}"
           AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '5' }}"
-          SWEEP_COUNT="${{ inputs.sweep_count || '30' }}"
           TOTAL_AGENTS=$(( SWEEP_PODS * AGENTS_PER_POD ))
           gh pr comment "${{ github.event.pull_request.number }}" --body "$(cat <<EOF
-          **SFT W&B Sweep started** — ${SWEEP_COUNT} iterations across ${SWEEP_PODS} pod(s) x ${AGENTS_PER_POD} agents/pod (${TOTAL_AGENTS} total agents)
+          **SFT W&B Sweep started** — running until run_cap (${RUN_CAP}, from sft_sweep.yaml) or the 6h job timeout, across ${SWEEP_PODS} pod(s) x ${AGENTS_PER_POD} agents/pod (${TOTAL_AGENTS} total agents)
 
           [View SFT sweep on W&B](${SWEEP_URL})
           EOF
@@ -835,14 +819,10 @@ jobs:
         run: |
           NUM_PODS="${{ inputs.sweep_agents || '1' }}"
           AGENTS_PER_POD="${{ inputs.sweep_agents_per_pod || '5' }}"
-          TOTAL_COUNT="${{ inputs.sweep_count || '30' }}"
-          TOTAL_AGENTS=$(( NUM_PODS * AGENTS_PER_POD ))
-          COUNT_PER=$(( TOTAL_COUNT / TOTAL_AGENTS ))
 
-          if [ "$COUNT_PER" -lt 1 ]; then
-            COUNT_PER=1
-          fi
-
+          # No per-agent run count: each of the AGENTS_PER_POD `wandb agent`
+          # processes runs unbounded, draining the sweep until run_cap (set in
+          # sft_sweep.yaml) is hit or the job times out. run_cap is the only cap.
           MATRIX=$(python3 -c "
           import json
           n = int('$NUM_PODS')
@@ -850,7 +830,6 @@ jobs:
           ")
 
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
-          echo "count_per_agent=$COUNT_PER" >> "$GITHUB_OUTPUT"
           echo "agents_per_pod=$AGENTS_PER_POD" >> "$GITHUB_OUTPUT"
 
   # ──────────────────────────────────────────────
@@ -862,7 +841,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.sft-sweep-setup.outputs.matrix) }}
     runs-on: ubuntu-latest
-    timeout-minutes: 240
+    timeout-minutes: 350
     steps:
       - uses: actions/checkout@v4
         with:
@@ -887,7 +866,6 @@ jobs:
           POD_ID="${{ steps.runpod.outputs.pod_id }}"
           PR_NUMBER="${{ github.event.pull_request.number || 'manual' }}"
           SWEEP_PATH="${{ needs.sft-sweep-setup.outputs.sweep_path }}"
-          COUNT_PER_AGENT="${{ needs.sft-sweep-setup.outputs.count_per_agent }}"
           AGENTS_PER_POD="${{ needs.sft-sweep-setup.outputs.agents_per_pod }}"
           AGENT_ID="${{ matrix.agent_id }}"
 
@@ -899,7 +877,6 @@ jobs:
             WANDB_API_KEY="$WANDB_API_KEY" \
             WANDB_PROJECT="${{ env.WANDB_CI_PROJECT }}" \
             SWEEP_ID="$SWEEP_PATH" \
-            SWEEP_COUNT="$COUNT_PER_AGENT" \
             AGENTS_PER_POD="$AGENTS_PER_POD" \
             AGENT_ID="$AGENT_ID" \
             PR_NUMBER="$PR_NUMBER" \

--- a/scripts/ci/gpu_sweep.sh
+++ b/scripts/ci/gpu_sweep.sh
@@ -15,7 +15,9 @@
 #   SWEEP_ID            - Full W&B sweep path (entity/project/sweep_id)
 #
 # Optional env vars:
-#   SWEEP_COUNT         - Number of iterations per agent process (default: 10)
+#   SWEEP_COUNT         - Max runs per agent process. Empty (default) = unbounded:
+#                         each agent keeps pulling runs until the sweep's run_cap
+#                         is reached or the job times out.
 #   AGENTS_PER_POD      - Number of parallel wandb agents on this pod (default: 1)
 #   WANDB_PROJECT       - W&B project name (default: factorion)
 #   PR_NUMBER           - PR number for tagging
@@ -27,7 +29,8 @@
 set -euo pipefail
 
 SWEEP_ID="${SWEEP_ID:?Must set SWEEP_ID (entity/project/sweep_id)}"
-SWEEP_COUNT="${SWEEP_COUNT:-10}"
+SWEEP_COUNT="${SWEEP_COUNT:-}"
+SWEEP_COUNT_DISPLAY="${SWEEP_COUNT:-unbounded (until run_cap)}"
 AGENTS_PER_POD="${AGENTS_PER_POD:-1}"
 WANDB_PROJECT="${WANDB_PROJECT:-factorion}"
 PR_NUMBER="${PR_NUMBER:-unknown}"
@@ -40,7 +43,7 @@ echo "============================================"
 echo "  GPU:             $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo 'unknown')"
 echo "  CUDA:            $(nvcc --version 2>/dev/null | tail -1 || echo 'unknown')"
 echo "  Sweep ID:        ${SWEEP_ID}"
-echo "  Iters/agent:     ${SWEEP_COUNT}"
+echo "  Runs/agent:      ${SWEEP_COUNT_DISPLAY}"
 echo "  Agents on pod:   ${AGENTS_PER_POD}"
 echo "  Pod ID:          ${AGENT_ID}"
 echo "  W&B project:     ${WANDB_PROJECT}"
@@ -48,11 +51,13 @@ echo "  PR:              ${PR_NUMBER}"
 echo "  Commit:          ${COMMIT_SHA}"
 echo "============================================"
 
-# ── Safety net: self-terminate after 4 hours if cleanup fails ─────
+# ── Safety net: self-terminate after 6.5 hours if cleanup fails ───
+# Backstop only — the GH job (timeout-minutes: 350) tears the pod down
+# first. This fires past the 6h GH hard limit only if that teardown fails.
 if [ -n "${RUNPOD_POD_ID:-}" ] && [ -n "${RUNPOD_API_KEY:-}" ]; then
-    echo ">>> Starting self-terminate watchdog (4h timeout)..."
+    echo ">>> Starting self-terminate watchdog (6.5h timeout)..."
     nohup bash -c "
-      sleep 14400
+      sleep 23400
       curl -s 'https://api.runpod.io/graphql?api_key=${RUNPOD_API_KEY}' \
         -H 'Content-Type: application/json' \
         -d '{\"query\": \"mutation { podTerminate(input: {podId: \\\"${RUNPOD_POD_ID}\\\"}) }\"}'
@@ -91,20 +96,28 @@ chmod +x run_sweep.sh
 export WANDB_API_KEY
 
 echo ""
-echo ">>> Launching ${AGENTS_PER_POD} parallel W&B sweep agents (${SWEEP_COUNT} iterations each)..."
+echo ">>> Launching ${AGENTS_PER_POD} parallel W&B sweep agents (${SWEEP_COUNT_DISPLAY} runs each)..."
 echo ">>> Sweep: ${SWEEP_ID}"
 echo ""
 
 # ── Launch sweep agents in parallel ──────────────────────────────
 # Each agent process independently pulls work from the W&B sweep controller.
 # CUDA time-slices between processes, keeping GPU utilisation high.
+# Pass --count only when SWEEP_COUNT is set; empty = unbounded, so the agent
+# drains the sweep until run_cap is reached or the job times out.
+COUNT_ARGS=()
+if [ -n "$SWEEP_COUNT" ]; then
+    COUNT_ARGS=(--count "$SWEEP_COUNT")
+fi
+
 PIDS=()
 mkdir -p /workspace/agent_logs
 
 for i in $(seq 0 $((AGENTS_PER_POD - 1))); do
     LOG="/workspace/agent_logs/agent_${AGENT_ID}_${i}.log"
     echo ">>> Starting agent ${AGENT_ID}.${i} (log: ${LOG})"
-    wandb agent --count "$SWEEP_COUNT" "$SWEEP_ID" > "$LOG" 2>&1 &
+    # ${COUNT_ARGS[@]+...} guards empty-array expansion under `set -u`.
+    wandb agent ${COUNT_ARGS[@]+"${COUNT_ARGS[@]}"} "$SWEEP_ID" > "$LOG" 2>&1 &
     PIDS+=($!)
 done
 
@@ -127,7 +140,7 @@ done
 echo ""
 echo "============================================"
 echo "  Sweep pod ${AGENT_ID} completed"
-echo "  Agents: ${AGENTS_PER_POD}, Iters/agent: ${SWEEP_COUNT}"
+echo "  Agents: ${AGENTS_PER_POD}, Runs/agent: ${SWEEP_COUNT_DISPLAY}"
 echo "  Failed agents: ${FAILED}/${AGENTS_PER_POD}"
 echo "============================================"
 

--- a/scripts/ci/sft_sweep.sh
+++ b/scripts/ci/sft_sweep.sh
@@ -14,7 +14,9 @@
 #   SWEEP_ID            - Full W&B sweep path (entity/project/sweep_id)
 #
 # Optional env vars:
-#   SWEEP_COUNT         - Number of iterations per agent process (default: 10)
+#   SWEEP_COUNT         - Max runs per agent process. Empty (default) = unbounded:
+#                         each agent keeps pulling runs until the sweep's run_cap
+#                         is reached or the job times out.
 #   AGENTS_PER_POD      - Number of parallel wandb agents on this pod (default: 1)
 #   WANDB_PROJECT       - W&B project name (default: factorion)
 #   PR_NUMBER           - PR number for tagging
@@ -26,7 +28,8 @@
 set -euo pipefail
 
 SWEEP_ID="${SWEEP_ID:?Must set SWEEP_ID (entity/project/sweep_id)}"
-SWEEP_COUNT="${SWEEP_COUNT:-10}"
+SWEEP_COUNT="${SWEEP_COUNT:-}"
+SWEEP_COUNT_DISPLAY="${SWEEP_COUNT:-unbounded (until run_cap)}"
 AGENTS_PER_POD="${AGENTS_PER_POD:-1}"
 WANDB_PROJECT="${WANDB_PROJECT:-factorion}"
 PR_NUMBER="${PR_NUMBER:-unknown}"
@@ -39,7 +42,7 @@ echo "============================================"
 echo "  GPU:             $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo 'unknown')"
 echo "  CUDA:            $(nvcc --version 2>/dev/null | tail -1 || echo 'unknown')"
 echo "  Sweep ID:        ${SWEEP_ID}"
-echo "  Iters/agent:     ${SWEEP_COUNT}"
+echo "  Runs/agent:      ${SWEEP_COUNT_DISPLAY}"
 echo "  Agents on pod:   ${AGENTS_PER_POD}"
 echo "  Pod ID:          ${AGENT_ID}"
 echo "  W&B project:     ${WANDB_PROJECT}"
@@ -47,11 +50,13 @@ echo "  PR:              ${PR_NUMBER}"
 echo "  Commit:          ${COMMIT_SHA}"
 echo "============================================"
 
-# ── Safety net: self-terminate after 4 hours if cleanup fails ─────
+# ── Safety net: self-terminate after 6.5 hours if cleanup fails ───
+# Backstop only — the GH job (timeout-minutes: 350) tears the pod down
+# first. This fires past the 6h GH hard limit only if that teardown fails.
 if [ -n "${RUNPOD_POD_ID:-}" ] && [ -n "${RUNPOD_API_KEY:-}" ]; then
-    echo ">>> Starting self-terminate watchdog (4h timeout)..."
+    echo ">>> Starting self-terminate watchdog (6.5h timeout)..."
     nohup bash -c "
-      sleep 14400
+      sleep 23400
       curl -s 'https://api.runpod.io/graphql?api_key=${RUNPOD_API_KEY}' \
         -H 'Content-Type: application/json' \
         -d '{\"query\": \"mutation { podTerminate(input: {podId: \\\"${RUNPOD_POD_ID}\\\"}) }\"}'
@@ -88,18 +93,26 @@ chmod +x run_sft_sweep.sh
 export WANDB_API_KEY
 
 echo ""
-echo ">>> Launching ${AGENTS_PER_POD} parallel W&B sweep agents (${SWEEP_COUNT} iterations each)..."
+echo ">>> Launching ${AGENTS_PER_POD} parallel W&B sweep agents (${SWEEP_COUNT_DISPLAY} runs each)..."
 echo ">>> Sweep: ${SWEEP_ID}"
 echo ""
 
 # ── Launch sweep agents in parallel ──────────────────────────────
+# Pass --count only when SWEEP_COUNT is set; empty = unbounded, so the agent
+# drains the sweep until run_cap is reached or the job times out.
+COUNT_ARGS=()
+if [ -n "$SWEEP_COUNT" ]; then
+    COUNT_ARGS=(--count "$SWEEP_COUNT")
+fi
+
 PIDS=()
 mkdir -p /workspace/agent_logs
 
 for i in $(seq 0 $((AGENTS_PER_POD - 1))); do
     LOG="/workspace/agent_logs/sft_agent_${AGENT_ID}_${i}.log"
     echo ">>> Starting SFT agent ${AGENT_ID}.${i} (log: ${LOG})"
-    wandb agent --count "$SWEEP_COUNT" "$SWEEP_ID" > "$LOG" 2>&1 &
+    # ${COUNT_ARGS[@]+...} guards empty-array expansion under `set -u`.
+    wandb agent ${COUNT_ARGS[@]+"${COUNT_ARGS[@]}"} "$SWEEP_ID" > "$LOG" 2>&1 &
     PIDS+=($!)
 done
 
@@ -122,7 +135,7 @@ done
 echo ""
 echo "============================================"
 echo "  SFT Sweep pod ${AGENT_ID} completed"
-echo "  Agents: ${AGENTS_PER_POD}, Iters/agent: ${SWEEP_COUNT}"
+echo "  Agents: ${AGENTS_PER_POD}, Runs/agent: ${SWEEP_COUNT_DISPLAY}"
 echo "  Failed agents: ${FAILED}/${AGENTS_PER_POD}"
 echo "============================================"
 

--- a/sft_sweep.yaml
+++ b/sft_sweep.yaml
@@ -11,7 +11,7 @@
 #   - data-shape tradeoffs: batch_size, max_level, tile_head_std
 
 method: bayes
-run_cap: 60
+run_cap: 30
 metric:
   name: "val/acc"
   goal: maximize

--- a/sweep.yaml
+++ b/sweep.yaml
@@ -1,7 +1,7 @@
 # sweep.yaml — PPO hyperparameter sweep
 
 method: bayes
-run_cap: 20
+run_cap: 30
 metric:
   name: "eval/throughput_eot"
   goal: maximize


### PR DESCRIPTION
## What & why

CI sweep run counts were capped by a `sweep_count` workflow input (default 20 PPO / 30 SFT), divided across agents and passed as `wandb agent --count`. That client-side cap bound *before* the YAML `run_cap`, so editing `run_cap` had no effect — the real ceiling was a hidden 20.

This makes the sweep YAML's **`run_cap`** the single authority on total runs, bounded only by wall-clock.

## Changes

- **`scripts/ci/gpu_sweep.sh` + `sft_sweep.sh`**: `SWEEP_COUNT` is now optional. Empty (the new default) runs `wandb agent` with **no `--count`**, so each agent drains the sweep until `run_cap` is hit (then exits cleanly) or the job times out. A set value still caps per-agent for quick tests. Guarded array expansion keeps `set -u` happy when unbounded. Self-terminate watchdog 4h → 6.5h so it only backstops a failed teardown.
- **`.github/workflows/ci.yml`**: dropped the `sweep_count` input and the count/agent division (and dead `count_per_agent` plumbing); agents run unbounded. Sweep jobs `timeout-minutes: 240 → 350` (full 6h GH cap, ~10 min reserved for the `always()` RunPod teardown). PR "Sweep started" comments now show the actual `run_cap` parsed from the YAML.
- **`sweep.yaml` / `sft_sweep.yaml`**: `run_cap` set to **30** each (were 20 / 60).

`sweep_agents` (pods) and `sweep_agents_per_pod` (GPU time-slicing) still control parallelism — just not the total count.

## How to control sweep size

Edit `run_cap` in `sweep.yaml` (PPO) or `sft_sweep.yaml` (SFT). The 6h job timeout is the wall-clock ceiling.

> Note: W&B's keyword is `run_cap`, not `max_runs`.

## Validation

`shellcheck` + `bash -n` clean; `ci.yml` parses as YAML; `ruff` passes; `run_cap` extraction returns 30/30. Launch loop verified end-to-end under bash 3.2 (stricter than CI's bash 5.x) with a stubbed `wandb`: unbounded path emits `wandb agent <sweep_id>` (no `--count`, no `set -u` error); override path emits `--count N`.

Heavy checklist steps (maturin rebuild, pytest, PPO/SFT smoke) were skipped — this change touches only CI YAML and bash, not engine/policy code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)