### PR TITLE
Default to RTX 2000 Ada + CUDA-13-capable hosts; fix the CI Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# Keep the docker build context small — the image only needs the lockfile.
+.git
+.venv
+**/__pycache__
+**/target
+factorio-data
+factorio-icons
+checkpoints
+*.pt
+*.tar.gz

--- a/.github/actions/runpod-setup/action.yml
+++ b/.github/actions/runpod-setup/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: true
   gpu_type:
     description: "RunPod GPU type"
-    default: "NVIDIA A100 80GB PCIe"
+    default: "NVIDIA RTX 2000 Ada Generation"
   name_prefix:
     description: "Pod name prefix"
     required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
       gpu_type:
         description: "RunPod GPU type ID"
         required: false
-        default: "NVIDIA GeForce RTX 4090"
+        default: "NVIDIA RTX 2000 Ada Generation"
         type: string
       total_timesteps:
         description: "Total timesteps for smoke test"
@@ -59,7 +59,7 @@ permissions:
 env:
   WANDB_CI_PROJECT: factorion
   PYTHON_VERSION: "3.11"
-  DEFAULT_GPU_TYPE: "NVIDIA GeForce RTX 4090"
+  DEFAULT_GPU_TYPE: "NVIDIA RTX 2000 Ada Generation"
 
 jobs:
   # ──────────────────────────────────────────────
@@ -647,7 +647,7 @@ jobs:
         with:
           runpod_api_key: ${{ secrets.RUNPOD_API_KEY }}
           ssh_private_key: ${{ secrets.RUNPOD_SSH_PRIVATE_KEY }}
-          gpu_type: ${{ inputs.gpu_type || 'NVIDIA A100 80GB PCIe' }}
+          gpu_type: ${{ inputs.gpu_type || 'NVIDIA RTX 2000 Ada Generation' }}
           name_prefix: ci-sft-smoke
 
       - name: Run SFT smoke test on GPU
@@ -700,7 +700,7 @@ jobs:
         with:
           runpod_api_key: ${{ secrets.RUNPOD_API_KEY }}
           ssh_private_key: ${{ secrets.RUNPOD_SSH_PRIVATE_KEY }}
-          gpu_type: ${{ inputs.gpu_type || 'NVIDIA A100 80GB PCIe' }}
+          gpu_type: ${{ inputs.gpu_type || 'NVIDIA RTX 2000 Ada Generation' }}
           name_prefix: ci-sft-bench
           include_git: "true"
 
@@ -853,7 +853,7 @@ jobs:
         with:
           runpod_api_key: ${{ secrets.RUNPOD_API_KEY }}
           ssh_private_key: ${{ secrets.RUNPOD_SSH_PRIVATE_KEY }}
-          gpu_type: ${{ inputs.gpu_type || 'NVIDIA A100 80GB PCIe' }}
+          gpu_type: ${{ inputs.gpu_type || 'NVIDIA RTX 2000 Ada Generation' }}
           name_prefix: ci-sft-sweep-${{ matrix.agent_id }}
 
       - name: Run SFT sweep agent on GPU

--- a/.github/workflows/ppo-train.yml
+++ b/.github/workflows/ppo-train.yml
@@ -55,7 +55,7 @@ on:
       gpu_type:
         description: "RunPod GPU type"
         required: false
-        default: "NVIDIA A100 80GB PCIe"
+        default: "NVIDIA RTX 2000 Ada Generation"
         type: string
 
 permissions:
@@ -83,9 +83,10 @@ jobs:
           python3 - <<'PY' >> "$GITHUB_OUTPUT"
           import os
           t = int(os.environ["TOTAL_TIMESTEPS"])
-          # Conservative A100 PPO rate (~200 env-steps/sec incl. the Rust
-          # throughput sim + curriculum eval), with a 2x safety margin so the
-          # watchdog never kills a legitimate run early. Calibratable.
+          # Conservative PPO rate (~200 env-steps/sec incl. the Rust throughput
+          # sim + curriculum eval). The rollout is single-core-CPU-bound, so this
+          # holds across GPUs (incl. the default RTX 2000 Ada). 2x safety margin
+          # so the watchdog never kills a legitimate run early. Calibratable.
           base_seconds = t / 200
           watchdog = int(base_seconds * 2 + 900)
           watchdog = max(watchdog, 1800)          # floor: 30 min

--- a/.github/workflows/sft-train.yml
+++ b/.github/workflows/sft-train.yml
@@ -26,7 +26,7 @@ on:
       gpu_type:
         description: "RunPod GPU type"
         required: false
-        default: "NVIDIA A100 80GB PCIe"
+        default: "NVIDIA RTX 2000 Ada Generation"
         type: string
 
 permissions:
@@ -57,8 +57,9 @@ jobs:
           n = int(os.environ["NUM_SAMPLES"])
           e = int(os.environ["EPOCHS"])
           # Calibration: the existing 4h (14400s) watchdog for the 300k × 30
-          # default implies ~1000 sample-epochs/sec on A100 once you back out
-          # a 1.5× safety margin. Reuse that rate so 300k × 30 lines up with
+          # default implies ~1000 sample-epochs/sec once you back out a 1.5×
+          # safety margin. SFT is data/CPU-bound, so the rate holds across GPUs
+          # (incl. the default RTX 2000 Ada). Reuse it so 300k × 30 lines up with
           # the historical default; longer runs scale linearly.
           base_seconds = (n * e) / 1000
           watchdog = int(base_seconds * 1.5 + 600)

--- a/docker/Dockerfile.ci-gpu
+++ b/docker/Dockerfile.ci-gpu
@@ -1,12 +1,16 @@
+# Build + push by hand when deps change (no CI job):
+#   docker build -f docker/Dockerfile.ci-gpu -t beyarkay/factorion-ci-gpu:latest . && docker push beyarkay/factorion-ci-gpu:latest
 FROM runpod/pytorch:2.4.0-py3.11-cuda12.4.1-devel-ubuntu22.04
 
-# Rust toolchain (needed to build factorion_rs via maturin)
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+        --default-toolchain stable --profile minimal
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Python deps (pinned from requirements.txt)
-COPY requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.txt
+RUN pip install --no-cache-dir uv
+COPY pyproject.toml uv.lock .python-version /tmp/lock/
+RUN cd /tmp/lock && \
+    uv export --frozen --no-emit-project --no-hashes -o requirements.txt && \
+    uv pip install --system --break-system-packages -r requirements.txt && \
+    cd / && rm -rf /tmp/lock
 
-# maturin for building the Rust extension
-RUN pip install --no-cache-dir maturin
+RUN python -c "import torch; assert torch.__version__.startswith('2.12'), torch.__version__"

--- a/scripts/ci/runpod_create.py
+++ b/scripts/ci/runpod_create.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Create a RunPod GPU pod for CI.
 
-Provisions an RTX 4090 (or specified GPU) pod, waits for it to reach a running
-state, and writes connection info to an output JSON file.
+Provisions an RTX 2000 Ada (or specified GPU) pod on a host new enough for our
+torch build (see ALLOWED_CUDA_VERSIONS), waits for it to reach a running state,
+and writes connection info to an output JSON file.
 
 Required env vars:
     RUNPOD_API_KEY  - RunPod API key
@@ -19,12 +20,23 @@ import time
 
 import runpod
 
+# Preferred first, then availability fallbacks (each pricier/bigger). The default
+# is the RTX 2000 Ada — the GPU the speed benchmarks were tuned on; these models
+# are tiny (122k params) and the workload is single-core-CPU-bound, so a bigger
+# GPU is overkill (see tests/benchmarks/EXPERIMENT_LOG.md).
 GPU_FALLBACKS = [
+    "NVIDIA RTX 2000 Ada Generation",
     "NVIDIA GeForce RTX 4090",
     "NVIDIA RTX A6000",
     "NVIDIA A100 80GB PCIe",
     "NVIDIA A100-SXM4-80GB",
 ]
+
+# Only schedule on hosts whose driver supports a CUDA version new enough for our
+# torch build. uv.lock pins torch 2.12.x+cu130, which needs a CUDA 13.0 runtime
+# (host driver >= 580); an older host (e.g. CUDA 12.x) leaves torch.cuda
+# unavailable. Keep in sync with the torch cuXXX build in pyproject/uv.lock.
+ALLOWED_CUDA_VERSIONS = ["13.0"]
 
 DOCKER_IMAGE = "beyarkay/factorion-ci-gpu:latest"
 CONTAINER_DISK_GB = 40
@@ -56,6 +68,7 @@ def create_pod(gpu_type: str, name_prefix: str = "ci", timeout: int = POD_START_
                 container_disk_in_gb=CONTAINER_DISK_GB,
                 ports="22/tcp",
                 support_public_ip=True,
+                allowed_cuda_versions=ALLOWED_CUDA_VERSIONS,
                 env={
                     "RUNPOD_API_KEY": os.environ["RUNPOD_API_KEY"],
                 },


### PR DESCRIPTION
## What

Make CI/training pods provision the **GPU this project was benchmarked on (RTX 2000 Ada)** on a **host new enough for our CUDA-13 torch**, and fix the stale CI Docker image so pods run the same torch as local dev.

## Why

- We defaulted to **A100 / RTX 4090** in several places, but the models are tiny (122k params) and the workload is single-core-CPU-bound — a big GPU is overkill (see `tests/benchmarks/EXPERIMENT_LOG.md`).
- `uv.lock` pins **torch 2.12.x+cu130** (needs a CUDA-13 / driver ≥580 host). Historically a too-old-driver host left `torch.cuda` unavailable and **everything silently ran on CPU**.
- The CI image (`docker/Dockerfile.ci-gpu`) was **stale and unbuildable**: it pip-installs a `requirements.txt` that no longer exists, and the published `:latest` still ships **torch 2.3.0+cu121** — older CUDA than local.

## Changes

**Provisioning (commit 1)**
- Every GPU default → `NVIDIA RTX 2000 Ada Generation`: the runpod-setup action, `ppo-train` / `sft-train` / `ci` workflows, and `runpod_create.py`'s fallback list (which still climbs to RTX 4090 → A6000 → A100 if unavailable).
- `runpod_create.py` passes `allowed_cuda_versions=["13.0"]` — pods only land on a host whose driver supports CUDA 13 (the real fix for the CPU-fallback failure). Verified the param exists in the runpod SDK (1.9.1).
- Reworded the two `A100` rate-estimate comments in the train watchdogs (rates are CPU-bound → GPU-independent).

**Docker image (commit 2)**
- Rewrote `docker/Dockerfile.ci-gpu` to render `uv.lock` via `uv export` and install the **exact locked deps** (torch 2.12.x + the `nvidia-*-cu13` CUDA-13 stack, from PyPI — no special index needed) into the **global** Python the pod scripts use (a venv wouldn't be on the PATH of SSH non-login shells). A baked `import torch; assert 2.12` fails the build if it lands in the wrong interpreter. Kept the RunPod PyTorch base (Python 3.11 + sshd + pod plumbing the CI SSH flow relies on).
- Added `.dockerignore` to keep the build context small.

## Note

The image is still **built + pushed by hand** (no CI job). After merging, rebuild once so pods pick up cu130:

```
docker build -f docker/Dockerfile.ci-gpu -t beyarkay/factorion-ci-gpu:latest .
docker push beyarkay/factorion-ci-gpu:latest
```

I couldn't build it on this box (no Docker daemon), but validated the core locally: `uv export` renders cleanly with `torch==2.12.1` + the full `nvidia-*-cu13` stack, and `maturin` is already in the lockfile. The Dockerfile's `assert 2.12` will catch a bad build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
