### PR TITLE
fix(webui): load PPO (torch.compile) checkpoints in factory builder

### DIFF
--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -336,6 +336,12 @@ def _load_checkpoint(path: str) -> None:
     provenance (local vs wandb) and sets it after this returns."""
     global _CHECKPOINT_STATE, _CHECKPOINT_PATH
     state = torch.load(path, map_location="cpu", weights_only=True)
+    # ppo.py saves its agent *after* torch.compile, which prepends
+    # "_orig_mod." to every parameter name; SFT checkpoints are saved
+    # uncompiled (clean names). Strip the prefix so both load identically
+    # — otherwise _encoder_arch finds zero conv keys and crashes, and the
+    # critic/eot-head filtering below silently misses every key.
+    state = {k.removeprefix("_orig_mod."): v for k, v in state.items()}
     _CHECKPOINT_STATE = state
     _CHECKPOINT_PATH = path
     _AGENT_CACHE.clear()

--- a/tests/test_factory_builder.py
+++ b/tests/test_factory_builder.py
@@ -51,6 +51,24 @@ def _make_tiny_checkpoint(size: int = 4, chan: int = 8) -> Path:
     return Path(path)
 
 
+def _make_compiled_checkpoint(size: int = 4, chan: int = 8) -> Path:
+    """Like `_make_tiny_checkpoint`, but every key is prefixed with
+    ``_orig_mod.`` to mimic a checkpoint saved by ppo.py *after*
+    ``torch.compile`` (which wraps the module and renames params). SFT
+    checkpoints are saved uncompiled, PPO ones are not — the builder must
+    load both."""
+    plain = _make_tiny_checkpoint(size=size, chan=chan)
+    try:
+        state = torch.load(str(plain), map_location="cpu", weights_only=True)
+    finally:
+        plain.unlink(missing_ok=True)
+    compiled = {f"_orig_mod.{k}": v for k, v in state.items()}
+    fd, path = tempfile.mkstemp(suffix=".pt")
+    os.close(fd)
+    torch.save(compiled, path)
+    return Path(path)
+
+
 @pytest.fixture(autouse=True)
 def _reset_fb_state():
     """factory_builder keeps the loaded checkpoint and per-size agents
@@ -192,6 +210,31 @@ class TestCheckpointLoading:
             fb._load_checkpoint(str(path))
             assert fb._CHECKPOINT_STATE is not None
             assert fb._CHECKPOINT_PATH == str(path)
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_load_compiled_checkpoint(self):
+        """A PPO checkpoint is saved after torch.compile, so every key
+        carries an ``_orig_mod.`` prefix. The builder must strip it:
+        otherwise _encoder_arch finds zero conv keys and crashes with
+        IndexError (regression for switching to a PPO model in the UI)."""
+        path = _make_compiled_checkpoint(size=4, chan=8)
+        try:
+            fb._load_checkpoint(str(path))
+            assert fb._CHECKPOINT_STATE is not None
+            # Keys must be normalised — nothing should retain the prefix.
+            assert all(
+                not k.startswith("_orig_mod.")
+                for k in fb._CHECKPOINT_STATE
+            )
+            info = fb._model_info()
+            assert info["loaded"] is True
+            assert info["layers"] == [8, 8, 8]
+            assert info["kernel_size"] == 3
+            # And the agent must build + load the weights without falling
+            # back to a fully random net (eot_head kept on size match).
+            agent = fb._get_agent(4)
+            assert agent is not None
         finally:
             path.unlink(missing_ok=True)
 


### PR DESCRIPTION
## Problem

`scripts/factory_builder.py` crashes when you type a **PPO-posttrained** run id (e.g. `4ylnwdgx`) into the UI's "switch model" box:

```
IndexError: list index out of range
  File ".../factory_builder.py", line 328, in _encoder_arch
    kernel_size = int(state[conv_keys[0]].shape[-1])
```

**Root cause:** `ppo.py` saves its agent *after* `torch.compile()`, which prepends `_orig_mod.` to every parameter name (e.g. `_orig_mod.encoder.0.weight`). SFT pretrained checkpoints are saved uncompiled, so their keys are clean (`encoder.0.weight`). `factory_builder` inspects keys by literal prefix:

- `_encoder_arch` filters for `k.startswith("encoder.")` → matches **zero** conv keys on a compiled checkpoint → `conv_keys[0]` raises `IndexError`.
- `_get_agent`'s critic/eot-head filtering (`eot_head.1.weight`, `critic_head.`, `eot_head.`) would also silently miss every key, loading a near-random net.

## Fix

Strip the `_orig_mod.` prefix once in `_load_checkpoint`, right after `torch.load`, so PPO and SFT checkpoints normalise to identical key names before anything downstream inspects them.

## Verification

- New regression test `test_load_compiled_checkpoint` builds a compiled-style checkpoint (every key prefixed with `_orig_mod.`) and asserts it loads, reports the right encoder arch, and builds an agent. The existing tests already cover the SFT (clean-key) path, so **both model types are exercised**.
- Confirmed against the real checkpoints from the bug report: `j0s5y2mc` (SFT) and `4ylnwdgx` (PPO) both load cleanly at native size 11 with the eot head intact and no state-dict mismatch warnings.
- Full suite green: `3546 passed, 77 skipped`. `ruff` + `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
