### PR TITLE
fix(webui): fail fast with an actionable error when the Rust extension is stale

### DIFF
--- a/factorion.py
+++ b/factorion.py
@@ -27,6 +27,38 @@ from torch.distributions import Categorical
 
 import factorion_rs
 
+# The Rust extension is built out-of-band (`maturin develop`) and is NOT
+# rebuilt automatically on import, so a stale wheel silently lacks functions
+# added after it was last built. factorion.py and its callers (ppo, sft, and
+# the web UI's auto-graph) reach into `factorion_rs` by name at call time, so a
+# stale build imports cleanly — `py_items` below still resolves — then crashes
+# much later with a cryptic `AttributeError: module 'factorion_rs' has no
+# attribute '...'` deep inside a request handler (e.g. `py_build_graph` when the
+# web UI builds the flow graph). Fail fast at import with an actionable message.
+_REQUIRED_FACTORION_RS = (
+    "simulate_throughput",
+    "py_build_graph",
+    "py_entity_tiles",
+    "py_items",
+    "py_recipes",
+)
+
+
+def _assert_factorion_rs_current(module) -> None:
+    """Raise an actionable ImportError if the installed factorion_rs is missing
+    any function this module needs — the tell-tale sign of a stale Rust build."""
+    missing = [name for name in _REQUIRED_FACTORION_RS if not hasattr(module, name)]
+    if missing:
+        raise ImportError(
+            "factorion_rs is out of date (missing: "
+            + ", ".join(missing)
+            + "). Rebuild the Rust extension:\n"
+            "  uv run maturin develop --release --manifest-path factorion_rs/Cargo.toml"
+        )
+
+
+_assert_factorion_rs_current(factorion_rs)
+
 wandb.login()
 
 

--- a/tests/test_graph_construction.py
+++ b/tests/test_graph_construction.py
@@ -311,3 +311,42 @@ class TestGeneratedWorldConnectivity:
             f"{kind.name} seed={seed}: {graph.number_of_nodes()} nodes vs "
             f"{non_empty} non-empty tiles"
         )
+
+
+# ── Stale-extension guard ────────────────────────────────────────────────────
+
+
+class TestFactorionRsCurrencyGuard:
+    """`build_graph_nx` reaches into `factorion_rs.py_build_graph` at call time,
+    so a Rust extension built before the graph migration (#178) imports cleanly
+    (it still has `py_items`) but then crashes deep in the web UI's auto-graph
+    with a cryptic `AttributeError: module 'factorion_rs' has no attribute
+    'py_build_graph'`. The import-time guard turns that into an actionable
+    error. See `factorion._assert_factorion_rs_current`."""
+
+    def test_stale_build_raises_actionable_error(self):
+        import types
+
+        import factorion
+
+        # A wheel built before #178: has py_items (so plain import succeeds) but
+        # not py_build_graph — exactly the state that produced the crash.
+        stale = types.SimpleNamespace(
+            simulate_throughput=lambda *a, **k: None,
+            py_entity_tiles=lambda *a, **k: None,
+            py_items=lambda *a, **k: {},
+            py_recipes=lambda *a, **k: {},
+        )
+        assert not hasattr(stale, "py_build_graph")
+        with pytest.raises(ImportError, match="py_build_graph"):
+            factorion._assert_factorion_rs_current(stale)
+        with pytest.raises(ImportError, match="maturin develop"):
+            factorion._assert_factorion_rs_current(stale)
+
+    def test_installed_build_passes_guard(self):
+        """The real, freshly-built extension satisfies the guard — also guards
+        against a typo'd name in the required-functions list."""
+        import factorion
+        import factorion_rs
+
+        factorion._assert_factorion_rs_current(factorion_rs)  # must not raise


### PR DESCRIPTION
## Problem

Clicking to place an entity in the web UI triggers the automatic "build graph" step, which crashes the request handler with a cryptic error:

```
AttributeError: module 'factorion_rs' has no attribute 'py_build_graph'
  File ".../factorion.py", line 1222, in build_graph_nx
    nodes, edges = factorion_rs.py_build_graph(arr.astype(np.int64))
```

## Root cause

The Rust extension (`factorion_rs`) is built out-of-band via `maturin develop` and is **not** rebuilt on import. The graph migration (#178, "Rust `build_graph` is the sole graph builder") made `factorion.build_graph_nx` call `factorion_rs.py_build_graph`. A wheel built *before* #178 still exposes `py_items`, so `import factorion` succeeds (factorion only touches `py_items` at import). The missing `py_build_graph` then surfaces only much later — deep inside the web UI POST handler when the flow graph is built.

Confirmed: the stale install exposed `['py_entity_tiles', 'py_items', 'py_recipes', 'simulate_throughput']` — no `py_build_graph`. A fresh build adds it.

## Fix

Add an import-time guard `_assert_factorion_rs_current` in `factorion.py` that verifies the installed `factorion_rs` exposes every function the module needs. If any are missing it raises an actionable `ImportError` pointing at the rebuild command, instead of letting a stale build crash cryptically at call time:

```
factorion_rs is out of date (missing: py_build_graph). Rebuild the Rust extension:
  uv run maturin develop --release --manifest-path factorion_rs/Cargo.toml
```

Putting the guard at `factorion.py` import time (rather than only in the web UI) means it protects every consumer — `ppo.py`, `sft.py`, and the builder — and fails fast at startup rather than on the first graph build.

## Tests

`TestFactorionRsCurrencyGuard` in `tests/test_graph_construction.py`:
- a stale-shaped module (has `py_items`, lacks `py_build_graph`) raises an `ImportError` mentioning both `py_build_graph` and `maturin develop`;
- the real installed extension passes the guard (also catches a typo'd name in the required-functions list).

Both fail without the fix (the guard function doesn't exist) and pass with it.

## Verification

- Full suite green: `3548 passed, 77 skipped`. `ruff` + `ty` clean.
- Branched fresh from `origin/main` (which already includes #196).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
