### PR TITLE
Ignore stale factorio-data checkouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ claude-resume.sh
 *.pt
 .claude/settings.local.json
 tests/benchmarks/baseline_signature.json
+# Removed as a submodule in #217; stale clones may linger in cached remote envs.
+factorio-data/


### PR DESCRIPTION
PR #217 removed the factorio-data submodule as dead weight, but cached
remote environments (and the session-start hook) can still leave a stale
clone at factorio-data/, which then shows up as an untracked directory.
Ignore it so leftover clones don't dirty the working tree.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014Zyg2SoTZi1peH5MhjEo8g