### PR TITLE
Remove debug print statement from FactorioEnv initialization

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -511,7 +511,6 @@ class FactorioEnv(gym.Env):
             idx = 0
         self.idx = idx
 
-        print(f"FactorioEnv({size=}, {max_steps=}, {render_mode=}, {idx=})")
         self.max_steps = max_steps
 
         self._world_CWH = torch.zeros((len(Channel), self.size, self.size))


### PR DESCRIPTION
## Summary
Removes a debug print statement that was logging environment initialization parameters during `FactorioEnv.__init__()`.

## Changes
- Removed the debug print statement `print(f"FactorioEnv({size=}, {max_steps=}, {render_mode=}, {idx=})")` from `FactorioEnv.__init__()` in `ppo.py`

## Details
This print statement was outputting initialization details to stdout on every environment instantiation, which is unnecessary noise during training runs and can clutter logs. The initialization parameters are already tracked through W&B logging and other instrumentation in the training pipeline.

https://claude.ai/code/session_01RHT98wMCavrCAh62C3kFkK