### PR TITLE
Add type casts to critic head weight assertions in test

### DIFF
--- a/tests/test_rl_from_checkpoint.py
+++ b/tests/test_rl_from_checkpoint.py
@@ -11,6 +11,7 @@ sensible RL fine-tuning run rather than RL-from-scratch:
 
 import os
 import sys
+from typing import cast
 
 import numpy as np
 import pytest
@@ -190,9 +191,11 @@ class TestCriticHeadStd:
         orthogonal (1, N) init makes the row's L2 norm equal to the std."""
         small = AgentCNN(envs, layers=(16, 16, 16), critic_head_std=0.01)
         big = AgentCNN(envs, layers=(16, 16, 16), critic_head_std=1.0)
-        assert small.critic_head[-1].weight.norm().item() < big.critic_head[-1].weight.norm().item()
-        assert small.critic_head[-1].weight.norm().item() == pytest.approx(0.01, abs=1e-3)
-        assert big.critic_head[-1].weight.norm().item() == pytest.approx(1.0, abs=1e-2)
+        small_weight = cast(torch.Tensor, small.critic_head[-1].weight)
+        big_weight = cast(torch.Tensor, big.critic_head[-1].weight)
+        assert small_weight.norm().item() < big_weight.norm().item()
+        assert small_weight.norm().item() == pytest.approx(0.01, abs=1e-3)
+        assert big_weight.norm().item() == pytest.approx(1.0, abs=1e-2)
 
     def test_post_load_reinit_replaces_weights_in_place_at_new_std(self, agent):
         """The post-load re-init (layer_init on the value head) rewrites it in


### PR DESCRIPTION
## Summary
Add explicit type casts to resolve type checker warnings in `test_construction_scales_value_head_magnitude`. The test was accessing `.weight` attributes on neural network modules without type annotations, causing potential type checker issues.

## Changes
- Import `cast` from `typing` module
- Extract `small.critic_head[-1].weight` and `big.critic_head[-1].weight` into local variables with explicit `torch.Tensor` type casts
- Update assertions to use the cast variables instead of inline attribute access

## Details
This change improves type safety and clarity by:
1. Making the tensor types explicit via `cast(torch.Tensor, ...)` 
2. Reducing repetition of the same attribute access pattern across three assertions
3. Helping static type checkers (like mypy) understand that these values are `torch.Tensor` objects with `.norm()` and `.item()` methods

The functional behavior of the test remains unchanged.

https://claude.ai/code/session_01J5cNLQCZVw1ocC5twfTcG6