### PR TITLE
Set PPO reward to terminal throughput only

### DIFF
--- a/training_config.py
+++ b/training_config.py
@@ -122,8 +122,8 @@ class PpoArgs(SharedArgs):
     """coefficient of the value function"""
     throughput_reward_scale: float = 1.0
     """scales the terminal throughput reward (paid once when the episode ends, on eot or max_steps); throughput is in [0, 1] so this sets the max terminal reward."""
-    step_penalty: float = 0.01
-    """penalty subtracted every step, so dragging the build out costs reward and the eot head learns to fire once the factory can't improve. Small relative to throughput_reward_scale."""
+    step_penalty: float = 0.0
+    """penalty subtracted every step, so dragging the build out costs reward and the eot head learns to fire once the factory can't improve. Small relative to throughput_reward_scale. Set to 0 so the reward is purely the terminal throughput (thput_eot)."""
     max_grad_norm: float = 1.979
     """the maximum norm for the gradient clipping"""
     target_kl: Optional[float] = 0.02


### PR DESCRIPTION
Default step_penalty to 0.0 so the per-step length penalty is removed and
the episode reward is purely the terminal throughput (thput_eot).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JXrkueSvwFEu3zHe1fVKS8