### PR TITLE
fix: train on a fresh factory every episode (PPO was pinned to ~num_envs factories)

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -480,6 +480,14 @@ class FactorioEnv(gym.Env):
         # _get_info() safe if it is ever called before the first reset.
         self._kind = LessonKind.MOVE_ONE_ITEM
 
+        # Training-only factory diversity. When the PPO loop sets _train_seed,
+        # reset() uses it and marches it forward by num_envs so every episode
+        # builds a fresh, never-before-seen factory and this env's seed stream
+        # stays disjoint from the other envs'. Left None for eval/render envs,
+        # which pass explicit seeds and rely on seed -> factory determinism.
+        self._train_seed: Optional[int] = None
+        self._num_envs: int = 1
+
     def _get_obs(self):
         return self._world_CWH
 
@@ -522,9 +530,19 @@ class FactorioEnv(gym.Env):
         return location_match, entity_match, direction_match
 
     def reset(self, seed: Optional[int] = None, options: Optional[dict] = None):
-        if seed is None:
-            seed = 0
-        self._seed = int(seed + self.idx)
+        if self._train_seed is not None:
+            # Training: use this env's running seed and march it forward by
+            # num_envs so every episode builds a fresh, never-before-seen
+            # factory (and this env's stream stays disjoint from the others').
+            # The passed seed is ignored on purpose: Gymnasium's NEXT_STEP
+            # autoreset always calls reset(seed=None), which previously pinned
+            # each env to a single factory (seed == idx) for the entire run.
+            self._seed = self._train_seed
+            self._train_seed += self._num_envs
+        else:
+            if seed is None:
+                seed = 0
+            self._seed = int(seed + self.idx)
         super().reset(seed=self._seed)
         if options is not None:
             self._reset_options = options
@@ -1328,6 +1346,17 @@ if __name__ == "__main__":
     envs = gym.vector.SyncVectorEnv(
         [make_env(args.env_id, i, args.capture_video, args.size, run_name, args.throughput_reward_scale, args.step_penalty) for i in range(args.num_envs)],
     )
+    # Train on a fresh factory every episode: give each env a running seed that
+    # marches forward by num_envs each reset (env i sweeps args.seed+i,
+    # +num_envs, +2*num_envs, …), so across all envs we cover args.seed, +1,
+    # +2, … and never replay a factory. Without this, Gymnasium's NEXT_STEP
+    # autoreset calls reset(seed=None) each episode, which pinned every env to a
+    # single factory (seed == idx) for the whole run. Eval/render envs keep
+    # their explicit-seed determinism.
+    for i, sub_env in enumerate(envs.envs):
+        fe = cast(FactorioEnv, sub_env.unwrapped)
+        fe._train_seed = args.seed + i
+        fe._num_envs = args.num_envs
 
     encoder_layers = layers_from_args(args)
     print(f"Creating agent with layers={encoder_layers}, {args.kernel_size=}, {args.tile_head_std=}, {args.dropout=} ")
@@ -1520,14 +1549,11 @@ if __name__ == "__main__":
             next_done = np.logical_or(terminations, truncations)
             rewards_SE[step] = torch.as_tensor(np.array(reward), dtype=torch.float32, device=device)
 
-            # Reset done envs back to a fully-blank (build-from-empty) factory.
-            done_indices = np.where(next_done)[0]
-            for idx in done_indices:
-                obs, _ = envs.envs[idx].reset(seed=args.seed + idx, options={
-                    'num_missing_entities': float('inf'),
-                })
-                next_obs_ECWH[idx] = obs
-
+            # Done envs are rebuilt by Gymnasium's NEXT_STEP autoreset, which
+            # calls FactorioEnv.reset(seed=None) -> the train_seed_base march
+            # above (a fresh, never-before-seen fully-blank factory). The old
+            # manual reset here passed a fixed per-idx seed and was silently
+            # clobbered by that autoreset, so every env replayed one factory.
             next_obs_ECWH = torch.as_tensor(np.array(next_obs_ECWH), dtype=torch.float32, device=device)
             next_done = torch.as_tensor(np.array(next_done), dtype=torch.float32, device=device)
 

--- a/tests/test_training_factory_diversity.py
+++ b/tests/test_training_factory_diversity.py
@@ -1,0 +1,124 @@
+"""Guard against the "train on the same N factories forever" bug.
+
+PPO used to reset every env to a fixed per-index seed each episode (and
+Gymnasium's NEXT_STEP autoreset pinned it further to seed == idx), so the
+policy only ever saw ~num_envs factories for the whole run. These tests assert
+that both training paths keep drawing *fresh* factories:
+
+  * PPO  — a seed counter handed to each env marches the factory seed forward,
+           so the SyncVectorEnv never replays a factory across episodes.
+  * SFT  — generate_dataset() marches its seed forward, so the dataset covers
+           ~one distinct factory per generated lesson, scaling with num_samples.
+"""
+
+import hashlib
+import os
+import sys
+from typing import cast
+
+import numpy as np
+import gymnasium as gym
+
+os.environ["WANDB_MODE"] = "disabled"
+os.environ["WANDB_DISABLED"] = "true"
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from ppo import FactorioEnv, make_env  # noqa: E402
+
+ENV_ID = "factorion/FactorioEnv-v0-diversity-test"
+
+
+def _factory_hash(env: FactorioEnv) -> str:
+    """Hash the target (solved) factory the policy must reconstruct."""
+    return hashlib.sha1(env._solved_world_CWH.numpy().tobytes()).hexdigest()
+
+
+# ── PPO: marching seed counter ───────────────────────────────────────────────
+
+
+class TestPPOFactoryDiversity:
+    def test_seed_marches_and_never_repeats(self):
+        env = FactorioEnv(size=7, idx=0)
+        env._train_seed = 1000
+        env._num_envs = 1  # single env -> +1 each reset sweeps contiguously
+        seeds, hashes = [], []
+        for _ in range(40):
+            env.reset()
+            seeds.append(env._seed)
+            hashes.append(_factory_hash(env))
+        # Seeds march forward every reset — no repeats at all.
+        assert seeds == list(range(1000, 1040))
+        # And the factories themselves are essentially all distinct (a couple of
+        # collisions across 40 random layouts is fine; the bug gave exactly 1).
+        assert len(set(hashes)) >= 38
+
+    def test_without_counter_seed_is_deterministic_for_eval(self):
+        # Eval/render rely on seed -> factory determinism; no counter set.
+        a = FactorioEnv(size=7, idx=0)
+        b = FactorioEnv(size=7, idx=0)
+        a.reset(seed=4242)
+        b.reset(seed=4242)
+        assert a._seed == b._seed == 4242
+        assert _factory_hash(a) == _factory_hash(b)
+
+    def test_sync_vector_env_does_not_replay_factories(self):
+        # The real training path: SyncVectorEnv + NEXT_STEP autoreset. Drive
+        # several eot-terminated episodes and assert every env, every episode,
+        # builds a never-before-seen factory.
+        gym.register(id=ENV_ID, entry_point="ppo:FactorioEnv")
+        n = 4
+        envs = gym.vector.SyncVectorEnv(
+            [make_env(ENV_ID, i, False, 7, "t") for i in range(n)]
+        )
+        for i, sub in enumerate(envs.envs):
+            fe = cast(FactorioEnv, sub.unwrapped)
+            fe._train_seed = 5000 + i
+            fe._num_envs = n
+        envs.reset(seed=5000, options={"num_missing_entities": float("inf")})
+
+        def eot_action():
+            return {
+                "xy": np.zeros((n, 2), dtype=np.int64),
+                "entity": np.zeros(n, dtype=np.int64),
+                "direction": np.zeros(n, dtype=np.int64),
+                "item": np.zeros(n, dtype=np.int64),
+                "misc": np.zeros(n, dtype=np.int64),
+                "eot": np.ones(n, dtype=np.int64),
+            }
+
+        seen = [cast(FactorioEnv, e.unwrapped)._seed for e in envs.envs]
+        for _ in range(6):
+            envs.step(eot_action())  # eot -> terminate
+            envs.step(eot_action())  # next step -> NEXT_STEP autoreset fires
+            seen.extend(cast(FactorioEnv, e.unwrapped)._seed for e in envs.envs)
+
+        # 4 envs x (1 + 6) episodes = 28 factory draws, all distinct seeds.
+        assert len(seen) == 28
+        assert len(set(seen)) == 28
+
+
+# ── SFT: generate_dataset marches its seed ───────────────────────────────────
+
+
+class TestSFTFactoryDiversity:
+    def _distinct_factory_seeds(self, num_samples: int) -> int:
+        from sft import SFTArgs, generate_dataset
+
+        args = SFTArgs(seed=1, size=5, num_samples=num_samples, max_level=0)
+        out = generate_dataset(args)
+        seed_tensor = out[8]  # per-pair lesson seed; unique => one per factory
+        return len(set(seed_tensor.tolist()))
+
+    def test_dataset_covers_many_distinct_factories(self):
+        # Each factory yields only a handful of (state, action) pairs, so a
+        # few-hundred-pair dataset must span many distinct factories — not a
+        # tiny fixed set.
+        assert self._distinct_factory_seeds(200) >= 20
+
+    def test_distinct_factories_scale_with_num_samples(self):
+        # The decisive "not the same N forever" check: ask for more data, get
+        # more distinct factories (the seed marches; it is not capped at N).
+        small = self._distinct_factory_seeds(150)
+        large = self._distinct_factory_seeds(450)
+        assert large > small


### PR DESCRIPTION
## The bug

PPO trained on a **fixed set of ~`num_envs` factories for the entire run** — and has since **2025-11-04** (commit `6bd587b`, *"Fix: a bunch of random-seed related issues"*).

Two compounding causes:
1. The training loop reset every done env with a **fixed per-index seed** (`reset(seed=args.seed + idx)`), and
2. Gymnasium's `AutoresetMode.NEXT_STEP` **silently clobbers** that manual reset on the next step with `reset(seed=None)` → `FactorioEnv.reset` mapped `None → 0` → `_seed = idx`.

Either way, env `idx` rebuilt the **same factory every episode**. Verified empirically: after a manual `reset(seed=9999)`, the next `envs.step()` reverts `_seed` to `idx`.

Meanwhile `eval/*` uses a **disjoint held-out** seed set. So `rollout/*` was a *training-accuracy* curve and `eval/*` a *generalization* curve — which is exactly why `rollout/MOVE_ONE_ITEM/throughput` climbed to **1.0** (memorized) while held-out `eval/throughput_eot` **fell** to ~0.04. The policy was overfitting to ~16 factories; PPO literally couldn't beat SFT because it never saw diverse data.

Before `6bd587b`, the manual reset passed no seed → `build_factory(seed=None)` → `np.random.seed(None)` → a **fresh random factory** each episode. That commit made seeds reproducible but, as a side effect, froze them — trading all factory diversity for determinism.

## The fix

Give each training env a running integer seed starting at `args.seed + idx` that **marches forward by `num_envs` every reset**, so across all envs the seeds sweep `args.seed, +1, +2, …` with **no repeats** — still fully deterministic from `args.seed`, but a fresh factory every episode.

- The dead manual reset is removed; the `NEXT_STEP` autoreset path now carries the march.
- **Eval/render envs are untouched** — they pass explicit seeds and keep `seed → factory` determinism (held-out eval stays valid).
- SFT was already correct (`generate_dataset` does `seed += 1`); no change needed there.

## Tests (PPO **and** SFT)

New `tests/test_training_factory_diversity.py`:
- PPO: a marching env produces strictly-distinct seeds/factories across resets; the real `SyncVectorEnv` + `NEXT_STEP` autoreset path never replays a factory across 28 episode-draws; and eval determinism (no march) is preserved.
- SFT: `generate_dataset` covers many distinct factories and the count **scales with `num_samples`** (not capped at a fixed N).

## Verification
- `pytest tests/` → **3308 passed, 77 skipped**
- `ruff` ✓ · `ty` ✓ · PPO smoke ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)