### PR TITLE
Fix SFT metric logging (W&B commit + stdout) and DataLoader hang

### DIFF
--- a/sft.py
+++ b/sft.py
@@ -994,13 +994,14 @@ def train_sft(args: SFTArgs):
         # so memory is bounded by the prefetch buffer. pin_memory + non_blocking
         # (in the batch source) hide the per-batch host->device copy behind the
         # GPU step.
-        stream_workers = os.cpu_count() or 1
+        stream_workers = min(16, os.cpu_count() or 1)
         train_stream_loader = DataLoader(
             StreamingDemoDataset(args.size, max_level, train_base, args.num_samples),
             batch_size=args.batch_size,
             num_workers=stream_workers,
             pin_memory=(device.type == "cuda"),
             persistent_workers=stream_workers > 0,
+            multiprocessing_context="forkserver",
         )
         n_train = args.num_samples
         steps_per_epoch = _steps_per_epoch(

--- a/sft.py
+++ b/sft.py
@@ -8,6 +8,7 @@ Usage:
     python ppo.py --start_from sft_checkpoint.pt ...
 """
 
+import io
 import json
 import os
 import random
@@ -902,6 +903,8 @@ def _dir_distance_diagnostics(distances, mismatches):
 
 def train_sft(args: SFTArgs):
     """Main SFT training loop."""
+    if isinstance(sys.stdout, io.TextIOWrapper):
+        sys.stdout.reconfigure(line_buffering=True)
     random.seed(args.seed)
     np.random.seed(args.seed)
     torch.manual_seed(args.seed)
@@ -1653,6 +1656,7 @@ def train_sft(args: SFTArgs):
                     **_dir_distance_diagnostics(dist_eval, dir_mismatch_eval),
                 },
                 step=samples_seen,
+                commit=True,
             )
 
         # Track best val accuracy for the summary, but DON'T select on it.


### PR DESCRIPTION
## Problem

A real SFT run (15M samples) showed no metrics in W&B, no incremental
console output, and hung at `161k/15M` until it was cancelled
([CI run](https://github.com/beyarkay/factorion/actions/runs/28670925417/job/85033802033)).
Three separate bugs, all introduced by the recent eval-cadence / tqdm /
streaming changes (#238, #240, #239), which compound: the hang means only
the first eval ran, and the two logging bugs meant that one eval reached
neither W&B nor the console.

## Fixes

**1. W&B metrics never committed live.** `run.log({...}, step=samples_seen)`
defaults to `commit=False` whenever an explicit `step` is passed (verified
in the wandb 0.27 docstring), so each eval's row was only finalised when the
*next* eval logged a larger step — and the final/only eval flushed just at
`run.finish()`. A run that hangs or is cancelled before the next eval uploads
nothing. → pass `commit=True`.

**2. stdout block-buffered.** The pod runs `python` without `-u`, stdout is a
pipe over SSH, and `tqdm.write()` → `sys.stdout` doesn't flush, so every
per-eval summary line sat in the buffer until process exit. → line-buffer
stdout (guarded for pytest's capture object).

**3. DataLoader hang at 161k.** The streaming path used
`num_workers=os.cpu_count()` (~64 on the pod) with the default Linux `fork`
start method. Forking that many workers from a CUDA-initialised, multi-threaded
(wandb) parent deadlocks — `fork()` copies the parent's mutexes in whatever
state they were in but not the threads holding them, so a worker blocks forever
on an inherited-locked mutex; 64 workers also balloon RAM enough for one to be
OOM-killed, which hangs the loader on that dead worker. It froze right after the
first eval drained the prefetch buffer. → cap workers at `min(16, cpu_count)`
and use `multiprocessing_context="forkserver"` (clean worker processes, no
inherited locks). This hang is new to #239; the old materialised path used
`num_workers=0`.

## Verification

- `ruff check` ✓, `ty check` ✓
- SFT smoke (checklist, size 5) ✓ — exercises the stream + forkserver path
- Streaming run with repeated eval pauses ✓ — the exact pause→resume sequence
  that hung on the pod
- `train_sft` e2e + logging tests ✓
- Confirmed the stdout fix flushes *during* a live run (lines appear before the
  process exits), not only at exit

**Caveat:** the hang only reproduces on Linux+CUDA (macOS uses `spawn`, not
`fork`), so the DataLoader fix can't be fully validated locally — a pod SFT-train
run is the real test. The logging fixes are fully verified.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
