### PR TITLE
CI: always report pod boot failures to the PR, and fix the vanished-commit root cause

### DIFF
--- a/ci/config.py
+++ b/ci/config.py
@@ -180,6 +180,7 @@ class SweepJob:
     algo: str  # "sft" | "ppo"
     sweep_path: str  # entity/project/sweep_id
     agents_per_pod: int = 5
+    extra_tags: list[str] = field(default_factory=list)  # e.g. pr:<N>, for boot-failure reporting
 
     KIND: ClassVar[str] = "sweep"
 

--- a/ci/gh_command.py
+++ b/ci/gh_command.py
@@ -434,6 +434,7 @@ def cmd_sweep(args, ctx) -> None:
                 algo=algo,
                 sweep_path=sweep_path,
                 agents_per_pod=args.agents_per_pod,
+                extra_tags=[f"pr:{ctx['pr']}"],
             ),
             args.gpu_type,
             wait=False,

--- a/ci/launch.py
+++ b/ci/launch.py
@@ -45,16 +45,32 @@ on_exit() {
     if [ "$rc" -ne 0 ]; then
         echo "[fci] job failed (exit ${rc}); uploading boot log to W&B"
         FCI_RC="$rc" python - << 'PY' || true
+import json
 import os
 
 import wandb
 
+# Carry the same kind:/pr:/... tags the real run would have, so the boot
+# failure flows through the ordinary reporter cron and lands on the PR — a
+# bare boot-failure run is invisible to it (it needs kind: and pr: tags).
+tags = [
+    "ci",
+    "boot-failure",
+    f"kind:{os.environ.get('FCI_KIND', 'unknown')}",
+    f"sha:{os.environ.get('FCI_SHA', 'unknown')[:7]}",
+]
+tags += json.loads(os.environ.get("FCI_EXTRA_TAGS", "[]"))
 run = wandb.init(
     project=os.environ.get("FCI_WANDB_PROJECT", "factorion"),
     name=f"boot-failure-{os.environ.get('RUNPOD_POD_ID', 'unknown')}",
-    tags=["ci", "boot-failure", f"sha:{os.environ.get('FCI_SHA', 'unknown')[:7]}"],
+    tags=tags,
 )
 run.summary["exit_code"] = int(os.environ.get("FCI_RC", "1"))
+try:
+    with open("/workspace/boot.log") as fh:
+        run.summary["boot_log_tail"] = "".join(fh.readlines()[-25:])
+except OSError:
+    pass
 if os.path.exists("/workspace/boot.log"):
     wandb.save("/workspace/boot.log", base_path="/workspace")
 run.finish(exit_code=1)
@@ -68,6 +84,11 @@ echo "[fci] cloning ${FCI_REPO_URL} @ ${FCI_SHA}"
 cd /workspace
 git clone --quiet "${FCI_REPO_URL}" factorion
 cd factorion
+# The head commit can leave every branch tip before the pod boots (PR merged
+# and its branch deleted, or force-pushed), so a plain clone won't contain it.
+# Fetch the exact SHA directly — GitHub still serves it via refs/pull/* — so
+# the checkout succeeds instead of dying with "reference is not a tree".
+git fetch --quiet origin "${FCI_SHA}"
 git checkout --quiet "${FCI_SHA}"
 bash ci/runner.sh
 """
@@ -155,6 +176,10 @@ def launch(
         "FCI_SHA": job.sha,
         "FCI_DEADLINE": str(deadline),
         "FCI_WANDB_PROJECT": WANDB_PROJECT,
+        # For the bootstrap's boot-failure run: the tags the real run would
+        # carry, so a failure that never reaches jobs.py still reports to the PR.
+        "FCI_KIND": job.KIND,
+        "FCI_EXTRA_TAGS": json.dumps(list(getattr(job, "extra_tags", []))),
     }
     if wandb_run_id:
         env["FCI_WANDB_RUN_ID"] = wandb_run_id

--- a/ci/report.py
+++ b/ci/report.py
@@ -635,6 +635,40 @@ def run_summary_markdown(
     return "\n".join(lines)
 
 
+def boot_failure_markdown(
+    run_id: str,
+    url: str,
+    kind: str,
+    sha7: str,
+    log_tail: str = "",
+) -> str:
+    """PR comment for a pod that died before it could start the run.
+
+    Boot failures never reach the training command (no metrics to report), so
+    this is a purpose-built message: what happened, the likely cause, and the
+    tail of the boot log for immediate diagnosis.
+    """
+    import os
+
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    commit = f"[`{sha7}`](https://github.com/{repo}/commit/{sha7})" if repo else f"`{sha7}`"
+    lines = [
+        RUN_MARKER_TEMPLATE.format(run_id=run_id),
+        f"## &#x274C; CI {kind} pod failed to boot",
+        "",
+        f"The pod for commit {commit} never started the run — it failed while "
+        "cloning the repo, building the Rust extension, or during setup, so no "
+        "training happened.",
+        "",
+        f"[Boot log on W&B]({url}) &middot; a common cause is the commit having "
+        "left every branch (PR merged and its branch deleted, or force-pushed) "
+        "after the pod was launched.",
+    ]
+    if log_tail.strip():
+        lines += ["", "```", log_tail.strip()[-1500:], "```"]
+    return "\n".join(lines)
+
+
 def select_unreported(
     candidates: list[dict], existing_bodies: list[str]
 ) -> list[dict]:
@@ -699,6 +733,8 @@ def post_pending_reports(window_days: int = 3, dry_run: bool = False) -> int:
                     (t.removeprefix("sha:") for t in tags if t.startswith("sha:")), "?"
                 ),
                 "summary_flat": flat,
+                "boot_failure": "boot-failure" in tags,
+                "boot_log_tail": str(summary.get("boot_log_tail", "")),
             }
         )
 
@@ -706,7 +742,24 @@ def post_pending_reports(window_days: int = 3, dry_run: bool = False) -> int:
     for pr_number, candidates in by_pr.items():
         bodies = github_api.list_pr_comment_bodies(pr_number)
         for c in select_unreported(candidates, bodies):
-            md = run_summary_markdown(**c)
+            if c["boot_failure"]:
+                md = boot_failure_markdown(
+                    run_id=c["run_id"],
+                    url=c["url"],
+                    kind=c["kind"],
+                    sha7=c["sha7"],
+                    log_tail=c["boot_log_tail"],
+                )
+            else:
+                md = run_summary_markdown(
+                    run_id=c["run_id"],
+                    name=c["name"],
+                    state=c["state"],
+                    url=c["url"],
+                    kind=c["kind"],
+                    sha7=c["sha7"],
+                    summary_flat=c["summary_flat"],
+                )
             if dry_run:
                 print(f"[dry-run] would comment on PR #{pr_number} for run {c['run_id']}")
             else:

--- a/tests/test_ci_gh_command.py
+++ b/tests/test_ci_gh_command.py
@@ -234,6 +234,11 @@ class TestSweepDispatch:
         specs = [_job_spec(p) for p in gh_ctx["pods"]]
         assert {s["kind"] for s in specs} == {"sweep"}
         assert {s["sweep_path"] for s in specs} == {"me/factorion/swp-sft"}
+        # Sweep pods carry the pr tag too, so a pod that dies before its agents
+        # start still reports the boot failure to the PR via the reporter cron.
+        for pod in gh_ctx["pods"]:
+            assert "pr:42" in json.loads(pod["env"]["FCI_EXTRA_TAGS"])
+            assert pod["env"]["FCI_KIND"] == "sweep"
         # The launch comment shows what's being swept, not just pod ids.
         launch_body = gh_ctx["comments"][0][1]
         assert "val/acc" in launch_body and "run_cap 30" in launch_body

--- a/tests/test_ci_gh_command.py
+++ b/tests/test_ci_gh_command.py
@@ -88,6 +88,16 @@ class TestSftDispatch:
         assert pod["env"]["FCI_SHA"] == SHA
         assert pod["name"].startswith("factorion-ci-sft-")
 
+        # A boot failure (pod dies before jobs.py) still reports to the PR:
+        # the pod carries the kind + pr tags the reporter cron keys on, and
+        # the bootstrap fetches the exact SHA so a vanished branch tip (merged
+        # + deleted PR branch, or force-push) still checks out.
+        assert pod["env"]["FCI_KIND"] == "sft"
+        assert "pr:42" in json.loads(pod["env"]["FCI_EXTRA_TAGS"])
+        boot = base64.b64decode(pod["env"]["FCI_BOOT_B64"]).decode()
+        assert 'git fetch --quiet origin "${FCI_SHA}"' in boot
+        assert "boot-failure" in boot and "FCI_EXTRA_TAGS" in boot
+
         ((pr, body),) = gh_ctx["comments"]
         assert pr == 42
         assert "pod-1" in body

--- a/tests/test_ci_infra.py
+++ b/tests/test_ci_infra.py
@@ -27,6 +27,7 @@ from ci.gh_command import parse_comment
 from ci.jobs import ppo_command, sft_command, sweep_agent_command
 from ci.report import (
     MetricRow,
+    boot_failure_markdown,
     compare_metric_rows,
     evaluate_assertion,
     flatten_summary,
@@ -417,6 +418,23 @@ class TestReporter:
         candidates = [{"run_id": "aaa"}, {"run_id": "bbb"}]
         bodies = ["intro", "report\n<!-- factorion-ci-run:aaa -->"]
         assert select_unreported(candidates, bodies) == [{"run_id": "bbb"}]
+
+    def test_boot_failure_reports_clearly_with_log_tail(self):
+        # A pod that dies before the run starts (clone/build/setup) still gets
+        # a PR comment — the same marker makes it idempotent for the cron, and
+        # it carries the boot-log tail so the failure is diagnosable in place.
+        md = boot_failure_markdown(
+            run_id="deadb33f",
+            url="https://wandb.ai/x/y/runs/deadb33f",
+            kind="ppo",
+            sha7=SHA[:7],
+            log_tail="[fci] cloning ...\nfatal: reference is not a tree: abc123\n",
+        )
+        assert "<!-- factorion-ci-run:deadb33f -->" in md
+        assert "failed to boot" in md
+        assert "ppo" in md
+        assert "https://wandb.ai/x/y/runs/deadb33f" in md
+        assert "reference is not a tree" in md  # the actual error, in a code block
 
     def test_run_summary_contains_marker_and_headline(self):
         md = run_summary_markdown(


### PR DESCRIPTION
A CI pod that died before reaching the training command (e.g. the checkout
failing) uploaded a `boot-failure` W&B run but never surfaced anything on the
PR, so failures went unnoticed. Two fixes:

Root cause: the head commit can leave every branch tip before the pod boots
(PR squash-merged + branch deleted, or force-pushed), and a plain `git clone`
only fetches branch heads — so `git checkout <sha>` died with "reference is
not a tree". Fetch the exact SHA directly (GitHub still serves it via
refs/pull/*) before the checkout.

Reporting: the boot-failure run carried only ci/boot-failure/sha tags, but the
reporter cron keys on kind: and pr: tags, so it skipped them. Pass the job's
KIND + extra_tags (which include pr:<N>) to the bootstrap so the failure run
is tagged like the real run would be and flows through the existing
W&B -> reporter-cron -> PR-comment pipeline. Give it a dedicated
`boot_failure_markdown` comment — what happened, the likely cause, and the
tail of the boot log for in-place diagnosis. Compare fan-out runs still carry
cmp: tags and are handled by the compare flow as before.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01T7oYcbN8jCLb8NGcfqqkyB