### PR TITLE
metrics: rename W&B keys throughput → thput (+ per-lesson rollout/{LESSON}/thput_raw)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Historically the project did RL-from-scratch with heavy scaffolding (curriculum 
 Runs are named by a hyperparameter signature, not a timestamp (`ppo.py:_run_signature`, `sft.py:_artifact_name`), e.g. `ppo-s11-lr5e-05-ent0-cw10-fromj0s5y2mc-c93-69-96-seed1`. `global_step` (env steps) is the PPO x-axis. PPO logs once per iteration into these sections (see `define_metric` block in `ppo.py`):
 
 - **`eval/`** — periodic greedy held-out throughput (`eval/throughput`, `eval/throughput_eot`, `eval/{LESSON}/*`), every `--eval-every` iters; directly overlay-able with the SFT baseline. **This is the headline progress signal**, and the sweep metric (`sweep.yaml`).
-- **`rollout/`** — on-policy sampled episode stats (`throughput`, `thput_raw`, `reward`, `length`, `eot_rate`, `invalid_frac`, `num_entities`, `entity_efficiency`, `frac_reachable`) + per-lesson `rollout/{LESSON}/{throughput,reward,length}`.
+- **`rollout/`** — on-policy sampled episode stats (`throughput`, `thput_raw`, `reward`, `length`, `eot_rate`, `invalid_frac`, `num_entities`, `entity_efficiency`, `frac_reachable`) + per-lesson `rollout/{LESSON}/{throughput,thput_raw,reward,length}` (raw items/s kept alongside the normalized throughput so lessons with very different ceilings stay comparable).
 - **`policy/`** — acting-policy distribution: `entropy`, per-head `entropy_{tile,entity,direction,item,misc,eot}`, `eot_prob`.
 - **`losses/`** `policy,value,entropy,total,approx_kl,clipfrac,explained_variance`; **`optim/`** `lr,critic_lr,ent_coef,grad_norm,critic_warmup`; **`perf/`** `sps,rollout_seconds,update_seconds,eval_seconds`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ The training pipeline is moving toward an **LLM-style two-stage split**:
 
 1. **Data generation** — `build_factory()` in `factorion.py` constructs a known-correct factory (returning `Optional[Factory]`), then `blank_entities()` produces a *(partial-factory, correct-completion)* training pair by removing N entities from it. Each lesson type (`MOVE_ONE_ITEM`, `SPLITTER_SPLIT`, `SPLITTER_MERGE`, …) covers a different entity or layout pattern.
 2. **SFT pretraining** — `sft.py` runs supervised training on those pairs, giving the policy a strong prior over entity placement. It uploads the best checkpoint as a W&B artifact (type `model`, containing `sft_checkpoint.pt`) so RL can pull it by run id.
-3. **RL finetuning** — PPO (`ppo.py`) refines the pretrained policy to push beyond what imitation achieves. Load an SFT checkpoint with `--start-from` (accepts **either** a local `.pt` path **or** a W&B run id like `j0s5y2mc` — the run's model artifact is downloaded automatically). Every episode builds from a **fully-blank** grid (no curriculum). The canonical SFT base is run **`j0s5y2mc`**; the bar PPO must clear is its `val/throughput_eot ≈ 0.11` (see "Throughput metrics" below).
+3. **RL finetuning** — PPO (`ppo.py`) refines the pretrained policy to push beyond what imitation achieves. Load an SFT checkpoint with `--start-from` (accepts **either** a local `.pt` path **or** a W&B run id like `j0s5y2mc` — the run's model artifact is downloaded automatically). Every episode builds from a **fully-blank** grid (no curriculum). The canonical SFT base is run **`j0s5y2mc`**; the bar PPO must clear is its `val/thput_eot ≈ 0.11` (see "Throughput metrics" below).
 
 Historically the project did RL-from-scratch with heavy scaffolding (curriculum on `num_missing_entities`, reward shaping, action masking) to handle the sparse-reward problem. Most of that scaffolding still exists but its role changes under the new pipeline: the curriculum axis becomes a data-sampling knob during SFT, and RL starts from a much better policy so sparse rewards matter less.
 
@@ -52,25 +52,25 @@ Historically the project did RL-from-scratch with heavy scaffolding (curriculum 
 - **State tensor** is `(C, W, H)` with `C = len(Channel) = 5` channels: `ENTITIES`, `DIRECTION`, `ITEMS` (recipe/filter), `MISC` (underground up/down), `FOOTPRINT` (1 = buildable).
 - **Lessons** (`LessonKind` in `factorion.py`): `MOVE_ONE_ITEM`, `SPLITTER_SPLIT`, `SPLITTER_MERGE`, `ASSEMBLE_1IN_1OUT`, `MOVE_VIA_UG_BELT`, `ASSEMBLE_2IN_1OUT`, `FROM_BLUEPRINT`. Each `build_factory(size, kind, seed, ...)` returns `Optional[Factory]` (rejection sampling can fail → `None`); `blank_entities(factory, num_missing_entities, seed)` removes N entity *units* (multi-tile entities count as one).
 - **`ppo.py`**: `Args` (all PPO hyperparams + `start_from`, `critic_warmup`, `eval_every`), `FactorioEnv` (`reset`/`step`; reward = `-step_penalty` per step `+ throughput_reward_scale * thput_normed` on termination; `eot` is a real action that ends the episode; `info['kind']` carries the lesson for per-lesson logging), `AgentCNN` (encoder + per-head outputs: tile/entity/direction/item/misc + `critic_head` + `eot_head`; stashes `_last_head_entropy`/`_last_eot_prob` for the policy/* metrics), `_resolve_start_from`/`_resolve_wandb_checkpoint` (checkpoint loading), `_run_signature` (run name), `_build_eval_set`/`_run_greedy_eval` (the eval/ section).
-- **`sft.py`**: `run_rollout_eval` returns `RolloutEval` with `overall`/`overall_eot` and per-`LessonKind` breakdowns; checkpoint is selected on `val/throughput` (EOT ignored). PPO reuses this for its `eval/` metrics (lazy import to avoid the ppo↔sft cycle).
+- **`sft.py`**: `run_rollout_eval` returns `RolloutEval` with `overall`/`overall_eot` and per-`LessonKind` breakdowns; checkpoint is selected on `val/thput` (EOT ignored). PPO reuses this for its `eval/` metrics (lazy import to avoid the ppo↔sft cycle).
 
 ## W&B dashboards
 
 Runs are named by a hyperparameter signature, not a timestamp (`ppo.py:_run_signature`, `sft.py:_artifact_name`), e.g. `ppo-s11-lr5e-05-ent0-cw10-fromj0s5y2mc-c93-69-96-seed1`. `global_step` (env steps) is the PPO x-axis. PPO logs once per iteration into these sections (see `define_metric` block in `ppo.py`):
 
-- **`eval/`** — periodic greedy held-out throughput (`eval/throughput`, `eval/throughput_eot`, `eval/{LESSON}/*`), every `--eval-every` iters; directly overlay-able with the SFT baseline. **This is the headline progress signal**, and the sweep metric (`sweep.yaml`).
-- **`rollout/`** — on-policy sampled episode stats (`throughput`, `thput_raw`, `reward`, `length`, `eot_rate`, `invalid_frac`, `num_entities`, `entity_efficiency`, `frac_reachable`) + per-lesson `rollout/{LESSON}/{throughput,thput_raw,reward,length}` (raw items/s kept alongside the normalized throughput so lessons with very different ceilings stay comparable).
+- **`eval/`** — periodic greedy held-out throughput (`eval/thput`, `eval/thput_eot`, `eval/{LESSON}/*`), every `--eval-every` iters; directly overlay-able with the SFT baseline. **This is the headline progress signal**, and the sweep metric (`sweep.yaml`).
+- **`rollout/`** — on-policy sampled episode stats (`thput`, `thput_raw`, `reward`, `length`, `eot_rate`, `invalid_frac`, `num_entities`, `entity_efficiency`, `frac_reachable`) + per-lesson `rollout/{LESSON}/{thput,thput_raw,reward,length}` (raw items/s kept alongside the normalized throughput so lessons with very different ceilings stay comparable).
 - **`policy/`** — acting-policy distribution: `entropy`, per-head `entropy_{tile,entity,direction,item,misc,eot}`, `eot_prob`.
 - **`losses/`** `policy,value,entropy,total,approx_kl,clipfrac,explained_variance`; **`optim/`** `lr,critic_lr,ent_coef,grad_norm,critic_warmup`; **`perf/`** `sps,rollout_seconds,update_seconds,eval_seconds`.
 
-## Throughput metrics (`throughput` vs `throughput_eot`)
+## Throughput metrics (`thput` vs `thput_eot`)
 
 Both come from a greedy rollout that blanks the **whole** grid and rebuilds from empty (the honest "can it build from scratch" test). Per-factory throughput is `info['thput_normed']` ∈ [0, 1] — raw items/sec ÷ that factory's max, so a perfectly-rebuilt factory scores 1.0 regardless of belt speed. Defined in `sft.py:run_rollout_eval`:
 
-- **`throughput`** (`overall`) — build skill *ignoring* the EOT head: step until the env finishes (throughput 1.0 or max_steps) and take the final throughput. "Can the model physically reconstruct the factory?"
-- **`throughput_eot`** (`overall_eot`) — build skill *respecting* the EOT head: snapshot the throughput the first time the EOT prob crosses `rollout_eot_threshold` (0.5); if it never fires, fall back to the final throughput. "How good is the factory at the moment the model decides it's done?"
+- **`thput`** (`overall`) — build skill *ignoring* the EOT head: step until the env finishes (throughput 1.0 or max_steps) and take the final throughput. "Can the model physically reconstruct the factory?"
+- **`thput_eot`** (`overall_eot`) — build skill *respecting* the EOT head: snapshot the throughput the first time the EOT prob crosses `rollout_eot_threshold` (0.5); if it never fires, fall back to the final throughput. "How good is the factory at the moment the model decides it's done?"
 
-`throughput_eot ≤ throughput` whenever the model stops early. **The RL goal is for PPO's achieved throughput to exceed the SFT base's `val/throughput_eot` (≈0.11 for `j0s5y2mc`).** Per-lesson the SFT base is uneven (MOVE_ONE_ITEM ~0.38, assembler lessons ~0).
+`thput_eot ≤ thput` whenever the model stops early. **The RL goal is for PPO's achieved throughput to exceed the SFT base's `val/thput_eot` (≈0.11 for `j0s5y2mc`).** Per-lesson the SFT base is uneven (MOVE_ONE_ITEM ~0.38, assembler lessons ~0).
 
 ## SFT → PPO handoff
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ throughput=0) bites much less than in the original RL-from-scratch setup.
 Point `--start-from` at either a local `.pt` file or a W&B run id (e.g. an SFT
 run like `j0s5y2mc`, whose model artifact is fetched automatically), and use
 `--critic-warmup` to train the fresh value head before unfreezing the policy.
-The aim is for PPO to beat the SFT base's `val/throughput_eot`.
+The aim is for PPO to beat the SFT base's `val/thput_eot`.
 
 Historically the project trained RL from scratch with an explicit curriculum
 that ramped `num_missing_entities` over time. That scaffolding still exists

--- a/ppo.py
+++ b/ppo.py
@@ -147,7 +147,7 @@ class Args:
     critic_warmup: int = 0
     """Freeze the actor (encoder + all policy heads) for this many PPO iterations and train only the critic head, then unfreeze. An SFT checkpoint loads a trained actor but a random critic; without a warm-up the random critic's garbage advantages wreck the SFT policy in the first updates. 0 disables (default, preserves from-scratch behaviour). LR + entropy annealing start at unfreeze."""
     eval_every: int = 7
-    """Run the greedy held-out eval (eval/throughput, eval/throughput_eot, per-lesson) every N PPO iterations (and on the final iteration). Mirrors the SFT rollout eval so the curves overlay the SFT baseline. 0 disables."""
+    """Run the greedy held-out eval (eval/thput, eval/thput_eot, per-lesson) every N PPO iterations (and on the final iteration). Mirrors the SFT rollout eval so the curves overlay the SFT baseline. 0 disables."""
     eval_seeds_per_kind: int = 12
     """Held-out factories per LessonKind in the greedy eval set."""
     eval_num_envs: int = 8
@@ -204,7 +204,7 @@ def _build_eval_set(args) -> dict:
 
 
 def _run_greedy_eval(agent, args, eval_seeds_to_kind, device) -> dict:
-    """Greedy held-out throughput eval, mirroring SFT's val/throughput[_eot] so
+    """Greedy held-out throughput eval, mirroring SFT's val/thput[_eot] so
     the curves overlay. Returns a flat dict of eval/* metrics. Reuses SFT's
     run_rollout_eval (lazy import: sft imports ppo, so a top-level import would
     be circular); it only reads .size/.seed/.max_level off args, hence the shim."""
@@ -224,15 +224,15 @@ def _run_greedy_eval(agent, args, eval_seeds_to_kind, device) -> dict:
         num_envs=args.eval_num_envs,
     )
     metrics = {
-        "eval/throughput": roll["overall"],
-        "eval/throughput_eot": roll["overall_eot"],
+        "eval/thput": roll["overall"],
+        "eval/thput_eot": roll["overall_eot"],
     }
     for kn, thp in roll["per_kind"].items():
         if roll["per_kind_n"].get(kn, 0) > 0:
-            metrics[f"eval/{kn}/throughput"] = thp
+            metrics[f"eval/{kn}/thput"] = thp
     for kn, thp in roll["per_kind_eot"].items():
         if roll["per_kind_n"].get(kn, 0) > 0:
-            metrics[f"eval/{kn}/throughput_eot"] = thp
+            metrics[f"eval/{kn}/thput_eot"] = thp
     return metrics
 
 
@@ -258,7 +258,7 @@ def _rollout_episode_metrics(
     vs assemblers <1/s) stay comparable in raw terms.
     """
     return {
-        "rollout/throughput": float(thput_normed),
+        "rollout/thput": float(thput_normed),
         "rollout/thput_raw": float(thput_raw),
         "rollout/reward": float(episode_return),
         "rollout/length": float(episode_len),
@@ -268,7 +268,7 @@ def _rollout_episode_metrics(
         "rollout/entity_efficiency": float(min_entities_required) / float(num_entities),
         "rollout/frac_reachable": float(frac_reachable),
         # Per-lesson breakdown — each averages over only this lesson's episodes.
-        f"rollout/{lesson}/throughput": float(thput_normed),
+        f"rollout/{lesson}/thput": float(thput_normed),
         f"rollout/{lesson}/thput_raw": float(thput_raw),
         f"rollout/{lesson}/reward": float(episode_return),
         f"rollout/{lesson}/length": float(episode_len),
@@ -1275,18 +1275,18 @@ if __name__ == "__main__":
         # the headline progress signal, so it summarises to its max.
         wandb.define_metric("*", step_metric="global_step")
         _LESSONS = [k.name for k in LessonKind]
-        wandb.define_metric("eval/throughput", summary="max")
-        wandb.define_metric("eval/throughput_eot", summary="max")
+        wandb.define_metric("eval/thput", summary="max")
+        wandb.define_metric("eval/thput_eot", summary="max")
         wandb.define_metric("eval/seconds", summary="last")
         for ln in _LESSONS:
-            wandb.define_metric(f"eval/{ln}/throughput", summary="max")
-            wandb.define_metric(f"eval/{ln}/throughput_eot", summary="max")
-        for m in ["throughput", "thput_raw", "reward", "length", "eot_rate",
+            wandb.define_metric(f"eval/{ln}/thput", summary="max")
+            wandb.define_metric(f"eval/{ln}/thput_eot", summary="max")
+        for m in ["thput", "thput_raw", "reward", "length", "eot_rate",
                   "invalid_frac", "num_entities", "entity_efficiency",
                   "frac_reachable"]:
             wandb.define_metric(f"rollout/{m}", summary="last")
         for ln in _LESSONS:
-            for m in ["throughput", "thput_raw", "reward", "length"]:
+            for m in ["thput", "thput_raw", "reward", "length"]:
                 wandb.define_metric(f"rollout/{ln}/{m}", summary="last")
         for m in ["entropy", "eot_prob"]:
             wandb.define_metric(f"policy/{m}", summary="last")
@@ -1438,7 +1438,7 @@ if __name__ == "__main__":
         return means
 
     # Fixed held-out greedy-eval set (disjoint from training seeds), used to log
-    # eval/* — directly comparable to the SFT baseline's val/throughput[_eot].
+    # eval/* — directly comparable to the SFT baseline's val/thput[_eot].
     eval_seeds_to_kind = _build_eval_set(args) if args.eval_every > 0 else {}
     if eval_seeds_to_kind:
         print(f"Greedy eval: {len(eval_seeds_to_kind)} held-out factories, "

--- a/ppo.py
+++ b/ppo.py
@@ -236,6 +236,45 @@ def _run_greedy_eval(agent, args, eval_seeds_to_kind, device) -> dict:
     return metrics
 
 
+def _rollout_episode_metrics(
+    lesson: str,
+    *,
+    episode_return: float,
+    episode_len: float,
+    thput_normed: float,
+    thput_raw: float,
+    ended_by_eot: float,
+    invalid_frac: float,
+    num_entities: float,
+    min_entities_required: float,
+    frac_reachable: float,
+) -> dict:
+    """Build the rollout/* metrics for one finished episode (overall + per-lesson).
+
+    Pure (no wandb/torch) so it can be unit-tested. The per-lesson keys carry
+    the lesson name, so each averages over only that lesson's episodes. Both the
+    overall and per-lesson views log thput_raw (items/s) alongside the
+    normalized throughput, so lessons with very different ceilings (belts ~15/s
+    vs assemblers <1/s) stay comparable in raw terms.
+    """
+    return {
+        "rollout/throughput": float(thput_normed),
+        "rollout/thput_raw": float(thput_raw),
+        "rollout/reward": float(episode_return),
+        "rollout/length": float(episode_len),
+        "rollout/eot_rate": float(ended_by_eot),
+        "rollout/invalid_frac": float(invalid_frac),
+        "rollout/num_entities": float(num_entities),
+        "rollout/entity_efficiency": float(min_entities_required) / float(num_entities),
+        "rollout/frac_reachable": float(frac_reachable),
+        # Per-lesson breakdown — each averages over only this lesson's episodes.
+        f"rollout/{lesson}/throughput": float(thput_normed),
+        f"rollout/{lesson}/thput_raw": float(thput_raw),
+        f"rollout/{lesson}/reward": float(episode_return),
+        f"rollout/{lesson}/length": float(episode_len),
+    }
+
+
 def _resolve_wandb_checkpoint(
     run_spec: str, project: str, entity: Optional[str]
 ) -> tuple[str, dict]:
@@ -1247,7 +1286,7 @@ if __name__ == "__main__":
                   "frac_reachable"]:
             wandb.define_metric(f"rollout/{m}", summary="last")
         for ln in _LESSONS:
-            for m in ["throughput", "reward", "length"]:
+            for m in ["throughput", "thput_raw", "reward", "length"]:
                 wandb.define_metric(f"rollout/{ln}/{m}", summary="last")
         for m in ["entropy", "eot_prob"]:
             wandb.define_metric(f"policy/{m}", summary="last")
@@ -1513,22 +1552,18 @@ if __name__ == "__main__":
 
                     end_of_episode_thputs.append(end_of_episode_thput)
 
-                    _record_episode({
-                        "rollout/throughput": float(end_of_episode_thput),
-                        "rollout/thput_raw": float(end_of_episode_thput_raw),
-                        "rollout/reward": float(episode_return),
-                        "rollout/length": float(episode_len),
-                        "rollout/eot_rate": ended_by_eot,
-                        "rollout/invalid_frac": float(infos['frac_invalid_actions'][i]),
-                        "rollout/num_entities": float(infos['num_entities'][i]),
-                        "rollout/entity_efficiency": float(infos['min_entities_required'][i]) / float(infos['num_entities'][i]),
-                        "rollout/frac_reachable": float(infos["frac_reachable"][i]),
-                        # Per-lesson breakdown — each averages over only this
-                        # lesson's episodes (the key is recorded just for them).
-                        f"rollout/{lesson}/throughput": float(end_of_episode_thput),
-                        f"rollout/{lesson}/reward": float(episode_return),
-                        f"rollout/{lesson}/length": float(episode_len),
-                    })
+                    _record_episode(_rollout_episode_metrics(
+                        lesson,
+                        episode_return=episode_return,
+                        episode_len=episode_len,
+                        thput_normed=end_of_episode_thput,
+                        thput_raw=end_of_episode_thput_raw,
+                        ended_by_eot=ended_by_eot,
+                        invalid_frac=infos['frac_invalid_actions'][i],
+                        num_entities=infos['num_entities'][i],
+                        min_entities_required=infos['min_entities_required'][i],
+                        frac_reachable=infos["frac_reachable"][i],
+                    ))
 
         rollout_seconds = time.time() - rollout_start
 

--- a/scripts/ci/apply_sft_sweep_best.py
+++ b/scripts/ci/apply_sft_sweep_best.py
@@ -140,7 +140,7 @@ def main():
         sys.exit(1)
 
     metric_cfg = sweep.config.get("metric", {})
-    metric_name = metric_cfg.get("name", "val/throughput")
+    metric_name = metric_cfg.get("name", "val/thput")
     metric_goal = metric_cfg.get("goal", "maximize")
     reverse = metric_goal == "maximize"
 

--- a/scripts/ci/apply_sweep_best.py
+++ b/scripts/ci/apply_sweep_best.py
@@ -149,7 +149,7 @@ def main():
         sys.exit(1)
 
     metric_cfg = sweep.config.get("metric", {})
-    metric_name = metric_cfg.get("name", "eval/throughput_eot")
+    metric_name = metric_cfg.get("name", "eval/thput_eot")
     metric_goal = metric_cfg.get("goal", "maximize")
     reverse = metric_goal == "maximize"
 

--- a/sft.py
+++ b/sft.py
@@ -214,7 +214,7 @@ class SFTArgs:
     eval_rollouts_num_envs: int = 8
     """parallel envs for rollout eval; batches the CNN forward across them"""
     rollout_eot_threshold: float = 0.5
-    """EOT-head prob above which we mark the model "would stop" (for val/throughput_eot)"""
+    """EOT-head prob above which we mark the model "would stop" (for val/thput_eot)"""
     checkpoint_path: str = "sft_checkpoint.pt"
     """path to save the trained model"""
     # CNN encoder width per layer slot (see ppo.layers_from_args). A slot of 0
@@ -481,7 +481,7 @@ def run_rollout_eval(
     final throughput. The mean of those snapshots is `overall_eot`.
 
     The (seed, kind) pairs are exactly the val_accuracy set — so a rise
-    in `val/throughput` over training is directly comparable to the
+    in `val/thput` over training is directly comparable to the
     existing per-kind val accuracy curves.
 
     Returns a dict with:
@@ -1462,7 +1462,7 @@ def train_sft(args: SFTArgs):
 
         # Rollout eval: every N epochs greedy-play the held-out factories
         # and record final throughput. Same lessons as val accuracy, so
-        # val/throughput is directly comparable to val/acc curves.
+        # val/thput is directly comparable to val/acc curves.
         do_rollout = args.eval_rollouts_every_n_epochs > 0 and (
             epoch % args.eval_rollouts_every_n_epochs == 0 or epoch == args.epochs
         )
@@ -1480,18 +1480,18 @@ def train_sft(args: SFTArgs):
             rollout_seconds = time.time() - t_rollout
             overall_thp = roll["overall"]
             per_kind_thp_n = roll["per_kind_n"]
-            # val/throughput ignores the EOT head (true build skill, and the
-            # default checkpoint-selection metric); val/throughput_eot stops
+            # val/thput ignores the EOT head (true build skill, and the
+            # default checkpoint-selection metric); val/thput_eot stops
             # at the first EOT fire (what the model's own stop head produces).
-            per_kind_metrics["val/throughput"] = overall_thp
-            per_kind_metrics["val/throughput_eot"] = roll["overall_eot"]
+            per_kind_metrics["val/thput"] = overall_thp
+            per_kind_metrics["val/thput_eot"] = roll["overall_eot"]
             per_kind_metrics["val/rollout_seconds"] = rollout_seconds
             for kn, thp in roll["per_kind"].items():
                 if per_kind_thp_n[kn] > 0:
-                    per_kind_metrics[f"val/{kn}/throughput"] = thp
+                    per_kind_metrics[f"val/{kn}/thput"] = thp
             for kn, thp in roll["per_kind_eot"].items():
                 if per_kind_thp_n[kn] > 0:
-                    per_kind_metrics[f"val/{kn}/throughput_eot"] = thp
+                    per_kind_metrics[f"val/{kn}/thput_eot"] = thp
         else:
             overall_thp = None
             rollout_seconds = None
@@ -1533,7 +1533,7 @@ def train_sft(args: SFTArgs):
             # across proportionally different x-ranges. Crucially, _step is
             # the axis EVERY default panel plots against — including ones
             # already pinned to "Step" in an existing workspace — so this
-            # fixes panels (e.g. val/<kind>/throughput) that define_metric's
+            # fixes panels (e.g. val/<kind>/thput) that define_metric's
             # step_metric alone could not retarget. samples_seen rather than
             # global_step because it stays comparable across batch_size
             # changes; both are still logged as metrics so either can be
@@ -1595,7 +1595,7 @@ def train_sft(args: SFTArgs):
             best_val_throughput = overall_thp
             torch.save(agent.state_dict(), args.checkpoint_path)
             ever_saved = True
-            print(f"  -> Saved best checkpoint (val/throughput {overall_thp:.3f})")
+            print(f"  -> Saved best checkpoint (val/thput {overall_thp:.3f})")
 
     if not ever_saved:
         # Rollouts disabled or no val factories — fall back to the final model
@@ -1603,7 +1603,7 @@ def train_sft(args: SFTArgs):
         torch.save(agent.state_dict(), args.checkpoint_path)
     total_time = time.time() - t0
     print(
-        f"\nBest val/throughput: {best_val_throughput:.3f}  (best val_acc {best_val_acc:.3f})"
+        f"\nBest val/thput: {best_val_throughput:.3f}  (best val_acc {best_val_acc:.3f})"
     )
     print(f"Checkpoint saved to: {args.checkpoint_path}")
 

--- a/sweep.yaml
+++ b/sweep.yaml
@@ -3,7 +3,7 @@
 method: bayes
 run_cap: 20
 metric:
-  name: "eval/throughput_eot"
+  name: "eval/thput_eot"
   goal: maximize
 
 parameters:

--- a/tests/test_ppo_logging.py
+++ b/tests/test_ppo_logging.py
@@ -150,14 +150,14 @@ class TestRolloutEpisodeMetrics:
 
     def test_overall_logs_raw_and_normed_throughput(self):
         m = self._metrics()
-        assert m["rollout/throughput"] == pytest.approx(0.6)
+        assert m["rollout/thput"] == pytest.approx(0.6)
         assert m["rollout/thput_raw"] == pytest.approx(9.0)
 
     def test_per_lesson_logs_raw_throughput(self):
         # The ASSERT: raw items/s must be logged per lesson, not just overall.
         m = self._metrics("SPLITTER_SPLIT")
         assert m["rollout/SPLITTER_SPLIT/thput_raw"] == pytest.approx(9.0)
-        assert m["rollout/SPLITTER_SPLIT/throughput"] == pytest.approx(0.6)
+        assert m["rollout/SPLITTER_SPLIT/thput"] == pytest.approx(0.6)
 
     def test_every_lesson_kind_gets_a_per_lesson_raw_key(self):
         for kind in LessonKind:

--- a/tests/test_ppo_logging.py
+++ b/tests/test_ppo_logging.py
@@ -21,6 +21,7 @@ from ppo import (  # noqa: E402
     make_env,
     _run_signature,
     _build_eval_set,
+    _rollout_episode_metrics,
 )
 from factorion import LessonKind, build_factory  # noqa: E402
 from helpers import Channel  # noqa: E402
@@ -127,3 +128,53 @@ class TestPerHeadEntropyStash:
         # entropy_B is per-sample (summed over heads); its mean should match the
         # sum of the per-head means stashed for logging.
         assert entropy_B.mean().detach().item() == pytest.approx(head_sum, abs=1e-4)
+
+
+# ── per-episode rollout metrics (overall + per-lesson, raw + normalized) ──────
+
+
+class TestRolloutEpisodeMetrics:
+    def _metrics(self, lesson="MOVE_ONE_ITEM"):
+        return _rollout_episode_metrics(
+            lesson,
+            episode_return=2.5,
+            episode_len=42.0,
+            thput_normed=0.6,
+            thput_raw=9.0,
+            ended_by_eot=1.0,
+            invalid_frac=0.1,
+            num_entities=4.0,
+            min_entities_required=3.0,
+            frac_reachable=0.75,
+        )
+
+    def test_overall_logs_raw_and_normed_throughput(self):
+        m = self._metrics()
+        assert m["rollout/throughput"] == pytest.approx(0.6)
+        assert m["rollout/thput_raw"] == pytest.approx(9.0)
+
+    def test_per_lesson_logs_raw_throughput(self):
+        # The ASSERT: raw items/s must be logged per lesson, not just overall.
+        m = self._metrics("SPLITTER_SPLIT")
+        assert m["rollout/SPLITTER_SPLIT/thput_raw"] == pytest.approx(9.0)
+        assert m["rollout/SPLITTER_SPLIT/throughput"] == pytest.approx(0.6)
+
+    def test_every_lesson_kind_gets_a_per_lesson_raw_key(self):
+        for kind in LessonKind:
+            m = _rollout_episode_metrics(
+                kind.name,
+                episode_return=0.0,
+                episode_len=1.0,
+                thput_normed=0.0,
+                thput_raw=1.23,
+                ended_by_eot=0.0,
+                invalid_frac=0.0,
+                num_entities=1.0,
+                min_entities_required=1.0,
+                frac_reachable=0.0,
+            )
+            assert m[f"rollout/{kind.name}/thput_raw"] == pytest.approx(1.23)
+
+    def test_entity_efficiency_is_required_over_placed(self):
+        m = self._metrics()
+        assert m["rollout/entity_efficiency"] == pytest.approx(3.0 / 4.0)


### PR DESCRIPTION
Three commits:

1. **`ppo: log per-lesson rollout/{LESSON}/thput_raw`** — per-lesson rollout logging only emitted normalized `throughput`; raw items/s existed only at the overall `rollout/thput_raw`. Adds `rollout/{LESSON}/thput_raw` so lessons with very different ceilings (belts ~15/s vs assemblers <1/s) stay comparable. Extracts the inline metrics dict into a pure, testable `_rollout_episode_metrics()` helper + tests.
2. **`metrics: rename W&B keys throughput → thput`** — renames the slashed metric keys: `eval/throughput[_eot]`, `rollout/throughput`, `val/throughput[_eot]`, and their per-lesson f-string variants → `.../thput[_eot]`. Updates `sweep.yaml`'s metric and the `apply_*_sweep_best.py` default metric names in lockstep.
3. **`docs: rename throughput → thput in metric-key references`** — CLAUDE.md + README key/short-name references.

### Scope (deliberately narrow — quoted/slashed metric keys only)
**Left intact:** `throughput_reward_scale` (CLI flag), `simulate_throughput` (Rust binding), variable identifiers, the underscore summary keys `moving_avg_throughput` / `best_val_throughput` (entangled with legacy curriculum code + `compare_runs.py`), the generic `read_metric` docstring examples (`wandb_metric.py`), `test_sweep_metric.py` (its non-slashed nested fixtures would mismatch a slashed rename), the prose separator in `factory_builder.py` (`nodes/edges/throughput`), the textual-test YAML `throughput:` schema key (Rust-parsed), and generic English prose.

### ⚠️ Consequences
- **Breaks W&B dashboard overlay** with the SFT base `j0s5y2mc` and all prior runs (they logged the old `throughput` keys). New runs re-baseline from here.
- **Conflicts with open #188** (`ppo-rl-sweep`): that branch's `sweep.yaml` still has `metric: eval/throughput_eot`. Whichever merges second needs `metric: eval/thput_eot`.

### Verification
- `pytest tests/` → **3303 passed, 77 skipped**
- `ruff check .` ✓ · `ty check .` ✓
- PPO smoke (5000 steps) ✓ · SFT smoke ✓ (prints `val/thput`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)