### PR TITLE
Allow CPU training under pytest so PPO/SFT tests run locally

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -1152,8 +1152,10 @@ def layers_from_args(args) -> list[int]:
 def assert_device_ok(device) -> None:
     if device.type in ("cuda", "mps"):
         return
-    # CI runs CPU-only smoke tests; everywhere else a CPU fallback is a bug.
-    if os.environ.get("CI"):
+    # CI and the local test suite run CPU-only smoke tests; everywhere else a
+    # CPU fallback is a bug. pytest sets PYTEST_CURRENT_TEST for every test, so
+    # `uv run pytest` trains on CPU without needing CI=true in the environment.
+    if os.environ.get("CI") or os.environ.get("PYTEST_CURRENT_TEST"):
         return
     raise RuntimeError(
         f"Refusing to train on '{device.type}': no CUDA GPU was found. This "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ import sys
 sys.path.insert(0, os.path.dirname(__file__))
 
 # The CPU-fallback guard (ppo.assert_device_ok) aborts on CPU everywhere except
-# CI. The test suite trains on CPU (sft end-to-end tests), so mark the session
-# as CI even when run locally on a CPU-only box. setdefault preserves a real CI
-# value. GitHub Actions already sets CI=true.
-os.environ.setdefault("CI", "true")
+# CI and under pytest. The test suite trains on CPU (sft/ppo end-to-end tests);
+# the guard recognises the pytest-set PYTEST_CURRENT_TEST env var, so local
+# `uv run pytest` runs CPU-only smoke tests without any CI=true env hack.

--- a/tests/test_device_guard.py
+++ b/tests/test_device_guard.py
@@ -4,8 +4,8 @@
 A GPU host whose NVIDIA driver is too old for the installed torch CUDA build
 makes torch silently select ``cpu`` — training then "works" but crawls. The
 guard turns that silent fallback into a hard error. CUDA (pods) and Apple MPS
-(local Mac dev) are accepted; CPU aborts — except under CI, which runs CPU-only
-smoke tests.
+(local Mac dev) are accepted; CPU aborts — except under CI or pytest, which run
+CPU-only smoke tests.
 """
 
 import pytest
@@ -29,13 +29,25 @@ def test_mps_accepted():
 
 
 def test_cpu_rejected(monkeypatch):
-    """Off CI, CPU aborts — the silent-fallback case we hit on a pod."""
+    """Off CI and outside pytest, CPU aborts — the silent-fallback case we hit
+    on a pod. Both signals must be cleared: pytest sets PYTEST_CURRENT_TEST for
+    every test, which the guard would otherwise honour."""
     monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
     with pytest.raises(RuntimeError, match="Refusing to train on 'cpu'"):
         assert_device_ok(CPU)
 
 
 def test_cpu_allowed_in_ci(monkeypatch):
     """CI (CI=true, set by GitHub Actions) runs CPU-only smoke tests."""
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
     monkeypatch.setenv("CI", "true")
+    assert_device_ok(CPU)  # must not raise
+
+
+def test_cpu_allowed_under_pytest(monkeypatch):
+    """The local test suite (pytest sets PYTEST_CURRENT_TEST) runs CPU-only
+    smoke tests without needing CI=true in the environment."""
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "tests/test_device_guard.py::x")
     assert_device_ok(CPU)  # must not raise


### PR DESCRIPTION
The CPU-fallback guard (assert_device_ok) aborted on CPU everywhere
except CI, so the SFT/PPO end-to-end tests only trained when CI=true was
set in the environment. conftest.py worked around this by forcing
CI=true for the whole session — a blunt hammer that makes every test
think it is running in CI.

Detect the test harness directly instead: pytest sets PYTEST_CURRENT_TEST
for every test, so the guard now permits CPU under pytest (in addition to
CI). `uv run pytest` trains the end-to-end tests on CPU locally with no
CI env hack. Drop the conftest CI=true override and update the device
guard tests (test_cpu_rejected must clear PYTEST_CURRENT_TEST; add a test
for the pytest-detection path).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UxXxh8c1DbehvgyBoQaLHB