### PR TITLE
guard: always fail on CPU fallback instead of silently training there

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -1037,6 +1037,20 @@ def layers_from_args(args) -> list[int]:
     return layers
 
 
+def assert_device_ok(device) -> None:
+    if device.type in ("cuda", "mps"):
+        return
+    # CI runs CPU-only smoke tests; everywhere else a CPU fallback is a bug.
+    if os.environ.get("CI"):
+        return
+    raise RuntimeError(
+        f"Refusing to train on '{device.type}': no CUDA GPU was found. This "
+        "usually means the host NVIDIA driver is too old for the installed torch "
+        "CUDA build (torch 2.12 ships CUDA 13, which needs driver >= 580). Fix the "
+        "host/driver, or pick a GPU+host that supports CUDA 13."
+    )
+
+
 class AgentCNN(nn.Module):
     def __init__(self, envs, layers=(48, 48, 64), kernel_size=3, tile_head_std=0.01, dropout=0.0):
         super().__init__()
@@ -1341,6 +1355,7 @@ if __name__ == "__main__":
         # metal doesn't like anything but f32
         torch.set_default_dtype(torch.float32)
     print(f"running on {device}")
+    assert_device_ok(device)
 
     print(f"Setting up envs with {args}")
     envs = gym.vector.SyncVectorEnv(

--- a/sft.py
+++ b/sft.py
@@ -38,7 +38,13 @@ from factorion import (  # noqa: E402
     str2ent,
 )
 
-from ppo import AgentCNN, FactorioEnv, make_env, layers_from_args  # noqa: E402
+from ppo import (  # noqa: E402
+    AgentCNN,
+    FactorioEnv,
+    make_env,
+    layers_from_args,
+    assert_device_ok,
+)
 
 
 def extract_expert_actions(solved_CWH, task_CWH):
@@ -942,6 +948,7 @@ def train_sft(args: SFTArgs):
         if torch.backends.mps.is_available()
         else "cpu"
     )
+    assert_device_ok(device)
     agent.to(device)
 
     optimizer = optim.AdamW(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,3 +5,9 @@ import sys
 
 # Add tests/ directory to sys.path so `from helpers import ...` works
 sys.path.insert(0, os.path.dirname(__file__))
+
+# The CPU-fallback guard (ppo.assert_device_ok) aborts on CPU everywhere except
+# CI. The test suite trains on CPU (sft end-to-end tests), so mark the session
+# as CI even when run locally on a CPU-only box. setdefault preserves a real CI
+# value. GitHub Actions already sets CI=true.
+os.environ.setdefault("CI", "true")

--- a/tests/test_device_guard.py
+++ b/tests/test_device_guard.py
@@ -1,0 +1,41 @@
+"""End-to-end tests for the always-on CPU-fallback guard
+(``ppo.assert_device_ok``).
+
+A GPU host whose NVIDIA driver is too old for the installed torch CUDA build
+makes torch silently select ``cpu`` — training then "works" but crawls. The
+guard turns that silent fallback into a hard error. CUDA (pods) and Apple MPS
+(local Mac dev) are accepted; CPU aborts — except under CI, which runs CPU-only
+smoke tests.
+"""
+
+import pytest
+import torch
+
+from ppo import assert_device_ok
+
+CPU = torch.device("cpu")
+MPS = torch.device("mps")
+CUDA = torch.device("cuda")
+
+
+def test_cuda_accepted():
+    """A real CUDA device (GPU pod) always passes."""
+    assert_device_ok(CUDA)  # must not raise
+
+
+def test_mps_accepted():
+    """Local Mac dev (Apple MPS) keeps working."""
+    assert_device_ok(MPS)  # must not raise
+
+
+def test_cpu_rejected(monkeypatch):
+    """Off CI, CPU aborts — the silent-fallback case we hit on a pod."""
+    monkeypatch.delenv("CI", raising=False)
+    with pytest.raises(RuntimeError, match="Refusing to train on 'cpu'"):
+        assert_device_ok(CPU)
+
+
+def test_cpu_allowed_in_ci(monkeypatch):
+    """CI (CI=true, set by GitHub Actions) runs CPU-only smoke tests."""
+    monkeypatch.setenv("CI", "true")
+    assert_device_ok(CPU)  # must not raise


### PR DESCRIPTION
## Why

A GPU host whose NVIDIA driver is too old for the installed torch CUDA build (torch 2.12 ships **CUDA 13**, which needs driver **≥ 580**) makes torch quietly select `cpu`. Training then "works" but crawls unnoticed, burning GPU spend. This is the failure mode behind the *"nvidia versions are wrong"* RTX 2000 Ada run.

## What

An **always-on** guard `assert_device_ok(device)` in `ppo.py`, called from both `ppo.py` and `sft.py` right after the device is chosen.

| Device | Result |
|---|---|
| **CUDA** (GPU pod) | ✅ runs |
| **MPS** (local Mac dev) | ✅ runs |
| **CPU**, under CI (`CI=true`) | ✅ runs — CI does CPU-only smoke tests |
| **CPU**, anywhere else | ❌ aborts with a clear CUDA-13/driver message |

No user-facing override: the only carve-out is the `CI` env var (set by GitHub Actions), because CI legitimately trains on CPU.

## Verified

- CPU off-CI (`--no-cuda --no-metal`) → aborts loudly.
- CPU with `CI=1` → runs.
- Default local run → `running on mps`.
- `ruff` ✓, `ty` ✓, `tests/test_device_guard.py` (4 tests) ✓, and the SFT end-to-end tests pass under CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)