### PR TITLE
Slim the CI GPU Docker image (19.6→6.6 GB) and pin its build platform

### DIFF
--- a/Dockerfile.ci-gpu
+++ b/Dockerfile.ci-gpu
@@ -1,6 +1,22 @@
-# Build + push by hand when deps change (no CI job):
-#   docker build -f Dockerfile.ci-gpu -t beyarkay/factorion-ci-gpu:latest . && docker push beyarkay/factorion-ci-gpu:latest
-FROM runpod/pytorch:2.4.0-py3.11-cuda12.4.1-devel-ubuntu22.04
+# GPU image for RunPod CI/training. Build + push by hand when deps change (no CI job):
+#   docker build --platform linux/amd64 -f Dockerfile.ci-gpu -t beyarkay/factorion-ci-gpu:latest . \
+#     && docker push beyarkay/factorion-ci-gpu:latest
+#
+# Slim base (python:3.11-slim, ~150 MB) instead of runpod/pytorch's CUDA-devel
+# image: torch 2.12.x+cu130 (pinned in uv.lock) bundles its own CUDA 13 runtime,
+# so the base needs no CUDA toolchain — the RunPod host injects the GPU driver at
+# run time. runpod_start.sh replicates RunPod's SSH bring-up so direct-SSH CI
+# keeps working. --platform pins amd64 so a build from an arm64 Mac still targets
+# RunPod's x86 hosts.
+FROM --platform=linux/amd64 python:3.11-slim-bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System deps: sshd (RunPod connectivity), git/curl/ca-certs, and a C toolchain
+# for maturin's release build of factorion_rs (done at run time in ppo_train.sh).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        openssh-server git curl ca-certificates build-essential \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
         --default-toolchain stable --profile minimal
@@ -14,3 +30,8 @@ RUN cd /tmp/lock && \
     cd / && rm -rf /tmp/lock
 
 RUN python -c "import torch; assert torch.__version__.startswith('2.12'), torch.__version__"
+
+RUN mkdir -p /workspace
+COPY runpod_start.sh /start.sh
+RUN chmod +x /start.sh
+CMD ["/start.sh"]

--- a/runpod_start.sh
+++ b/runpod_start.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Pod bring-up for RunPod, mirroring the SSH + env-export behaviour of RunPod's
+# stock /start.sh (minus the nginx/jupyter bits CI never uses). RunPod injects
+# the pod's public key as $PUBLIC_KEY and auto-sets the RUNPOD_* env vars.
+set -e
+
+setup_ssh() {
+    if [[ $PUBLIC_KEY ]]; then
+        echo "Setting up SSH..."
+        mkdir -p ~/.ssh
+        echo "$PUBLIC_KEY" >> ~/.ssh/authorized_keys
+        chmod 700 -R ~/.ssh
+        ssh-keygen -A            # generate any missing host keys
+        mkdir -p /run/sshd
+        /usr/sbin/sshd           # daemonises; start script continues
+    fi
+}
+
+# Make RUNPOD_* (used by ppo_train.sh's self-terminate watchdog) and PATH visible
+# to SSH sessions, matching RunPod's stock start script.
+export_env_vars() {
+    printenv | grep -E '^RUNPOD_|^PATH=|^_=' \
+        | awk -F = '{ print "export " $1 "=\"" $2 "\"" }' >> /etc/rp_environment
+    echo 'source /etc/rp_environment' >> ~/.bashrc
+}
+
+setup_ssh
+export_env_vars
+
+echo "Pod ready."
+sleep infinity


### PR DESCRIPTION
## What

Rework `Dockerfile.ci-gpu` to shrink the RunPod CI/training image from **19.6 GB → 6.6 GB (−66%)** and make it build correctly from an arm64 Mac.

## Why it was so big

~10 GB of the old image was dead weight baked into the `runpod/pytorch:…-cuda12.4.1-devel` base's own layers — which a derived Dockerfile **cannot** remove (Docker layers are additive; a later `pip uninstall`/`apt purge` only adds a whiteout layer, the bytes still ship):

| Size | Base layer | Why it's dead |
|------|-----------|---------------|
| 5.3 GB | base's `pip install torch torchvision torchaudio` (2.4.0 **+cu124**) | our lockfile overwrites `torch` with **2.12.1+cu130**; the cu12 nvidia wheels + torchvision/torchaudio 2.4.x just linger (and are ABI-broken against the new torch) |
| 5.0 GB | base's apt `cuda-*-dev` / `libcublas-dev` / nsight (CUDA 12.4 **devel** toolchain) | torch bundles its own cu130 runtime; the host injects the driver. `nvcc` is only used in a non-fatal diagnostic echo |

So the only real fix is changing the base.

## What changed

- **Base → `python:3.11-slim-bookworm`** (~150 MB). Keeps only what's needed: `openssh-server`, `git`/`curl`/`ca-certificates`, `build-essential` (for maturin's release build of `factorion_rs`), the Rust toolchain, and the frozen lockfile (which brings `torch 2.12.1+cu130` + its own CUDA 13 runtime).
- **`runpod_start.sh`** replicates RunPod's SSH bring-up (pulled from the stock base's `/start.sh`): `$PUBLIC_KEY` → `authorized_keys`, host-key generation, `sshd`, and `RUNPOD_*` env export for SSH sessions. Drops only the nginx/jupyter bits CI never uses. RunPod connects via direct SSH into the container, so this path must be preserved.
- **`FROM --platform=linux/amd64`** pins the target arch, so a build from an arm64 Mac still produces a RunPod-compatible x86 image (no `--platform` flag to remember). This trips a benign buildkit lint (`FromPlatformFlagConstDisallowed`) — intended, since RunPod is x86-only.

## Verification (local, on the built `linux/amd64` image)

- `import torch` → `2.12.1+cu130` (same GPU capability as before).
- A real release `maturin build` of `factorion_rs` builds, installs, and imports cleanly (`build_factory`, `py_build_graph`, `render_factory`, …) — i.e. the image does exactly what `ppo_train.sh` does at run time.
- Final size **6.59 GB**.

## Not done in this PR

- **The image has NOT been pushed to Docker Hub** — `beyarkay/factorion-ci-gpu:latest` on the registry is unchanged.
- **Needs a live RunPod SSH smoke test** before the new image replaces `:latest`: the one thing not verifiable locally is the real `PUBLIC_KEY` handshake (needs an actual pod). The logic mirrors RunPod's own script, so risk is low, but it should be confirmed on a pod first.

## Note for #254

This image preserves RunPod's env path (`RUNPOD_*` exported to SSH sessions via `/etc/rp_environment` + `~/.bashrc`), so whatever gets `RUNPOD_POD_ID`/`RUNPOD_API_KEY` into `ppo_train.sh`'s watchdog over SSH keeps working. Worth a glance if the CI rework changes how the training script is invoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
