### PR TITLE
Only post the dispatch-failure fallback when the dispatcher never replied

### DIFF
--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -60,6 +60,7 @@ jobs:
         run: uv pip install --system tyro runpod wandb pyyaml requests
 
       - name: Dispatch
+        id: dispatch
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
           COMMENT_URL: ${{ github.event.comment.html_url }}
@@ -85,9 +86,12 @@ jobs:
 
       # ci/gh_command.py replies with its own errors; this catches everything
       # BEFORE it (checkout, deps, a PR head with no ci/ directory) so a /ci
-      # command can never fail without a trace on the PR.
+      # command can never fail without a trace on the PR. `replied` guards it:
+      # a run that already commented (e.g. a compare exiting 1 on a failed
+      # assertion after posting its report) must not add a bogus "failed
+      # before it could reply".
       - name: Report dispatch failure
-        if: failure()
+        if: failure() && steps.dispatch.outputs.replied != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/ci/gh_command.py
+++ b/ci/gh_command.py
@@ -237,7 +237,15 @@ def _with_trigger_footer(ctx, body: str) -> str:
 
 
 def _post(ctx, body: str) -> int:
-    return github_api.post_pr_comment(ctx["pr"], _with_trigger_footer(ctx, body))
+    comment_id = github_api.post_pr_comment(ctx["pr"], _with_trigger_footer(ctx, body))
+    # Tell the workflow we replied: its dispatch-failure fallback comment is
+    # only for runs that die BEFORE reaching the PR (a deliberate exit 1 — a
+    # failed compare assertion — already reported itself).
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if output_path:
+        with open(output_path, "a") as fh:
+            fh.write("replied=true\n")
+    return comment_id
 
 
 def cmd_sft(args, ctx) -> None:


### PR DESCRIPTION
A compare that posts its report and then exits 1 on a failed assertion tripped the workflow's `failure()` fallback into adding a bogus "❌ /ci dispatch failed before it could reply" comment right after the report (observed live on PR #243 at 15:38).

The dispatcher now writes a `replied=true` step output on its first successful PR comment, and the fallback step is gated on `steps.dispatch.outputs.replied != 'true'` — so it fires only for runs that genuinely died before reaching the PR (checkout/deps failures, a PR head with no `ci/` directory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129L9UK7XhsRfkRk5pizoKR

---
_Generated by [Claude Code](https://claude.ai/code/session_0129L9UK7XhsRfkRk5pizoKR)_