### PR TITLE
sft: add live tqdm progress bar to the training loop

### DIFF
--- a/sft.py
+++ b/sft.py
@@ -1197,8 +1197,6 @@ def train_sft(args: SFTArgs):
     epoch = 0
     next_eval_at = args.eval_every_n_samples
     stream_done = False
-    # Live per-batch progress (samples/s, ETA) on stderr so a single-epoch run
-    # stays visible between the sparse eval prints, even under buffered stdout.
     pbar = tqdm.tqdm(total=total_samples, unit="smpl", unit_scale=True)
     while not stream_done:
         t_train = time.time()
@@ -1289,7 +1287,7 @@ def train_sft(args: SFTArgs):
             scheduler.step()
             global_step += 1
             samples_seen += B
-            pbar.update(B)  # cheap tick, no GPU sync
+            pbar.update(B)
 
             acc_loss += torch.stack([
                 loss, loss_tile, loss_ent, loss_dir, loss_item, loss_misc, loss_eot

--- a/sft.py
+++ b/sft.py
@@ -23,6 +23,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.optim as optim
+import tqdm
 import tyro
 from torch.utils.data import DataLoader, TensorDataset
 
@@ -1196,6 +1197,9 @@ def train_sft(args: SFTArgs):
     epoch = 0
     next_eval_at = args.eval_every_n_samples
     stream_done = False
+    # Live per-batch progress (samples/s, ETA) on stderr so a single-epoch run
+    # stays visible between the sparse eval prints, even under buffered stdout.
+    pbar = tqdm.tqdm(total=total_samples, unit="smpl", unit_scale=True)
     while not stream_done:
         t_train = time.time()
         agent.train()
@@ -1285,6 +1289,7 @@ def train_sft(args: SFTArgs):
             scheduler.step()
             global_step += 1
             samples_seen += B
+            pbar.update(B)  # cheap tick, no GPU sync
 
             acc_loss += torch.stack([
                 loss, loss_tile, loss_ent, loss_dir, loss_item, loss_misc, loss_eot
@@ -1654,7 +1659,7 @@ def train_sft(args: SFTArgs):
             rollout_seconds = None
             per_kind_thp_n = {}
 
-        print(
+        pbar.write(
             f"{samples_seen:>{len(str(total_samples))}}/{total_samples} samples "
             f"(epoch {epoch}/{args.epochs}) | "
             f"train_loss={train_loss:.4f} train_acc={train_acc:.3f} "
@@ -1680,7 +1685,7 @@ def train_sft(args: SFTArgs):
                 for k in LessonKind
                 if per_kind_n[k.name] > 0
             )
-            print(f"  per-kind val_acc: {kind_summary}")
+            pbar.write(f"  per-kind val_acc: {kind_summary}")
 
         if args.track and run is not None:
             # Drive wandb's underlying _step with samples_seen (cumulative
@@ -1753,8 +1758,9 @@ def train_sft(args: SFTArgs):
             best_val_throughput = overall_thp
             torch.save(agent.state_dict(), args.checkpoint_path)
             ever_saved = True
-            print(f"  -> Saved best checkpoint (val/thput {overall_thp:.3f})")
+            pbar.write(f"  -> Saved best checkpoint (val/thput {overall_thp:.3f})")
 
+    pbar.close()
     if not ever_saved:
         # Rollouts disabled or no val factories — fall back to the final model
         # so a checkpoint always exists.


### PR DESCRIPTION
## Summary

Follow-up to #238. After that PR moved SFT eval/logging from per-epoch to per-sample cadence, a single-epoch run over millions of samples only printed at eval boundaries (every `eval_every_n_samples`, default 1M). Since the CI training script runs `python sft.py` with stdout redirected, Python **block-buffers** those prints — so the run showed nothing for minutes even though it was training fine.

PPO never had this problem because it drives a `tqdm` bar (written to stderr, unbuffered). SFT had no such bar. This adds one.

## Changes

- Add a per-batch `tqdm` progress bar over the SFT training loop showing live **samples/s and ETA**, so a long single-epoch run gives continuous feedback between the sparse eval prints — visible even under buffered/redirected stdout.
- Route the eval-summary lines through `pbar.write(...)` so they flush and interleave cleanly with the bar instead of clobbering it.

9 insertions, 3 deletions in `sft.py`.

## Verification

- `ruff` + `ty` clean.
- SFT smoke run with stdout piped (block-buffered): the bar advances continuously (`0% → 20% → 36% → …`) while the `N/total samples … val_acc=…` lines land at each eval point.
- `tests/test_sft.py`: 107 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKRguZvtLK513jhmRzkTG2

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKRguZvtLK513jhmRzkTG2)_