### PR TITLE
Fix flaky val seed generation for unbuildable lesson kinds

### DIFF
--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -670,21 +670,31 @@ class TestRunRolloutEval:
     """End-to-end coverage of greedy rollout eval on held-out val factories."""
 
     def _build_val_seeds_to_kind(self, size, num_kinds=4, start_seed=10_000):
-        """Iterate seeds until we have `num_kinds` (seed -> kind) pairs each
-        of which produces a valid lesson at max_level. Mirrors the
-        try/except-continue pattern that generate_dataset uses for malformed
-        seeds, so this fixture doesn't get flaky when an enum value lands a
-        bad seed."""
-        kinds = list(LessonKind)
+        """Collect up to `num_kinds` (seed -> kind) pairs, one per distinct
+        lesson kind, each producing a valid lesson at the given size. Mirrors
+        the try/except-continue pattern that generate_dataset uses for
+        malformed seeds, so this fixture doesn't get flaky when an enum value
+        lands a bad seed.
+
+        Some kinds can never be generated on a tiny grid (e.g.
+        ASSEMBLE_2IN_1OUT does not fit at size 5). Rather than burn the whole
+        seed budget retrying an unbuildable kind, skip a kind after
+        `max_fails_per_kind` consecutive rejections and move to the next one."""
+        max_fails_per_kind = 40
         out: dict[int, int] = {}
         seed = start_seed
-        while len(out) < num_kinds and seed < start_seed + 1000:
-            kind = kinds[len(out) % len(kinds)]
-            if build_factory(size=size, kind=kind, seed=seed) is None:
+        for kind in LessonKind:
+            if len(out) >= num_kinds:
+                break
+            fails = 0
+            while fails < max_fails_per_kind:
+                if build_factory(size=size, kind=kind, seed=seed) is None:
+                    seed += 1
+                    fails += 1
+                    continue
+                out[seed] = kind.value
                 seed += 1
-                continue
-            out[seed] = kind.value
-            seed += 1
+                break
         return out
 
     def test_returns_throughput_in_unit_range(self, registered_env):


### PR DESCRIPTION
## Summary
Fixes a flaky test fixture (`_build_val_seeds_to_kind`) that could exhaust its seed budget retrying unbuildable lesson kinds on tiny grids, causing test failures. The fixture now skips kinds that fail to build after a fixed number of attempts, rather than cycling through all kinds repeatedly.

## Key Changes
- **Restructured seed iteration logic**: Changed from a single `while` loop that cycles through kinds round-robin to a `for` loop over kinds with an inner `while` loop per kind. This ensures each kind gets a fair attempt budget before moving on.
- **Added per-kind failure budget**: Introduced `max_fails_per_kind = 40` to limit consecutive rejections per lesson kind. Once a kind fails this many times, it is skipped rather than burning the entire seed budget.
- **Improved docstring**: Clarified that some kinds (e.g., `ASSEMBLE_2IN_1OUT`) cannot be generated on tiny grids, and documented the new skip-after-N-failures strategy to prevent flakiness.

## Implementation Details
The old logic would iterate `kinds[len(out) % len(kinds)]` in a single loop, meaning if one kind was unbuildable at a given size, the fixture would keep cycling back to it and wasting seeds. The new logic:
1. Iterates through each `LessonKind` once
2. For each kind, tries up to `max_fails_per_kind` seeds before giving up
3. Breaks early if `num_kinds` pairs are already collected
4. Moves to the next kind if the current one exhausts its failure budget

This prevents the fixture from getting stuck on unbuildable kinds while still maintaining the try/except-continue pattern that mirrors `generate_dataset`'s robustness to malformed seeds.

https://claude.ai/code/session_01S1SBbYKdg9ernsCpW4FCbE