### PR TITLE
Add long-handed inserter entity with reach-2 connectivity

### DIFF
--- a/factorion_rs/src/entities.rs
+++ b/factorion_rs/src/entities.rs
@@ -151,14 +151,13 @@ impl FactoryEntity for Inserter {
     }
 }
 
-// ── Long-Handed Inserter ────────────────────────────────────────────────────
-//
-// A long-handed inserter is a plain inserter that reaches *two* tiles instead
-// of one: it picks up from the tile two cells behind it and drops onto the tile
-// two cells ahead, skipping the cell in between entirely. Everything else —
-// throughput, the set of entities it can pull from / push to, the flow
-// transform — is identical to the plain inserter (it just passes `reach = 2`).
-
+/// # Long-Handed Inserter
+///
+/// A long-handed inserter is a plain inserter that reaches *two* tiles instead
+/// of one: it picks up from the tile two cells behind it and drops onto the tile
+/// two cells ahead, skipping the cell in between entirely. Everything else —
+/// throughput, the set of entities it can pull from / push to, the flow
+/// transform — is identical to the plain inserter (it just passes `reach = 2`).
 pub struct LongHandedInserter;
 
 impl FactoryEntity for LongHandedInserter {

--- a/factorion_rs/src/entities.rs
+++ b/factorion_rs/src/entities.rs
@@ -39,6 +39,7 @@ pub trait FactoryEntity {
 pub enum EntityEnum {
     TransportBelt(TransportBelt),
     Inserter(Inserter),
+    LongHandedInserter(LongHandedInserter),
     AssemblingMachine(AssemblingMachine),
     UndergroundBelt(UndergroundBelt),
     Sink(Sink),
@@ -54,6 +55,7 @@ impl EntityEnum {
         Some(match kind {
             Item::TransportBelt => Self::TransportBelt(TransportBelt),
             Item::Inserter => Self::Inserter(Inserter),
+            Item::LongHandedInserter => Self::LongHandedInserter(LongHandedInserter),
             Item::AssemblingMachine1 => {
                 Self::AssemblingMachine(AssemblingMachine { recipe_item: item })
             }
@@ -71,6 +73,7 @@ impl FactoryEntity for EntityEnum {
         match self {
             Self::TransportBelt(e) => e.kind(),
             Self::Inserter(e) => e.kind(),
+            Self::LongHandedInserter(e) => e.kind(),
             Self::AssemblingMachine(e) => e.kind(),
             Self::UndergroundBelt(e) => e.kind(),
             Self::Sink(e) => e.kind(),
@@ -83,6 +86,7 @@ impl FactoryEntity for EntityEnum {
         match self {
             Self::TransportBelt(e) => e.connections(pos, dir, world),
             Self::Inserter(e) => e.connections(pos, dir, world),
+            Self::LongHandedInserter(e) => e.connections(pos, dir, world),
             Self::AssemblingMachine(e) => e.connections(pos, dir, world),
             Self::UndergroundBelt(e) => e.connections(pos, dir, world),
             Self::Sink(e) => e.connections(pos, dir, world),
@@ -95,6 +99,7 @@ impl FactoryEntity for EntityEnum {
         match self {
             Self::TransportBelt(e) => e.transform_flow(input),
             Self::Inserter(e) => e.transform_flow(input),
+            Self::LongHandedInserter(e) => e.transform_flow(input),
             Self::AssemblingMachine(e) => e.transform_flow(input),
             Self::UndergroundBelt(e) => e.transform_flow(input),
             Self::Sink(e) => e.transform_flow(input),
@@ -135,7 +140,34 @@ impl FactoryEntity for Inserter {
     }
 
     fn connections(&self, pos: (usize, usize), dir: Direction, world: &World) -> Vec<Edge> {
-        inserter_connections(Item::Inserter, pos, dir, world)
+        inserter_connections(Item::Inserter, pos, dir, world, 1)
+    }
+
+    fn transform_flow(&self, input: &HashMap<Item, f64>) -> HashMap<Item, f64> {
+        input
+            .iter()
+            .map(|(&item, &rate)| (item, rate.min(self.flow_rate())))
+            .collect()
+    }
+}
+
+// ── Long-Handed Inserter ────────────────────────────────────────────────────
+//
+// A long-handed inserter is a plain inserter that reaches *two* tiles instead
+// of one: it picks up from the tile two cells behind it and drops onto the tile
+// two cells ahead, skipping the cell in between entirely. Everything else —
+// throughput, the set of entities it can pull from / push to, the flow
+// transform — is identical to the plain inserter (it just passes `reach = 2`).
+
+pub struct LongHandedInserter;
+
+impl FactoryEntity for LongHandedInserter {
+    fn kind(&self) -> Item {
+        Item::LongHandedInserter
+    }
+
+    fn connections(&self, pos: (usize, usize), dir: Direction, world: &World) -> Vec<Edge> {
+        inserter_connections(Item::LongHandedInserter, pos, dir, world, 2)
     }
 
     fn transform_flow(&self, input: &HashMap<Item, f64>) -> HashMap<Item, f64> {
@@ -443,32 +475,36 @@ fn belt_connections(
 }
 
 /// Inserter connection logic: pick up from the belt-like / underground /
-/// assembler behind, and drop onto the belt-like / underground / assembler
-/// ahead. Source/sink count as belt-like entities here (they connect like belts).
+/// assembler `reach` tiles behind, and drop onto the belt-like / underground /
+/// assembler `reach` tiles ahead. Source/sink count as belt-like entities here
+/// (they connect like belts).
+///
+/// `reach` is the distance, in tiles, that the inserter's hand spans: `1` for
+/// a plain inserter (it touches the cells immediately behind/ahead) and `2` for
+/// a long-handed inserter (it skips the adjacent cell and reaches the one
+/// beyond). The intermediate cell is never touched — a long-handed inserter
+/// only ever interacts with the tile exactly `reach` away. If that tile belongs
+/// to a multi-tile entity (e.g. one of an assembler's nine tiles), the edge is
+/// canonicalised to the entity's anchor node in `build_graph`.
 fn inserter_connections(
     self_kind: Item,
     pos: (usize, usize),
     dir: Direction,
     world: &World,
+    reach: i64,
 ) -> Vec<Edge> {
     let mut edges = Vec::new();
     let (x, y) = pos;
     let (dx, dy) = dir.delta();
     let self_id = NodeId::new(self_kind, x, y);
 
-    // Pick up from behind (opposite of facing direction). A real inserter can
-    // only pick up from an entity that carries or produces items: a source,
-    // belt, underground belt, or assembler. Notably NOT another inserter (see
-    // #122) or a sink. (Splitters are excluded too, mirroring the drop side —
-    // not quite true to Factorio, may revisit.)
-    //
-    // The source/sink markers share this function but keep the permissive
-    // pickup: a sink legitimately receives from the inserter/belt/assembler
-    // behind it — an inserter can't *drop* onto a sink (see the drop filter
-    // below), so delivery is modelled as the sink pulling — and a source's
-    // input is ignored anyway (its output is infinite).
-    let src_x = x as i64 - dx;
-    let src_y = y as i64 - dy;
+    // Pick up from `reach` tiles behind (opposite of facing direction). A real
+    // inserter can only pick up from an entity that carries or produces items:
+    // a source, belt, underground belt, or assembler. Notably NOT another
+    // inserter (see #122) or a sink. (Splitters are excluded too, mirroring the
+    // drop side — not quite true to Factorio, may revisit.)
+    let src_x = x as i64 - dx * reach;
+    let src_y = y as i64 - dy * reach;
     if world.in_bounds(src_x, src_y) {
         let sx = src_x as usize;
         let sy = src_y as usize;
@@ -487,9 +523,9 @@ fn inserter_connections(
         }
     }
 
-    // Drop onto the cell ahead (in facing direction)
-    let dst_x = x as i64 + dx;
-    let dst_y = y as i64 + dy;
+    // Drop onto the cell `reach` tiles ahead (in facing direction)
+    let dst_x = x as i64 + dx * reach;
+    let dst_y = y as i64 + dy * reach;
     if world.in_bounds(dst_x, dst_y) {
         let dx_u = dst_x as usize;
         let dy_u = dst_y as usize;
@@ -858,6 +894,110 @@ mod tests {
         );
         // Nothing insertable ahead either, so there should be no edges at all.
         assert!(edges.is_empty(), "expected no edges, got: {edges:?}");
+    }
+
+    #[test]
+    fn test_long_handed_inserter_connections() {
+        // Long inserter at (2,0) facing east reaches TWO tiles: it picks up
+        // from the source at (0,0) and drops onto the belt at (4,0). The tiles
+        // immediately behind/ahead — (1,0) and (3,0) — are skipped.
+        let mut w = World::empty(5, 1);
+        w.place(0, 0, Item::Source, Direction::East, None);
+        w.place(2, 0, Item::LongHandedInserter, Direction::East, None);
+        w.place(4, 0, Item::TransportBelt, Direction::East, None);
+
+        let lhi = LongHandedInserter;
+        let edges = lhi.connections((2, 0), Direction::East, &w);
+
+        assert_eq!(edges.len(), 2, "got edges: {edges:?}");
+        // Source(0,0) → LongHandedInserter(2,0)
+        assert!(edges.contains(&(
+            NodeId::new(Item::Source, 0, 0),
+            NodeId::new(Item::LongHandedInserter, 2, 0),
+        )));
+        // LongHandedInserter(2,0) → Belt(4,0)
+        assert!(edges.contains(&(
+            NodeId::new(Item::LongHandedInserter, 2, 0),
+            NodeId::new(Item::TransportBelt, 4, 0),
+        )));
+    }
+
+    #[test]
+    fn test_long_handed_inserter_skips_adjacent_tiles() {
+        // Belts sit directly behind/ahead of the long inserter (distance 1).
+        // A long inserter only touches tiles at distance 2, so neither belt
+        // connects and there are no edges at all.
+        let mut w = World::empty(3, 1);
+        w.place(0, 0, Item::TransportBelt, Direction::East, None);
+        w.place(1, 0, Item::LongHandedInserter, Direction::East, None);
+        w.place(2, 0, Item::TransportBelt, Direction::East, None);
+
+        let lhi = LongHandedInserter;
+        let edges = lhi.connections((1, 0), Direction::East, &w);
+
+        assert!(
+            edges.is_empty(),
+            "a long inserter must not touch its immediately adjacent tiles; \
+             got: {edges:?}"
+        );
+    }
+
+    #[test]
+    fn test_long_handed_inserter_reaches_multitile_anchor() {
+        // The multi-tile case the long inserter has to get right: reaching a
+        // NON-anchor tile of an assembler must still produce a single edge to
+        // the assembler's *anchor* node (build_graph canonicalises secondary
+        // tiles → anchor). The assembler is anchored at (3,0) and spans cols
+        // 3..=5, rows 0..=2. The long inserter at (1,1) faces east and drops
+        // two tiles ahead onto (3,1) — a secondary assembler tile, not the
+        // anchor — yet the graph edge points at the anchor (3,0).
+        use crate::graph::build_graph;
+        let mut w = World::empty(6, 3);
+        w.place_multi_tile(
+            3,
+            0,
+            Item::AssemblingMachine1,
+            Direction::None,
+            Some(Item::ElectronicCircuit),
+            3,
+            3,
+        );
+        w.place(1, 1, Item::LongHandedInserter, Direction::East, None);
+
+        let g = build_graph(&w);
+        let lhi = g
+            .get_index(&NodeId::new(Item::LongHandedInserter, 1, 1))
+            .expect("long inserter node");
+        let asm = g
+            .get_index(&NodeId::new(Item::AssemblingMachine1, 3, 0))
+            .expect("assembler anchor node");
+        assert!(
+            g.successors[lhi].contains(&asm),
+            "long inserter should drop onto the assembler anchor node; \
+             successors: {:?}",
+            g.successors[lhi]
+        );
+    }
+
+    #[test]
+    fn test_long_handed_inserter_wont_pick_up_from_inserter_or_splitter() {
+        // Mirrors the plain inserter's exclusions (#122): a long inserter
+        // reaching an inserter or a splitter tile creates no edge.
+        let mut w = World::empty(5, 2);
+        // Inserter two tiles behind the long inserter.
+        w.place(0, 0, Item::Inserter, Direction::East, None);
+        w.place(2, 0, Item::LongHandedInserter, Direction::East, None);
+        // Splitter two tiles ahead (anchored at (4,0), 2x1 facing east).
+        w.place_splitter(4, 0, Direction::East, None);
+
+        let lhi = LongHandedInserter;
+        let edges = lhi.connections((2, 0), Direction::East, &w);
+
+        assert!(
+            edges.is_empty(),
+            "a long inserter must not connect to inserters or splitters; \
+             got: {edges:?}"
+        );
     }
 
     #[test]

--- a/factorion_rs/src/textual.rs
+++ b/factorion_rs/src/textual.rs
@@ -80,6 +80,7 @@ const TOL: f64 = 1e-9;
 const ENTITY_CHARS: &[(char, Item, Misc)] = &[
     ('b', Item::TransportBelt, Misc::None),
     ('i', Item::Inserter, Misc::None),
+    ('l', Item::LongHandedInserter, Misc::None),
     ('a', Item::AssemblingMachine1, Misc::None),
     ('Y', Item::Splitter, Misc::None),
     ('d', Item::UndergroundBelt, Misc::UndergroundDown),

--- a/factorion_rs/src/types.rs
+++ b/factorion_rs/src/types.rs
@@ -98,8 +98,14 @@ impl Misc {
 ///
 /// Integer-id layout:
 ///   1..=5   — agent-placeable entities (TB, Inserter, AM1, UB, Splitter)
-///   6..=65  — non-placeable items (recipe ingredients / products / raw
-///             materials / non-modeled buildings exposed only as items)
+///   6..=65  — mostly non-placeable items (recipe ingredients / products /
+///             raw materials / non-modeled buildings exposed only as items).
+///             The one exception is `LongHandedInserter` (34): it carries a
+///             recipe like the others but is *also* a placeable entity (an
+///             inserter variant that reaches two tiles instead of one), so it
+///             returns `true` from `is_placeable`. Placeability is decided by
+///             `is_placeable`, not by id range — the head excludes only the
+///             last two ids, so a placeable id in the middle is fine.
 ///   66..=67 — env-spawned (Sink, Source) — MUST remain the last two
 ///             ids; ppo.py sizes its entity head to `len(items)-2` to
 ///             structurally exclude them. See `test_source_and_sink_are_last_two_ids`.
@@ -354,6 +360,7 @@ impl Item {
             self,
             Item::TransportBelt
                 | Item::Inserter
+                | Item::LongHandedInserter
                 | Item::AssemblingMachine1
                 | Item::UndergroundBelt
                 | Item::Sink
@@ -369,6 +376,10 @@ impl Item {
         match self {
             Item::TransportBelt => 15.0,
             Item::Inserter => 0.86,
+            // A long-handed inserter is functionally identical to a plain
+            // inserter — same throughput — it only reaches two tiles instead
+            // of one. See `LongHandedInserter` in entities.rs.
+            Item::LongHandedInserter => 0.86,
             Item::AssemblingMachine1 => 0.5,
             Item::UndergroundBelt => 15.0,
             Item::Sink => f64::INFINITY,
@@ -403,7 +414,6 @@ impl Item {
             | Item::FastUndergroundBelt
             | Item::FastSplitter
             | Item::BurnerInserter
-            | Item::LongHandedInserter
             | Item::FastInserter
             | Item::SmallElectricPole
             | Item::MediumElectricPole
@@ -1247,6 +1257,8 @@ mod tests {
     fn test_item_flow_rates() {
         assert_eq!(Item::TransportBelt.flow_rate(), 15.0);
         assert_eq!(Item::Inserter.flow_rate(), 0.86);
+        // A long-handed inserter has the same throughput as a plain inserter.
+        assert_eq!(Item::LongHandedInserter.flow_rate(), 0.86);
         assert_eq!(Item::AssemblingMachine1.flow_rate(), 0.5);
         assert_eq!(Item::UndergroundBelt.flow_rate(), 15.0);
         assert!(Item::Sink.flow_rate().is_infinite());
@@ -1260,6 +1272,7 @@ mod tests {
         for placeable in [
             Item::TransportBelt,
             Item::Inserter,
+            Item::LongHandedInserter,
             Item::AssemblingMachine1,
             Item::UndergroundBelt,
             Item::Sink,

--- a/factorion_rs/tests/factories/long_handed_inserter.yaml
+++ b/factorion_rs/tests/factories/long_handed_inserter.yaml
@@ -1,0 +1,51 @@
+# Long-handed inserter (`l`): an inserter variant that reaches TWO tiles
+# instead of one. It picks up from the tile two cells behind it and drops onto
+# the tile two cells ahead, skipping the cell in between. Throughput and the
+# set of entities it interacts with are identical to a plain inserter (`i`);
+# only the reach differs. Facing markers: ^>v<.
+description: |
+  The canonical vertical layout. A north-facing long inserter at (1,2) picks
+  up from the source two tiles below it at (1,4) and drops onto the sink two
+  tiles above it at (1,0). The cells immediately above/below it stay empty —
+  the long hand reaches right over them. Inserter-limited to 0.86 i/s.
+items:
+- { x: 1, y: 4, item: copper_cable }
+- { x: 1, y: 0, item: copper_cable }
+throughput:
+- { item: copper_cable, per_second: 0.86 }
+graph: |
+  S@1,4 -> l@1,2
+  l@1,2 -> K@1,0
+factory: |
+  .. K^ ..
+  .. .. ..
+  .. l^ ..
+  .. .. ..
+  .. S^ ..
+---
+description: |
+  The same reach horizontally, with empty gaps making the two-tile span
+  explicit: source at (0,0) -> long inserter at (2,0) -> sink at (4,0). The
+  inserter never touches the gap cells (1,0) and (3,0).
+items:
+- { x: 0, y: 0, item: copper_cable }
+- { x: 4, y: 0, item: copper_cable }
+throughput:
+- { item: copper_cable, per_second: 0.86 }
+graph: |
+  S@0,0 -> l@2,0
+  l@2,0 -> K@4,0
+factory: |
+  S> .. l> .. K>
+---
+description: |
+  Reach-2 over a populated gap: belts sit in the skipped cells (1,0) and (3,0)
+  but the long inserter still bridges the belts two tiles out, at (0,0) and
+  (4,0). The belt chain and the long-hand edges coexist.
+graph: |
+  b@0,0 -> b@1,0
+  b@0,0 -> l@2,0
+  b@3,0 -> b@4,0
+  l@2,0 -> b@4,0
+factory: |
+  b> b> l> b> b>

--- a/factorion_rs/tests/factories/long_handed_inserter_assembler_block.yaml
+++ b/factorion_rs/tests/factories/long_handed_inserter_assembler_block.yaml
@@ -1,0 +1,129 @@
+# A 3x3 block of long inserters pressed against a 3x3 assembler, on each of the
+# four sides, both feeding it (inserters -> assembler) and draining it
+# (assembler -> inserters). Demonstrates two things at once:
+#   * A long inserter connects to the assembler from any tile its reach-2 cell
+#     lands on (including the assembler's interior tile), and every such edge
+#     canonicalises to the assembler anchor (top-left).
+#   * Reach is exactly 2: the far column/row of the block sits three tiles from
+#     the body and never connects, so each side yields exactly six edges.
+
+# ── Feeding the assembler (inserters -> assembler) ───────────────────────────
+
+description: input from the WEST — block of east-facing long inserters feeds the assembler
+graph: |
+  l@1,0 -> a@3,0
+  l@2,0 -> a@3,0
+  l@1,1 -> a@3,0
+  l@2,1 -> a@3,0
+  l@1,2 -> a@3,0
+  l@2,2 -> a@3,0
+factory: |
+  l> l> l> aaaaaaaa
+  l> l> l> aa    aa
+  l> l> l> aaaaaaaa
+---
+description: input from the EAST — block of west-facing long inserters feeds the assembler
+graph: |
+  l@3,0 -> a@0,0
+  l@4,0 -> a@0,0
+  l@3,1 -> a@0,0
+  l@4,1 -> a@0,0
+  l@3,2 -> a@0,0
+  l@4,2 -> a@0,0
+factory: |
+  aaaaaaaa l< l< l<
+  aa    aa l< l< l<
+  aaaaaaaa l< l< l<
+---
+description: input from the NORTH — block of south-facing long inserters feeds the assembler
+graph: |
+  l@0,1 -> a@0,3
+  l@1,1 -> a@0,3
+  l@2,1 -> a@0,3
+  l@0,2 -> a@0,3
+  l@1,2 -> a@0,3
+  l@2,2 -> a@0,3
+factory: |
+  lv lv lv
+  lv lv lv
+  lv lv lv
+  aaaaaaaa
+  aa    aa
+  aaaaaaaa
+---
+description: input from the SOUTH — block of north-facing long inserters feeds the assembler
+graph: |
+  l@0,3 -> a@0,0
+  l@1,3 -> a@0,0
+  l@2,3 -> a@0,0
+  l@0,4 -> a@0,0
+  l@1,4 -> a@0,0
+  l@2,4 -> a@0,0
+factory: |
+  aaaaaaaa
+  aa    aa
+  aaaaaaaa
+  l^ l^ l^
+  l^ l^ l^
+  l^ l^ l^
+---
+
+# ── Draining the assembler (assembler -> inserters) ──────────────────────────
+
+description: output to the EAST — assembler feeds a block of east-facing long inserters
+graph: |
+  a@0,0 -> l@3,0
+  a@0,0 -> l@4,0
+  a@0,0 -> l@3,1
+  a@0,0 -> l@4,1
+  a@0,0 -> l@3,2
+  a@0,0 -> l@4,2
+factory: |
+  aaaaaaaa l> l> l>
+  aa    aa l> l> l>
+  aaaaaaaa l> l> l>
+---
+description: output to the WEST — assembler feeds a block of west-facing long inserters
+graph: |
+  a@3,0 -> l@1,0
+  a@3,0 -> l@2,0
+  a@3,0 -> l@1,1
+  a@3,0 -> l@2,1
+  a@3,0 -> l@1,2
+  a@3,0 -> l@2,2
+factory: |
+  l< l< l< aaaaaaaa
+  l< l< l< aa    aa
+  l< l< l< aaaaaaaa
+---
+description: output to the NORTH — assembler feeds a block of north-facing long inserters
+graph: |
+  a@0,3 -> l@0,1
+  a@0,3 -> l@1,1
+  a@0,3 -> l@2,1
+  a@0,3 -> l@0,2
+  a@0,3 -> l@1,2
+  a@0,3 -> l@2,2
+factory: |
+  l^ l^ l^
+  l^ l^ l^
+  l^ l^ l^
+  aaaaaaaa
+  aa    aa
+  aaaaaaaa
+---
+description: output to the SOUTH — assembler feeds a block of south-facing long inserters
+graph: |
+  a@0,0 -> l@0,3
+  a@0,0 -> l@1,3
+  a@0,0 -> l@2,3
+  a@0,0 -> l@0,4
+  a@0,0 -> l@1,4
+  a@0,0 -> l@2,4
+factory: |
+  aaaaaaaa
+  aa    aa
+  aaaaaaaa
+  lv lv lv
+  lv lv lv
+  lv lv lv

--- a/factorion_rs/tests/factories/long_handed_inserter_multitile.yaml
+++ b/factorion_rs/tests/factories/long_handed_inserter_multitile.yaml
@@ -1,0 +1,61 @@
+# Long inserter vs multi-tile entities. When the reach-2 cell lands on any tile
+# of a 3x3 assembler, build_graph canonicalises the edge to the assembler's
+# anchor (top-left). A splitter, like for a plain inserter, never connects.
+# Each assembler sits TWO tiles from the long inserter, with an empty gap, so
+# the edge is the long hand reaching in — not the assembler's own perimeter
+# scan (which only sees plain inserters at distance 1).
+
+description: west side — long inserter two tiles left, facing east, feeds the assembler
+graph: |
+  l@0,1 -> a@2,0
+factory: |
+  .. .. aaaaaaaa
+  l> .. aa    aa
+  .. .. aaaaaaaa
+---
+description: east side — long inserter two tiles right, facing east, is fed by the assembler
+graph: |
+  a@0,0 -> l@4,1
+factory: |
+  aaaaaaaa .. ..
+  aa    aa .. l>
+  aaaaaaaa .. ..
+---
+description: north side — long inserter two tiles above, facing south, feeds the assembler
+graph: |
+  l@1,0 -> a@0,2
+factory: |
+  .. lv ..
+  .. .. ..
+  aaaaaaaa
+  aa    aa
+  aaaaaaaa
+---
+description: south side — long inserter two tiles below, facing south, is fed by the assembler
+graph: |
+  a@0,0 -> l@1,4
+factory: |
+  aaaaaaaa
+  aa    aa
+  aaaaaaaa
+  .. .. ..
+  .. lv ..
+---
+description: |
+  Reaching a NON-anchor assembler tile still resolves to the anchor: the long
+  inserter at (0,2) faces east and drops two tiles ahead onto (2,2), the
+  assembler's bottom-left tile, yet the edge points at the anchor (2,0).
+graph: |
+  l@0,2 -> a@2,0
+factory: |
+  .. .. aaaaaaaa
+  .. .. aa    aa
+  l> .. aaaaaaaa
+---
+description: |
+  A long inserter does not connect to a splitter (same exclusion as a plain
+  inserter), even when its reach-2 cell lands on a splitter tile.
+graph: ""
+factory: |
+  l> .. Y> ..
+  .. .. Y> ..

--- a/factorion_rs/tests/factories/long_handed_inserter_reach_distance.yaml
+++ b/factorion_rs/tests/factories/long_handed_inserter_reach_distance.yaml
@@ -1,0 +1,51 @@
+# The reach boundary, vertically. A long inserter touches the cell EXACTLY two
+# away — never one (too near), never three (too far). These pin the boundary on
+# both sides of the sweet spot with a north-facing inserter between a source and
+# a sink.
+
+description: |
+  Distance 3 — too far. The source and sink sit three cells from the inserter,
+  one past its reach, so nothing connects.
+graph: ""
+factory: |
+  .. K^ ..
+  .. .. ..
+  .. .. ..
+  .. l^ ..
+  .. .. ..
+  .. .. ..
+  .. S^ ..
+---
+description: |
+  Distance 1 — too near. The source and sink are directly adjacent (one cell
+  away); the long hand reaches over both to the empty cells beyond, so nothing
+  connects.
+graph: ""
+factory: |
+  .. .. ..
+  .. K^ ..
+  .. l^ ..
+  .. S^ ..
+  .. .. ..
+---
+description: |
+  Drop at distance 2: the sink is two cells ahead (connects) while the source
+  one cell behind is skipped — so only the drop edge forms.
+graph: "l@1,2 -> K@1,0"
+factory: |
+  .. K^ ..
+  .. .. ..
+  .. l^ ..
+  .. S^ ..
+  .. .. ..
+---
+description: |
+  Pickup at distance 2: the source is two cells behind (connects) while the sink
+  one cell ahead is skipped — so only the pickup edge forms.
+graph: "S@1,4 -> l@1,2"
+factory: |
+  .. .. ..
+  .. K^ ..
+  .. l^ ..
+  .. .. ..
+  .. S^ ..

--- a/factorion_rs/tests/factories/long_handed_inserter_skip.yaml
+++ b/factorion_rs/tests/factories/long_handed_inserter_skip.yaml
@@ -1,0 +1,44 @@
+# A long-handed inserter only ever touches the tile exactly TWO cells away. The
+# immediately-adjacent cell (distance 1) is always skipped, whatever sits there.
+# In each case below the only candidate neighbour is at distance 1, so the graph
+# is empty — and the long inserter's reach-2 cell is an in-bounds empty tile, so
+# "no edge" is genuinely the skip, not an out-of-bounds accident.
+
+description: belt directly behind a long inserter is skipped (reach-2 cell empty)
+graph: ""
+factory: |
+  .. b> l> ..
+---
+description: belt directly ahead of a long inserter is skipped (reach-2 cell empty)
+graph: ""
+factory: |
+  .. l> b> ..
+---
+description: source directly behind a long inserter is skipped
+graph: ""
+factory: |
+  .. S> l> ..
+---
+description: sink directly ahead of a long inserter is skipped
+graph: ""
+factory: |
+  .. l> K> ..
+---
+description: an inserter directly ahead of a long inserter is skipped
+graph: ""
+factory: |
+  .. l> i> ..
+---
+description: belts flanking both adjacent sides connect to neither
+graph: ""
+factory: |
+  b> l> b>
+---
+description: |
+  Vertical skip: a north-facing long inserter reaches over the belt directly
+  below it to the empty cell two down, so the adjacent belt never connects.
+graph: ""
+factory: |
+  .. l^ ..
+  .. b^ ..
+  .. .. ..

--- a/factorion_rs/tests/factories/long_handed_inserter_source_sink.yaml
+++ b/factorion_rs/tests/factories/long_handed_inserter_source_sink.yaml
@@ -1,0 +1,27 @@
+# Long inserter vs the env-spawned source (S) / sink (K) markers, at reach 2.
+# A long inserter legitimately pulls from a source two tiles behind it and
+# drops onto a sink two tiles ahead — the building blocks of every throughput
+# fixture. The "drops into a source" case mirrors inserter_into_source.yaml:
+# the engine currently produces a spurious edge there, so it is parked with
+# `ignored: true` until the engine stops connecting inserters to sources.
+
+description: long inserter pulls from a source two tiles behind it
+graph: |
+  S@0,0 -> l@2,0
+factory: |
+  S> .. l> ..
+---
+description: long inserter drops onto a sink two tiles ahead of it
+graph: |
+  l@1,0 -> K@3,0
+factory: |
+  .. l> .. K>
+---
+description: |
+  A long inserter must not insert *into* a source (an infinite producer, not a
+  container). The engine is currently WRONG here, producing a spurious
+  l -> S edge, so this is parked like the plain-inserter case.
+ignored: true
+graph: ""
+factory: |
+  .. l> .. S>

--- a/factorion_rs/tests/factories/long_handed_inserter_throughput.yaml
+++ b/factorion_rs/tests/factories/long_handed_inserter_throughput.yaml
@@ -1,0 +1,132 @@
+# End-to-end throughput through long-handed inserters. A long inserter caps a
+# line at 0.86 i/s, exactly like a plain inserter — only its reach differs — so
+# every chain below delivers 0.86 to its sink.
+
+description: source -> long inserter -> sink, facing EAST (reach 2 each side)
+items:
+- { x: 0, y: 0, item: copper_cable }
+- { x: 4, y: 0, item: copper_cable }
+throughput:
+- { item: copper_cable, per_second: 0.86 }
+graph: |
+  S@0,0 -> l@2,0
+  l@2,0 -> K@4,0
+factory: |
+  S> .. l> .. K>
+---
+description: source -> long inserter -> sink, facing WEST
+items:
+- { x: 4, y: 0, item: copper_cable }
+- { x: 0, y: 0, item: copper_cable }
+throughput:
+- { item: copper_cable, per_second: 0.86 }
+graph: |
+  S@4,0 -> l@2,0
+  l@2,0 -> K@0,0
+factory: |
+  K< .. l< .. S<
+---
+description: source -> long inserter -> sink, facing NORTH
+items:
+- { x: 0, y: 4, item: copper_cable }
+- { x: 0, y: 0, item: copper_cable }
+throughput:
+- { item: copper_cable, per_second: 0.86 }
+graph: |
+  S@0,4 -> l@0,2
+  l@0,2 -> K@0,0
+factory: |
+  K^
+  ..
+  l^
+  ..
+  S^
+---
+description: source -> long inserter -> sink, facing SOUTH
+items:
+- { x: 0, y: 0, item: copper_cable }
+- { x: 0, y: 4, item: copper_cable }
+throughput:
+- { item: copper_cable, per_second: 0.86 }
+graph: |
+  S@0,0 -> l@0,2
+  l@0,2 -> K@0,4
+factory: |
+  Sv
+  ..
+  lv
+  ..
+  Kv
+---
+description: |
+  A long inserter caps a full-speed belt line: the source feeds a 15 i/s belt,
+  the long inserter reaches two tiles past the belt's end and throttles the
+  whole line to 0.86.
+items:
+- { x: 0, y: 0, item: iron_plate }
+- { x: 5, y: 0, item: iron_plate }
+throughput:
+- { item: iron_plate, per_second: 0.86 }
+graph: |
+  S@0,0 -> b@1,0
+  b@1,0 -> l@3,0
+  l@3,0 -> K@5,0
+factory: |
+  S> b> .. l> .. K>
+---
+description: |
+  Two long inserters in series, bridged by a belt (a long inserter cannot drop
+  directly onto another inserter, so a belt sits between them). Still 0.86.
+items:
+- { x: 0, y: 0, item: copper_cable }
+- { x: 8, y: 0, item: copper_cable }
+throughput:
+- { item: copper_cable, per_second: 0.86 }
+graph: |
+  S@0,0 -> l@2,0
+  l@2,0 -> b@4,0
+  b@4,0 -> l@6,0
+  l@6,0 -> K@8,0
+factory: |
+  S> .. l> .. b> .. l> .. K>
+---
+description: |
+  Long inserter into an underground belt: it drops onto the entrance two tiles
+  ahead, the item tunnels to the exit, and the exit feeds the sink. 0.86.
+items:
+- { x: 0, y: 0, item: copper_cable }
+- { x: 7, y: 0, item: copper_cable }
+throughput:
+- { item: copper_cable, per_second: 0.86 }
+graph: |
+  S@0,0 -> l@2,0
+  l@2,0 -> d@4,0
+  d@4,0 -> u@6,0
+  u@6,0 -> K@7,0
+factory: |
+  S> .. l> .. d> .. u> K>
+---
+description: |
+  A 3x3 assembler crafting copper_cable, fed and drained by LONG inserters that
+  reach two tiles into the body each side:
+
+      source -> long inserter -> assembler -> long inserter -> sink
+
+  The input inserter caps intake at 0.86 copper_plate; the recipe yields 2
+  cables per plate, so the body emits 1.72 cable/s, and the output long
+  inserter throttles delivery back to 0.86.
+items:
+- { x: 0, y: 1, item: copper_plate }       # source emits copper_plate
+- { x: 4, y: 0, item: copper_cable }       # assembler recipe (anchor = top-left)
+- { x: 10, y: 1, item: copper_cable }      # sink counts cable
+throughput:
+- { item: copper_cable, per_second: 0.86 }
+graph: |
+  S@0,1 -> l@2,1
+  l@2,1 -> a@4,0
+  a@4,0 -> l@8,1
+  l@8,1 -> K@10,1
+factory: |
+  .. .. .. .. aaaaaaaa .. .. .. ..
+  S> .. l> .. aa    aa .. l> .. K>
+  .. .. .. .. aaaaaaaa .. .. .. ..

--- a/factorion_rs/tests/factories/long_handed_inserter_to_other.yaml
+++ b/factorion_rs/tests/factories/long_handed_inserter_to_other.yaml
@@ -1,0 +1,329 @@
+# Connectivity oracle: every case where the FIRST entity (A) is a
+# long-handed inserter (l). B is placed TWO tiles East of A, with an empty
+# gap between them, because a long inserter reaches distance 2 — it skips
+# the adjacent cell entirely. `graph:` is build_graph's exact edge set.
+# A faces East -> B is the drop target (l -> B); A faces West -> B is the
+# pickup source (B -> l); A faces N/S -> B is off-axis, no edge. The target's
+# own facing never matters (an inserter grabs/places regardless), so every
+# B direction is enumerated to pin that invariant down.
+# Glyphs: b belt, i inserter, u ug_up(exit), d ug_down(entrance); facing ^>v<.
+
+description: long_handed_inserter/N vs belt/N
+graph: ""
+factory: |
+  .. l^ .. b^ ..
+---
+description: long_handed_inserter/N vs belt/E
+graph: ""
+factory: |
+  .. l^ .. b> ..
+---
+description: long_handed_inserter/N vs belt/S
+graph: ""
+factory: |
+  .. l^ .. bv ..
+---
+description: long_handed_inserter/N vs belt/W
+graph: ""
+factory: |
+  .. l^ .. b< ..
+---
+description: long_handed_inserter/N vs inserter/N
+graph: ""
+factory: |
+  .. l^ .. i^ ..
+---
+description: long_handed_inserter/N vs inserter/E
+graph: ""
+factory: |
+  .. l^ .. i> ..
+---
+description: long_handed_inserter/N vs inserter/S
+graph: ""
+factory: |
+  .. l^ .. iv ..
+---
+description: long_handed_inserter/N vs inserter/W
+graph: ""
+factory: |
+  .. l^ .. i< ..
+---
+description: long_handed_inserter/N vs ug_up/N
+graph: ""
+factory: |
+  .. l^ .. u^ ..
+---
+description: long_handed_inserter/N vs ug_up/E
+graph: ""
+factory: |
+  .. l^ .. u> ..
+---
+description: long_handed_inserter/N vs ug_up/S
+graph: ""
+factory: |
+  .. l^ .. uv ..
+---
+description: long_handed_inserter/N vs ug_up/W
+graph: ""
+factory: |
+  .. l^ .. u< ..
+---
+description: long_handed_inserter/N vs ug_down/N
+graph: ""
+factory: |
+  .. l^ .. d^ ..
+---
+description: long_handed_inserter/N vs ug_down/E
+graph: ""
+factory: |
+  .. l^ .. d> ..
+---
+description: long_handed_inserter/N vs ug_down/S
+graph: ""
+factory: |
+  .. l^ .. dv ..
+---
+description: long_handed_inserter/N vs ug_down/W
+graph: ""
+factory: |
+  .. l^ .. d< ..
+---
+description: long_handed_inserter/E vs belt/N
+graph: "l@1,0 -> b@3,0"
+factory: |
+  .. l> .. b^ ..
+---
+description: long_handed_inserter/E vs belt/E
+graph: "l@1,0 -> b@3,0"
+factory: |
+  .. l> .. b> ..
+---
+description: long_handed_inserter/E vs belt/S
+graph: "l@1,0 -> b@3,0"
+factory: |
+  .. l> .. bv ..
+---
+description: long_handed_inserter/E vs belt/W
+graph: "l@1,0 -> b@3,0"
+factory: |
+  .. l> .. b< ..
+---
+description: long_handed_inserter/E vs inserter/N
+graph: ""
+factory: |
+  .. l> .. i^ ..
+---
+description: long_handed_inserter/E vs inserter/E
+graph: ""
+factory: |
+  .. l> .. i> ..
+---
+description: long_handed_inserter/E vs inserter/S
+graph: ""
+factory: |
+  .. l> .. iv ..
+---
+description: long_handed_inserter/E vs inserter/W
+graph: ""
+factory: |
+  .. l> .. i< ..
+---
+description: long_handed_inserter/E vs ug_up/N
+graph: "l@1,0 -> u@3,0"
+factory: |
+  .. l> .. u^ ..
+---
+description: long_handed_inserter/E vs ug_up/E
+graph: "l@1,0 -> u@3,0"
+factory: |
+  .. l> .. u> ..
+---
+description: long_handed_inserter/E vs ug_up/S
+graph: "l@1,0 -> u@3,0"
+factory: |
+  .. l> .. uv ..
+---
+description: long_handed_inserter/E vs ug_up/W
+graph: "l@1,0 -> u@3,0"
+factory: |
+  .. l> .. u< ..
+---
+description: long_handed_inserter/E vs ug_down/N
+graph: "l@1,0 -> d@3,0"
+factory: |
+  .. l> .. d^ ..
+---
+description: long_handed_inserter/E vs ug_down/E
+graph: "l@1,0 -> d@3,0"
+factory: |
+  .. l> .. d> ..
+---
+description: long_handed_inserter/E vs ug_down/S
+graph: "l@1,0 -> d@3,0"
+factory: |
+  .. l> .. dv ..
+---
+description: long_handed_inserter/E vs ug_down/W
+graph: "l@1,0 -> d@3,0"
+factory: |
+  .. l> .. d< ..
+---
+description: long_handed_inserter/S vs belt/N
+graph: ""
+factory: |
+  .. lv .. b^ ..
+---
+description: long_handed_inserter/S vs belt/E
+graph: ""
+factory: |
+  .. lv .. b> ..
+---
+description: long_handed_inserter/S vs belt/S
+graph: ""
+factory: |
+  .. lv .. bv ..
+---
+description: long_handed_inserter/S vs belt/W
+graph: ""
+factory: |
+  .. lv .. b< ..
+---
+description: long_handed_inserter/S vs inserter/N
+graph: ""
+factory: |
+  .. lv .. i^ ..
+---
+description: long_handed_inserter/S vs inserter/E
+graph: ""
+factory: |
+  .. lv .. i> ..
+---
+description: long_handed_inserter/S vs inserter/S
+graph: ""
+factory: |
+  .. lv .. iv ..
+---
+description: long_handed_inserter/S vs inserter/W
+graph: ""
+factory: |
+  .. lv .. i< ..
+---
+description: long_handed_inserter/S vs ug_up/N
+graph: ""
+factory: |
+  .. lv .. u^ ..
+---
+description: long_handed_inserter/S vs ug_up/E
+graph: ""
+factory: |
+  .. lv .. u> ..
+---
+description: long_handed_inserter/S vs ug_up/S
+graph: ""
+factory: |
+  .. lv .. uv ..
+---
+description: long_handed_inserter/S vs ug_up/W
+graph: ""
+factory: |
+  .. lv .. u< ..
+---
+description: long_handed_inserter/S vs ug_down/N
+graph: ""
+factory: |
+  .. lv .. d^ ..
+---
+description: long_handed_inserter/S vs ug_down/E
+graph: ""
+factory: |
+  .. lv .. d> ..
+---
+description: long_handed_inserter/S vs ug_down/S
+graph: ""
+factory: |
+  .. lv .. dv ..
+---
+description: long_handed_inserter/S vs ug_down/W
+graph: ""
+factory: |
+  .. lv .. d< ..
+---
+description: long_handed_inserter/W vs belt/N
+graph: "b@3,0 -> l@1,0"
+factory: |
+  .. l< .. b^ ..
+---
+description: long_handed_inserter/W vs belt/E
+graph: "b@3,0 -> l@1,0"
+factory: |
+  .. l< .. b> ..
+---
+description: long_handed_inserter/W vs belt/S
+graph: "b@3,0 -> l@1,0"
+factory: |
+  .. l< .. bv ..
+---
+description: long_handed_inserter/W vs belt/W
+graph: "b@3,0 -> l@1,0"
+factory: |
+  .. l< .. b< ..
+---
+description: long_handed_inserter/W vs inserter/N
+graph: ""
+factory: |
+  .. l< .. i^ ..
+---
+description: long_handed_inserter/W vs inserter/E
+graph: ""
+factory: |
+  .. l< .. i> ..
+---
+description: long_handed_inserter/W vs inserter/S
+graph: ""
+factory: |
+  .. l< .. iv ..
+---
+description: long_handed_inserter/W vs inserter/W
+graph: ""
+factory: |
+  .. l< .. i< ..
+---
+description: long_handed_inserter/W vs ug_up/N
+graph: "u@3,0 -> l@1,0"
+factory: |
+  .. l< .. u^ ..
+---
+description: long_handed_inserter/W vs ug_up/E
+graph: "u@3,0 -> l@1,0"
+factory: |
+  .. l< .. u> ..
+---
+description: long_handed_inserter/W vs ug_up/S
+graph: "u@3,0 -> l@1,0"
+factory: |
+  .. l< .. uv ..
+---
+description: long_handed_inserter/W vs ug_up/W
+graph: "u@3,0 -> l@1,0"
+factory: |
+  .. l< .. u< ..
+---
+description: long_handed_inserter/W vs ug_down/N
+graph: "d@3,0 -> l@1,0"
+factory: |
+  .. l< .. d^ ..
+---
+description: long_handed_inserter/W vs ug_down/E
+graph: "d@3,0 -> l@1,0"
+factory: |
+  .. l< .. d> ..
+---
+description: long_handed_inserter/W vs ug_down/S
+graph: "d@3,0 -> l@1,0"
+factory: |
+  .. l< .. dv ..
+---
+description: long_handed_inserter/W vs ug_down/W
+graph: "d@3,0 -> l@1,0"
+factory: |
+  .. l< .. d< ..

--- a/factorion_rs/tests/factories/long_handed_inserter_underground.yaml
+++ b/factorion_rs/tests/factories/long_handed_inserter_underground.yaml
@@ -1,0 +1,15 @@
+# Long inserter spanning an underground-belt entrance and exit. It picks up from
+# the entrance (d) two tiles behind and drops onto the exit (u) two tiles ahead.
+#
+# Note the THIRD edge: the entrance and exit also pair with each other
+# (d -> u). That tunnel link is the undergrounds' own doing — it forms whenever
+# a matching entrance/exit are in range and same-facing, and the tunnel passes
+# straight beneath the long inserter on the surface — so all three edges are
+# real and the graph asserts every one.
+description: long inserter bridges an underground entrance and exit at reach 2
+graph: |
+  d@0,0 -> l@2,0
+  l@2,0 -> u@4,0
+  d@0,0 -> u@4,0
+factory: |
+  d> .. l> .. u>

--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -71,6 +71,7 @@ PLACEABLE_ENTITIES = [
     "underground_belt",
     "splitter",
     "inserter",
+    "long_handed_inserter",
     "stack_inserter",
     "bulk_inserter",
     "assembling_machine_1",
@@ -93,7 +94,7 @@ HOTBAR = [
     "stack_inserter",
     "bulk_inserter",
     "assembling_machine_1",
-    None,
+    "long_handed_inserter",
     None,
     "empty",
 ]

--- a/tests/test_graph_construction.py
+++ b/tests/test_graph_construction.py
@@ -99,6 +99,41 @@ class TestHandcraftedGraphSnapshots:
             (_n("inserter", 3, 0), _n("bulk_inserter", 4, 0)),
         }
 
+    def test_long_handed_inserter_reaches_two_tiles(self):
+        # A long-handed inserter reaches TWO tiles: it picks up from the source
+        # two cells behind it (0,0) and drops onto the sink two cells ahead
+        # (4,0), skipping the empty cells (1,0) and (3,0) in between.
+        w = make_world(6)
+        set_entity(w, 0, 0, "source", Direction.EAST, "copper_cable")
+        set_entity(w, 2, 0, "long_handed_inserter", Direction.EAST)
+        set_entity(w, 4, 0, "sink", Direction.EAST, "copper_cable")
+        nodes, edges = _summary(build_factory_graph(w))
+        assert nodes == {
+            _n("stack_inserter", 0, 0),
+            _n("long_handed_inserter", 2, 0),
+            _n("bulk_inserter", 4, 0),
+        }
+        assert edges == {
+            (_n("stack_inserter", 0, 0), _n("long_handed_inserter", 2, 0)),
+            (_n("long_handed_inserter", 2, 0), _n("bulk_inserter", 4, 0)),
+        }
+
+    def test_long_handed_inserter_skips_adjacent_tiles(self):
+        # Belts sit directly behind/ahead of the long inserter (distance 1). A
+        # long inserter only ever touches tiles at distance 2, so neither belt
+        # connects and the graph has no edges.
+        w = make_world(6)
+        set_entity(w, 0, 0, "transport_belt", Direction.EAST)
+        set_entity(w, 1, 0, "long_handed_inserter", Direction.EAST)
+        set_entity(w, 2, 0, "transport_belt", Direction.EAST)
+        nodes, edges = _summary(build_factory_graph(w))
+        assert nodes == {
+            _n("transport_belt", 0, 0),
+            _n("long_handed_inserter", 1, 0),
+            _n("transport_belt", 2, 0),
+        }
+        assert edges == set()
+
     def test_underground_belt_run(self):
         # belt → underground(down) … underground(up) → belt.
         w = make_world(6)

--- a/tests/test_handcrafted.py
+++ b/tests/test_handcrafted.py
@@ -197,6 +197,21 @@ class TestInserterPatterns:
         t, u = rs_throughput(world)
         assert t == pytest.approx(0.86, abs=1e-6)
 
+    def test_long_handed_inserter_reaches_two_tiles(self):
+        """Source ... long-handed inserter ... sink, two-tile gaps each side.
+
+        The long-handed inserter picks up from the source two tiles behind it
+        and drops onto the sink two tiles ahead, skipping the empty cells in
+        between. Throughput is inserter-limited (0.86), same as a plain
+        inserter — only the reach differs.
+        """
+        world = make_world(7)
+        set_entity(world, 0, 0, "stack_inserter", Direction.EAST, "copper_cable")
+        set_entity(world, 2, 0, "long_handed_inserter", Direction.EAST)
+        set_entity(world, 4, 0, "bulk_inserter", Direction.EAST, "copper_cable")
+        t, u = rs_throughput(world)
+        assert t == pytest.approx(0.86, abs=1e-6)
+
     def test_inserter_all_directions(self):
         """Inserters in all four cardinal directions."""
         cases: list[

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -69,13 +69,20 @@ class TestPyItemsBinding:
         rs = factorion_rs.py_items()
         ids = sorted(rs.keys())
         sink_id, source_id = ids[-2], ids[-1]
-        # Placeable: agent-buildable (1..5) + env-spawned source/sink (last two)
-        for value in [1, 2, 3, 4, 5, sink_id, source_id]:
+        # The long-handed inserter is an inserter variant: it carries a recipe
+        # like the other mid-range items but is *also* a placeable entity (it
+        # reaches two tiles instead of one). Placeability is decided per-item,
+        # not by id range, so it sits in the placeable set despite its id.
+        lhi_id = next(v for v in ids if rs[v]["name"] == "long_handed_inserter")
+        # Placeable: agent-buildable (1..5) + the long-handed inserter +
+        # env-spawned source/sink (last two).
+        placeable = {1, 2, 3, 4, 5, lhi_id, sink_id, source_id}
+        for value in placeable:
             assert rs[value]["is_placeable"] is True, f"id {value} should be placeable"
         # Everything else (non-placeable items) — recipe ingredients,
         # raw materials, and non-modeled buildings exposed only as items.
         for value in ids:
-            if value in {1, 2, 3, 4, 5, sink_id, source_id}:
+            if value in placeable:
                 continue
             assert rs[value]["is_placeable"] is False, (
                 f"id {value} ({rs[value]['name']!r}) should not be placeable"


### PR DESCRIPTION
## Summary

Adds a new `LongHandedInserter` entity variant that reaches two tiles instead of one. It picks up from the tile two cells behind it and drops onto the tile two cells ahead, skipping the immediately adjacent cell entirely. Throughput and interaction rules are identical to a plain inserter; only the reach differs.

## Key Changes

- **New entity type**: `LongHandedInserter` struct in `entities.rs` with reach=2 connectivity logic
- **Updated `EntityEnum`**: Added `LongHandedInserter` variant and routed all trait methods (`kind`, `connections`, `transform_flow`)
- **Generalized inserter connectivity**: Refactored `inserter_connections()` to accept a `reach` parameter (1 for plain inserters, 2 for long-handed), allowing both to share the same core logic
- **Item enum**: Added `LongHandedInserter` to `Item` enum in `types.rs` with placeability flag set to `true`
- **Textual representation**: Added `'l'` glyph for long-handed inserters in `textual.rs`
- **Factory builder**: Added `long_handed_inserter` to the entity list in `scripts/factory_builder.py`

## Implementation Details

The long-handed inserter's reach-2 behavior is implemented by multiplying the direction delta by the reach value when computing source/destination positions:
- Source position: `(x - dx * reach, y - dy * reach)` instead of `(x - dx, y - dy)`
- Destination position: `(x + dx * reach, y + dy * reach)` instead of `(x + dx, y + dy)`

This ensures the inserter only ever interacts with the tile exactly `reach` cells away, never touching intermediate cells. When the reach-2 cell lands on a multi-tile entity (e.g., an assembler), the edge is canonicalized to the entity's anchor node by `build_graph`.

## Test Coverage

Comprehensive test fixtures added:
- `long_handed_inserter.yaml` — Basic reach-2 behavior (vertical and horizontal)
- `long_handed_inserter_to_other.yaml` — Connectivity oracle: all 64 combinations of long inserter facing (N/E/S/W) vs target entity type (belt/inserter/ug_up/ug_down) and target facing
- `long_handed_inserter_skip.yaml` — Verifies adjacent cells are always skipped
- `long_handed_inserter_source_sink.yaml` — Interaction with source/sink markers
- `long_handed_inserter_multitile.yaml` — Multi-tile entity (assembler) edge canonicalization
- `long_handed_inserter_throughput.yaml` — End-to-end throughput validation (0.86 i/s, same as plain inserter)

Unit tests in `entities.rs` verify reach-2 pickup/drop and that adjacent tiles are correctly skipped.

https://claude.ai/code/session_01MpRn6J4nQY2zx3k2ic1r4f