### PR TITLE
Add recipe metadata: produced_by machines and total_raw costs

### DIFF
--- a/factorion.py
+++ b/factorion.py
@@ -164,6 +164,14 @@ class Recipe:
     consumes: dict[str, float]
     produces: dict[str, float]
     crafting_time: float  # canonical wiki seconds per craft
+    # Machine item-names that can craft this recipe (hand-crafting excluded);
+    # the assembling-machine tiers for this fluid-free set.
+    produced_by: list[str]
+    # Fully-expanded raw ingredient cost (each input reduced through the
+    # recipe set to items with no recipe) and the cumulative craft time of
+    # that whole tree. Derived in Rust — see types.rs::TotalRaw.
+    total_raw: dict[str, float]
+    total_raw_time: float
 
 
 # Recipes are defined in Rust (factorion_rs/src/types.rs::all_recipes)
@@ -174,6 +182,9 @@ recipes = {
         consumes=dict(data["consumes"]),
         produces=dict(data["produces"]),
         crafting_time=data["crafting_time"],
+        produced_by=list(data["produced_by"]),
+        total_raw=dict(data["total_raw"]),
+        total_raw_time=data["total_raw_time"],
     )
     for name, data in factorion_rs.py_recipes().items()
 }

--- a/factorion.py
+++ b/factorion.py
@@ -164,12 +164,7 @@ class Recipe:
     consumes: dict[str, float]
     produces: dict[str, float]
     crafting_time: float  # canonical wiki seconds per craft
-    # Machine item-names that can craft this recipe (hand-crafting excluded);
-    # the assembling-machine tiers for this fluid-free set.
     produced_by: list[str]
-    # Fully-expanded raw ingredient cost (each input reduced through the
-    # recipe set to items with no recipe) and the cumulative craft time of
-    # that whole tree. Derived in Rust — see types.rs::TotalRaw.
     total_raw: dict[str, float]
     total_raw_time: float
 

--- a/factorion_rs/__init__.pyi
+++ b/factorion_rs/__init__.pyi
@@ -18,6 +18,9 @@ class RecipeData(TypedDict):
     consumes: dict[str, float]
     produces: dict[str, float]
     crafting_time: float
+    produced_by: list[str]
+    total_raw: dict[str, float]
+    total_raw_time: float
 
 def simulate_throughput(world: NDArray[np.int64]) -> tuple[float, int]: ...
 def py_build_graph(

--- a/factorion_rs/src/factory_gen.rs
+++ b/factorion_rs/src/factory_gen.rs
@@ -1915,13 +1915,17 @@ fn build_memorise_recipes(
     n_ingredients: usize,
 ) -> Option<BuiltFactory> {
     let s = size as i64;
-    // Only recipes with exactly `n_ingredients` inputs are eligible — the
-    // lesson drills memorising recipe identity at a fixed input-arm count. If no
-    // recipe matches (an ingredient count the table never uses) there is nothing
-    // to build, so reject immediately.
+    // Eligible recipes have exactly `n_ingredients` inputs (the lesson drills
+    // memorising recipe identity at a fixed input-arm count) and must be
+    // craftable by the assembling machine 1 this lesson places — otherwise the
+    // machine would be tagged with a recipe it can't make. If nothing matches
+    // (an ingredient count the table never uses) there is nothing to build, so
+    // reject immediately.
     let recipes: Vec<(Item, Recipe)> = all_recipes()
         .into_iter()
-        .filter(|(_, r)| r.consumes.len() == n_ingredients)
+        .filter(|(_, r)| {
+            r.consumes.len() == n_ingredients && r.produced_by.contains(&Item::AssemblingMachine1)
+        })
         .collect();
     if recipes.is_empty() {
         return None;
@@ -2146,9 +2150,15 @@ fn build_factory_1_ingredient(
     if s < 7 {
         return None;
     }
+    // Single-ingredient, single-product recipes the placed assembling machine 1
+    // can actually craft (its `produced_by` lists tier 1).
     let recipes: Vec<(Item, Recipe)> = all_recipes()
         .into_iter()
-        .filter(|(_, r)| r.consumes.len() == 1 && r.produces.len() == 1)
+        .filter(|(_, r)| {
+            r.consumes.len() == 1
+                && r.produces.len() == 1
+                && r.produced_by.contains(&Item::AssemblingMachine1)
+        })
         .collect();
     if recipes.is_empty() {
         return None;
@@ -2781,6 +2791,47 @@ mod tests {
                 }
             }
             assert!(built > 40, "{kind:?}: most seeds should build, got {built}");
+        }
+    }
+
+    #[test]
+    fn test_assembler_recipes_are_am1_craftable() {
+        // Every lesson that places an assembling machine 1 must tag it with a
+        // recipe tier 1 can craft — the `produced_by` filter must exclude
+        // engine_unit (the sole advanced-crafting recipe, tiers 2/3 only).
+        let kinds = [
+            LessonKind::Memorise1IngredientRecipes,
+            LessonKind::Memorise2IngredientRecipes,
+            LessonKind::Memorise3IngredientRecipes,
+            LessonKind::Memorise4IngredientRecipes,
+            LessonKind::Factory1Ingredient,
+        ];
+        for kind in kinds {
+            let mut checked = 0;
+            for seed in 0..60u64 {
+                let Some(f) = build_factory(11, kind, seed, true, f64::INFINITY) else {
+                    continue;
+                };
+                for x in 0..f.world.width() {
+                    for y in 0..f.world.height() {
+                        if f.world.entity_at(x, y) != Some(Item::AssemblingMachine1) {
+                            continue;
+                        }
+                        let Some(recipe_item) = f.world.item_at(x, y) else {
+                            continue;
+                        };
+                        let recipe = crate::types::get_recipe(recipe_item).unwrap_or_else(|| {
+                            panic!("{kind:?} seed={seed}: {recipe_item:?} has no recipe")
+                        });
+                        assert!(
+                            recipe.produced_by.contains(&Item::AssemblingMachine1),
+                            "{kind:?} seed={seed}: {recipe_item:?} not craftable by AM1"
+                        );
+                        checked += 1;
+                    }
+                }
+            }
+            assert!(checked > 0, "{kind:?}: no assembler recipes inspected");
         }
     }
 

--- a/factorion_rs/src/lib.rs
+++ b/factorion_rs/src/lib.rs
@@ -47,9 +47,11 @@ use graph::build_graph;
 #[cfg(feature = "pyo3-bindings")]
 use render::render as render_world;
 #[cfg(feature = "pyo3-bindings")]
+use std::collections::HashMap;
+#[cfg(feature = "pyo3-bindings")]
 use throughput::{calc_throughput, factory_score};
 #[cfg(feature = "pyo3-bindings")]
-use types::{all_items, all_recipes, Direction};
+use types::{all_items, all_recipes, Direction, Item, Recipe};
 #[cfg(feature = "pyo3-bindings")]
 use world::World;
 
@@ -161,7 +163,14 @@ fn py_items(py: Python<'_>) -> PyResult<Py<PyDict>> {
 ///
 /// Shape: `{item_name: {"consumes": {item_name: rate, ...},
 ///                      "produces": {item_name: rate, ...},
-///                      "crafting_time": seconds_per_craft}}`.
+///                      "crafting_time": seconds_per_craft,
+///                      "produced_by": [machine_name, ...],
+///                      "total_raw": {item_name: amount, ...},
+///                      "total_raw_time": cumulative_seconds}}`.
+///
+/// `total_raw` is derived (each ingredient reduced through the recipe set to
+/// items with no recipe); `total_raw_time` is the summed craft time of the
+/// whole tree — see [`types::TotalRaw`].
 ///
 /// This is the single source of truth for recipe data — Python builds its
 /// `recipes` dict from this at module load.
@@ -169,7 +178,10 @@ fn py_items(py: Python<'_>) -> PyResult<Py<PyDict>> {
 #[pyfunction]
 fn py_recipes(py: Python<'_>) -> PyResult<Py<PyDict>> {
     let outer = PyDict::new(py);
-    for (item, recipe) in all_recipes() {
+    let recipes = all_recipes();
+    // Built once and shared across every recipe's total_raw expansion.
+    let index: HashMap<Item, Recipe> = recipes.iter().cloned().collect();
+    for (item, recipe) in &recipes {
         let entry = PyDict::new(py);
         let consumes = PyDict::new(py);
         for &(i, rate) in recipe.consumes.iter() {
@@ -179,9 +191,18 @@ fn py_recipes(py: Python<'_>) -> PyResult<Py<PyDict>> {
         for &(i, rate) in recipe.produces.iter() {
             produces.set_item(i.name(), rate)?;
         }
+        let total = recipe.total_raw(&index);
+        let total_raw = PyDict::new(py);
+        for &(i, amount) in total.items.iter() {
+            total_raw.set_item(i.name(), amount)?;
+        }
+        let produced_by: Vec<&str> = recipe.produced_by.iter().map(|m| m.name()).collect();
         entry.set_item("consumes", consumes)?;
         entry.set_item("produces", produces)?;
         entry.set_item("crafting_time", recipe.crafting_time)?;
+        entry.set_item("produced_by", produced_by)?;
+        entry.set_item("total_raw", total_raw)?;
+        entry.set_item("total_raw_time", total.time)?;
         outer.set_item(item.name(), entry)?;
     }
     Ok(outer.into())

--- a/factorion_rs/src/types.rs
+++ b/factorion_rs/src/types.rs
@@ -263,11 +263,15 @@ pub enum Item {
     DischargeDefenseRemote = 83,
     PersonalRoboport = 84,
     FlamethrowerTurret = 85,
+    // Higher assembler tiers aren't agent-placeable; they exist as items so
+    // recipes can name them in `produced_by` (a `crafting` recipe is made by
+    // assembling machine 1/2/3, `advanced-crafting` by 2/3 only).
+    AssemblingMachine3 = 86,
     // Env-spawned, not agent-placeable — must remain the LAST two ids so
     // the policy's entity head can be sized to `len(items) - 2` and
     // structurally exclude them from sampling (see ppo.py).
-    Sink = 86,   // named "bulk_inserter"
-    Source = 87, // named "stack_inserter"
+    Sink = 87,   // named "bulk_inserter"
+    Source = 88, // named "stack_inserter"
 }
 
 impl Item {
@@ -360,8 +364,9 @@ impl Item {
             83 => Some(Item::DischargeDefenseRemote),
             84 => Some(Item::PersonalRoboport),
             85 => Some(Item::FlamethrowerTurret),
-            86 => Some(Item::Sink),
-            87 => Some(Item::Source),
+            86 => Some(Item::AssemblingMachine3),
+            87 => Some(Item::Sink),
+            88 => Some(Item::Source),
             _ => None,
         }
     }
@@ -466,6 +471,7 @@ impl Item {
             Item::DischargeDefenseRemote => "discharge_defense_remote",
             Item::PersonalRoboport => "personal_roboport",
             Item::FlamethrowerTurret => "flamethrower_turret",
+            Item::AssemblingMachine3 => "assembling_machine_3",
         }
     }
 
@@ -597,7 +603,8 @@ impl Item {
             | Item::LightArmor
             | Item::DischargeDefenseRemote
             | Item::PersonalRoboport
-            | Item::FlamethrowerTurret => 0.0,
+            | Item::FlamethrowerTurret
+            | Item::AssemblingMachine3 => 0.0,
         }
     }
 

--- a/factorion_rs/src/types.rs
+++ b/factorion_rs/src/types.rs
@@ -1,4 +1,5 @@
 use nonempty::{nonempty, NonEmpty};
+use std::collections::HashMap;
 use strum::IntoEnumIterator;
 
 /// Channels in the WHC tensor (3rd dimension).
@@ -663,6 +664,27 @@ pub struct Recipe {
     pub consumes: NonEmpty<(Item, f64)>,
     pub produces: NonEmpty<(Item, f64)>,
     pub crafting_time: f64,
+    /// Machines that can craft this recipe (hand-crafting excluded, so the
+    /// list is `NonEmpty` of real entities). Every recipe in this fluid-free
+    /// set is made in assembling machines: tiers 1/2/3 for a `crafting`
+    /// recipe, tiers 2/3 for an `advanced-crafting` one (machine 1 can't).
+    pub produced_by: NonEmpty<Item>,
+}
+
+/// The fully-expanded raw-material cost of one craft of a recipe: every
+/// ingredient reduced recursively through the recipe set until it bottoms
+/// out at items with no recipe (the raws — plates, ore, wood, and the
+/// fluid-gated intermediates the model treats as base), mirroring the
+/// wiki's "Total raw" infobox row.
+///
+/// `time` is the *cumulative* crafting time of the whole tree (summed over
+/// every intermediate craft, at Base-game crafting speed 1), not just the
+/// final recipe's `crafting_time` — so it answers "how much craft-time from
+/// raws" rather than duplicating the recipe's own time.
+#[derive(Debug, Clone)]
+pub struct TotalRaw {
+    pub items: NonEmpty<(Item, f64)>,
+    pub time: f64,
 }
 
 impl Recipe {
@@ -683,6 +705,75 @@ impl Recipe {
             .find(|(i, _)| *i == item)
             .map(|(_, r)| *r)
     }
+
+    /// The total raw cost of one craft of this recipe, expanded through
+    /// `index` (a lookup of produced-item → recipe, e.g. built once from
+    /// [`all_recipes`]). The result is `NonEmpty` because `consumes` is,
+    /// and every ingredient expands to at least one raw.
+    pub fn total_raw(&self, index: &HashMap<Item, Recipe>) -> TotalRaw {
+        let mut time = self.crafting_time;
+        // Seed from the first ingredient so the accumulator is non-empty by
+        // construction; fold the rest in, summing repeated raws.
+        let (head_item, head_qty) = self.consumes.head;
+        let (mut items, seed_time) = raw_expand(head_item, head_qty, index);
+        time += seed_time;
+        for &(ing, qty) in self.consumes.tail.iter() {
+            let (sub, sub_time) = raw_expand(ing, qty, index);
+            time += sub_time;
+            for (raw, amount) in sub {
+                add_raw(&mut items, raw, amount);
+            }
+        }
+        TotalRaw { items, time }
+    }
+}
+
+/// Sum `qty` of `item` into `items`, merging with an existing entry rather
+/// than duplicating it.
+fn add_raw(items: &mut NonEmpty<(Item, f64)>, item: Item, qty: f64) {
+    if let Some(entry) = items.iter_mut().find(|(i, _)| *i == item) {
+        entry.1 += qty;
+        return;
+    }
+    items.push((item, qty));
+}
+
+/// Reduce a demand for `qty` of `item` to its raw components, following
+/// `index` recursively. An item with no recipe is itself raw. Returns the
+/// raws plus the cumulative crafting time spent producing them. The recipe
+/// set is a DAG (no item consumes its own output, directly or transitively),
+/// so the recursion always terminates.
+fn raw_expand(item: Item, qty: f64, index: &HashMap<Item, Recipe>) -> (NonEmpty<(Item, f64)>, f64) {
+    let Some(recipe) = index.get(&item) else {
+        return (NonEmpty::new((item, qty)), 0.0);
+    };
+    // How many crafts yield `qty` of `item` (all recipes list positive
+    // output rates, so the filter only guards against malformed data).
+    let crafts = match recipe.produces_rate(item).filter(|p| *p > 0.0) {
+        Some(per_craft) => qty / per_craft,
+        None => qty,
+    };
+    let mut time = crafts * recipe.crafting_time;
+    let (head_item, head_qty) = recipe.consumes.head;
+    let (mut items, seed_time) = raw_expand(head_item, head_qty * crafts, index);
+    time += seed_time;
+    for &(ing, ing_qty) in recipe.consumes.tail.iter() {
+        let (sub, sub_time) = raw_expand(ing, ing_qty * crafts, index);
+        time += sub_time;
+        for (raw, amount) in sub {
+            add_raw(&mut items, raw, amount);
+        }
+    }
+    (items, time)
+}
+
+/// The total raw cost of a single item's recipe, if it has one. Convenience
+/// wrapper that builds the recipe index from [`all_recipes`]; callers doing
+/// this in bulk should build the index once and call [`Recipe::total_raw`].
+#[allow(dead_code)]
+pub fn total_raw_of(item: Item) -> Option<TotalRaw> {
+    let index: HashMap<Item, Recipe> = all_recipes().into_iter().collect();
+    index.get(&item).map(|recipe| recipe.total_raw(&index))
 }
 
 /// All crafting recipes in the game. The single source of truth — both
@@ -696,6 +787,21 @@ impl Recipe {
 /// MEMORISE_N_INGREDIENT_RECIPES bucket holds an equal 15 recipes; the
 /// parked ones are redundant tier/duplicate variants, kept in source so
 /// they can be restored by deleting the comment markers.
+/// The assembling machines that craft a standard `crafting`-category recipe.
+fn crafting() -> NonEmpty<Item> {
+    nonempty![
+        Item::AssemblingMachine1,
+        Item::AssemblingMachine2,
+        Item::AssemblingMachine3
+    ]
+}
+
+/// The assembling machines that craft an `advanced-crafting` recipe —
+/// assembling machine 1 can't reach it, so only tiers 2 and 3.
+fn advanced_crafting() -> NonEmpty<Item> {
+    nonempty![Item::AssemblingMachine2, Item::AssemblingMachine3]
+}
+
 pub fn all_recipes() -> Vec<(Item, Recipe)> {
     vec![
         // 1 copper plate -> 2 copper cables, 0.5s
@@ -705,6 +811,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::CopperPlate, 1.0)],
                 produces: nonempty![(Item::CopperCable, 2.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         // 3 copper cable + 1 iron plate -> 1 electronic circuit, 0.5s
@@ -714,6 +821,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::CopperCable, 3.0), (Item::IronPlate, 1.0)],
                 produces: nonempty![(Item::ElectronicCircuit, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         // 2 iron plates -> 1 iron gear wheel, 0.5s
@@ -723,6 +831,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronPlate, 2.0)],
                 produces: nonempty![(Item::IronGearWheel, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         // 1 iron gear wheel + 1 iron plate -> 2 transport belts, 0.5s
@@ -732,6 +841,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronGearWheel, 1.0), (Item::IronPlate, 1.0)],
                 produces: nonempty![(Item::TransportBelt, 2.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         // 1 EC + 1 IGW + 1 iron plate -> 1 inserter, 0.5s
@@ -745,6 +855,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::Inserter, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         // 3 EC + 5 IGW + 9 iron plates -> 1 assembling machine 1, 0.5s
@@ -758,6 +869,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::AssemblingMachine1, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         // ===========================================================
@@ -777,6 +889,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronPlate, 1.0)],
                 produces: nonempty![(Item::IronStick, 2.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         // 4 cable + 2 EC + 2 plastic -> 1 advanced_circuit, 6s
@@ -790,6 +903,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::AdvancedCircuit, 1.0)],
                 crafting_time: 6.0,
+                produced_by: crafting(),
             },
         ),
         // 1 IGW + 2 pipe + 1 steel_plate -> 1 engine_unit, 10s
@@ -803,6 +917,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::EngineUnit, 1.0)],
                 crafting_time: 10.0,
+                produced_by: advanced_crafting(),
             },
         ),
         // Storage
@@ -813,6 +928,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::Wood, 2.0)],
                 produces: nonempty![(Item::WoodenChest, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         // 8 iron_plate -> 1 iron_chest, 0.5s
@@ -822,6 +938,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronPlate, 8.0)],
                 produces: nonempty![(Item::IronChest, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         // 20 iron_plate + 5 steel_plate -> 1 storage_tank, 3s
@@ -831,6 +948,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronPlate, 20.0), (Item::SteelPlate, 5.0)],
                 produces: nonempty![(Item::StorageTank, 1.0)],
                 crafting_time: 3.0,
+                produced_by: crafting(),
             },
         ),
         // Fast belt tier
@@ -842,6 +960,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronGearWheel, 5.0), (Item::TransportBelt, 1.0)],
                 produces: nonempty![(Item::FastTransportBelt, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         */
@@ -853,6 +972,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronGearWheel, 40.0), (Item::UndergroundBelt, 2.0)],
                 produces: nonempty![(Item::FastUndergroundBelt, 2.0)],
                 crafting_time: 2.0,
+                produced_by: crafting(),
             },
         ),
         */
@@ -868,6 +988,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::FastSplitter, 1.0)],
                 crafting_time: 2.0,
+                produced_by: crafting(),
             },
         ),
         */
@@ -879,6 +1000,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronGearWheel, 1.0), (Item::IronPlate, 1.0)],
                 produces: nonempty![(Item::BurnerInserter, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         // parked (bucket balance): 1 inserter + 1 IGW + 1 iron_plate -> 1 long_handed_inserter, 0.5s
@@ -893,6 +1015,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::LongHandedInserter, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         */
@@ -908,6 +1031,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::FastInserter, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         */
@@ -919,6 +1043,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::CopperCable, 2.0), (Item::Wood, 1.0)],
                 produces: nonempty![(Item::SmallElectricPole, 2.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         // 2 cable + 4 iron_stick + 2 steel_plate -> 1 medium_electric_pole, 0.5s
@@ -932,6 +1057,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::MediumElectricPole, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         // parked (bucket balance): 4 cable + 8 iron_stick + 5 steel_plate -> 1 big_electric_pole, 0.5s
@@ -946,6 +1072,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::BigElectricPole, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         */
@@ -960,6 +1087,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::Substation, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         // 1 iron_plate -> 1 pipe, 0.5s
@@ -969,6 +1097,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronPlate, 1.0)],
                 produces: nonempty![(Item::Pipe, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         // 5 iron_plate + 10 pipe -> 2 pipe_to_ground, 0.5s
@@ -978,6 +1107,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronPlate, 5.0), (Item::Pipe, 10.0)],
                 produces: nonempty![(Item::PipeToGround, 2.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         // 1 engine_unit + 1 pipe + 1 steel_plate -> 1 pump, 2s
@@ -991,6 +1121,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::Pump, 1.0)],
                 crafting_time: 2.0,
+                produced_by: crafting(),
             },
         ),
         // Production buildings + modules
@@ -1001,6 +1132,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::Battery, 5.0), (Item::IronPlate, 2.0)],
                 produces: nonempty![(Item::Accumulator, 1.0)],
                 crafting_time: 10.0,
+                produced_by: crafting(),
             },
         ),
         // 20 advanced + 10 cable + 20 EC + 10 steel_plate -> 1 beacon, 15s
@@ -1015,6 +1147,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::Beacon, 1.0)],
                 crafting_time: 15.0,
+                produced_by: crafting(),
             },
         ),
         // 4 pipe + 1 stone_furnace -> 1 boiler, 0.5s
@@ -1024,6 +1157,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::Pipe, 4.0), (Item::StoneFurnace, 1.0)],
                 produces: nonempty![(Item::Boiler, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         // 3 IGW + 3 iron_plate + 1 stone_furnace -> 1 burner_mining_drill, 2s
@@ -1037,6 +1171,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::BurnerMiningDrill, 1.0)],
                 crafting_time: 2.0,
+                produced_by: crafting(),
             },
         ),
         // 5 EC + 5 IGW + 5 pipe + 5 steel_plate -> 1 chemical_plant, 5s
@@ -1051,6 +1186,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::ChemicalPlant, 1.0)],
                 crafting_time: 5.0,
+                produced_by: crafting(),
             },
         ),
         // parked (bucket balance): 5 advanced + 5 EC -> 1 efficiency_module, 15s
@@ -1062,6 +1198,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::AdvancedCircuit, 5.0), (Item::ElectronicCircuit, 5.0)],
                 produces: nonempty![(Item::EfficiencyModule, 1.0)],
                 crafting_time: 15.0,
+                produced_by: crafting(),
             },
         ),
         */
@@ -1076,6 +1213,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::ElectricFurnace, 1.0)],
                 crafting_time: 5.0,
+                produced_by: crafting(),
             },
         ),
         // 100 copper_plate + 10 pipe + 10 steel_plate -> 1 heat_exchanger, 3s
@@ -1089,6 +1227,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::HeatExchanger, 1.0)],
                 crafting_time: 3.0,
+                produced_by: crafting(),
             },
         ),
         // 20 copper_plate + 10 steel_plate -> 1 heat_pipe, 1s
@@ -1098,6 +1237,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::CopperPlate, 20.0), (Item::SteelPlate, 10.0)],
                 produces: nonempty![(Item::HeatPipe, 1.0)],
                 crafting_time: 1.0,
+                produced_by: crafting(),
             },
         ),
         // 10 EC + 10 IGW + 4 transport_belt -> 1 lab, 2s
@@ -1111,6 +1251,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::Lab, 1.0)],
                 crafting_time: 2.0,
+                produced_by: crafting(),
             },
         ),
         // 500 advanced + 500 concrete + 500 copper_plate + 500 steel_plate -> 1 nuclear_reactor, 8s
@@ -1125,6 +1266,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::NuclearReactor, 1.0)],
                 crafting_time: 8.0,
+                produced_by: crafting(),
             },
         ),
         // 2 IGW + 3 pipe -> 1 offshore_pump, 0.5s
@@ -1134,6 +1276,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronGearWheel, 2.0), (Item::Pipe, 3.0)],
                 produces: nonempty![(Item::OffshorePump, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         // 10 EC + 10 IGW + 10 pipe + 15 steel_plate + 10 stone_brick -> 1 oil_refinery, 8s
@@ -1149,6 +1292,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::OilRefinery, 1.0)],
                 crafting_time: 8.0,
+                produced_by: crafting(),
             },
         ),
         // parked (bucket balance): 5 advanced + 5 EC -> 1 productivity_module, 15s
@@ -1159,6 +1303,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::AdvancedCircuit, 5.0), (Item::ElectronicCircuit, 5.0)],
                 produces: nonempty![(Item::ProductivityModule, 1.0)],
                 crafting_time: 15.0,
+                produced_by: crafting(),
             },
         ),
         */
@@ -1174,6 +1319,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::Pumpjack, 1.0)],
                 crafting_time: 5.0,
+                produced_by: crafting(),
             },
         ),
         // parked (bucket balance): 5 advanced + 5 EC -> 1 quality_module, 15s
@@ -1184,6 +1330,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::AdvancedCircuit, 5.0), (Item::ElectronicCircuit, 5.0)],
                 produces: nonempty![(Item::QualityModule, 1.0)],
                 crafting_time: 15.0,
+                produced_by: crafting(),
             },
         ),
         */
@@ -1194,6 +1341,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::ElectronicCircuit, 2.0), (Item::IronGearWheel, 2.0)],
                 produces: nonempty![(Item::RepairPack, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         // 5 copper_plate + 15 EC + 5 steel_plate -> 1 solar_panel, 10s
@@ -1207,6 +1355,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::SolarPanel, 1.0)],
                 crafting_time: 10.0,
+                produced_by: crafting(),
             },
         ),
         // 5 advanced + 5 EC -> 1 speed_module, 15s
@@ -1216,6 +1365,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::AdvancedCircuit, 5.0), (Item::ElectronicCircuit, 5.0)],
                 produces: nonempty![(Item::SpeedModule, 1.0)],
                 crafting_time: 15.0,
+                produced_by: crafting(),
             },
         ),
         // 8 IGW + 10 iron_plate + 5 pipe -> 1 steam_engine, 0.5s
@@ -1229,6 +1379,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::SteamEngine, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         // parked (bucket balance): 50 copper_plate + 50 IGW + 20 pipe -> 1 steam_turbine, 3s
@@ -1243,6 +1394,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::SteamTurbine, 1.0)],
                 crafting_time: 3.0,
+                produced_by: crafting(),
             },
         ),
         */
@@ -1253,6 +1405,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::SteelPlate, 6.0), (Item::StoneBrick, 10.0)],
                 produces: nonempty![(Item::SteelFurnace, 1.0)],
                 crafting_time: 3.0,
+                produced_by: crafting(),
             },
         ),
         // 5 stone -> 1 stone_furnace, 0.5s
@@ -1262,6 +1415,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::Stone, 5.0)],
                 produces: nonempty![(Item::StoneFurnace, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         (
@@ -1270,6 +1424,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::SteelPlate, 1.0)],
                 produces: nonempty![(Item::Barrel, 1.0)],
                 crafting_time: 1.0,
+                produced_by: crafting(),
             },
         ),
         (
@@ -1278,6 +1433,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronPlate, 4.0)],
                 produces: nonempty![(Item::FirearmMagazine, 1.0)],
                 crafting_time: 1.0,
+                produced_by: crafting(),
             },
         ),
         (
@@ -1286,6 +1442,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::StoneBrick, 5.0)],
                 produces: nonempty![(Item::StoneWall, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         (
@@ -1294,6 +1451,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::SteelPlate, 8.0)],
                 produces: nonempty![(Item::SteelChest, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         (
@@ -1302,6 +1460,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::Concrete, 10.0)],
                 produces: nonempty![(Item::HazardConcrete, 10.0)],
                 crafting_time: 0.25,
+                produced_by: crafting(),
             },
         ),
         (
@@ -1310,6 +1469,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::Stone, 20.0)],
                 produces: nonempty![(Item::Landfill, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         (
@@ -1318,6 +1478,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronPlate, 10.0), (Item::TransportBelt, 5.0)],
                 produces: nonempty![(Item::UndergroundBelt, 2.0)],
                 crafting_time: 1.0,
+                produced_by: crafting(),
             },
         ),
         (
@@ -1326,6 +1487,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::CopperPlate, 1.0), (Item::IronGearWheel, 1.0)],
                 produces: nonempty![(Item::AutomationSciencePack, 1.0)],
                 crafting_time: 5.0,
+                produced_by: crafting(),
             },
         ),
         (
@@ -1338,6 +1500,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::Splitter, 1.0)],
                 crafting_time: 1.0,
+                produced_by: crafting(),
             },
         ),
         (
@@ -1350,6 +1513,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::Radar, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         (
@@ -1363,6 +1527,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::Shotgun, 1.0)],
                 crafting_time: 10.0,
+                produced_by: crafting(),
             },
         ),
         (
@@ -1376,6 +1541,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::CombatShotgun, 1.0)],
                 crafting_time: 10.0,
+                produced_by: crafting(),
             },
         ),
         (
@@ -1389,6 +1555,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::TrainStop, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         (
@@ -1402,6 +1569,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::AssemblingMachine2, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         (
@@ -1415,6 +1583,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::Centrifuge, 1.0)],
                 crafting_time: 4.0,
+                produced_by: crafting(),
             },
         ),
         (
@@ -1428,6 +1597,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::Tank, 1.0)],
                 crafting_time: 5.0,
+                produced_by: crafting(),
             },
         ),
         (
@@ -1441,6 +1611,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::ArtilleryTurret, 1.0)],
                 crafting_time: 40.0,
+                produced_by: crafting(),
             },
         ),
         (
@@ -1454,6 +1625,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::ProgrammableSpeaker, 1.0)],
                 crafting_time: 2.0,
+                produced_by: crafting(),
             },
         ),
         (
@@ -1467,6 +1639,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::FluidWagon, 1.0)],
                 crafting_time: 1.5,
+                produced_by: crafting(),
             },
         ),
         (
@@ -1475,6 +1648,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronPlate, 40.0)],
                 produces: nonempty![(Item::LightArmor, 1.0)],
                 crafting_time: 3.0,
+                produced_by: crafting(),
             },
         ),
         (
@@ -1483,6 +1657,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::ElectronicCircuit, 1.0)],
                 produces: nonempty![(Item::DischargeDefenseRemote, 1.0)],
                 crafting_time: 0.5,
+                produced_by: crafting(),
             },
         ),
         (
@@ -1496,6 +1671,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::PersonalRoboport, 1.0)],
                 crafting_time: 10.0,
+                produced_by: crafting(),
             },
         ),
         (
@@ -1509,6 +1685,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::FlamethrowerTurret, 1.0)],
                 crafting_time: 20.0,
+                produced_by: crafting(),
             },
         ),
     ]
@@ -1819,6 +1996,87 @@ mod tests {
 
         assert!(get_recipe(Item::IronPlate).is_none());
         assert!(get_recipe(Item::CopperPlate).is_none());
+    }
+
+    #[test]
+    fn test_produced_by_crafting_vs_advanced() {
+        // A standard `crafting` recipe lists all three assembler tiers.
+        let ec = get_recipe(Item::ElectronicCircuit).unwrap();
+        assert_eq!(
+            ec.produced_by.iter().copied().collect::<Vec<_>>(),
+            vec![
+                Item::AssemblingMachine1,
+                Item::AssemblingMachine2,
+                Item::AssemblingMachine3
+            ]
+        );
+        // The one `advanced-crafting` recipe excludes assembling machine 1.
+        let eu = get_recipe(Item::EngineUnit).unwrap();
+        assert_eq!(
+            eu.produced_by.iter().copied().collect::<Vec<_>>(),
+            vec![Item::AssemblingMachine2, Item::AssemblingMachine3]
+        );
+    }
+
+    #[test]
+    fn test_every_recipe_produced_by_assemblers() {
+        // The whole (fluid-free) set is crafted in assembling machines.
+        let assemblers = [
+            Item::AssemblingMachine1,
+            Item::AssemblingMachine2,
+            Item::AssemblingMachine3,
+        ];
+        for (item, recipe) in all_recipes() {
+            for machine in recipe.produced_by.iter() {
+                assert!(
+                    assemblers.contains(machine),
+                    "{item:?} produced_by non-assembler {machine:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_total_raw_none_for_raw_items() {
+        // Items with no recipe are themselves raw — they have no expansion.
+        assert!(total_raw_of(Item::IronPlate).is_none());
+        assert!(total_raw_of(Item::CopperPlate).is_none());
+        assert!(total_raw_of(Item::SteelPlate).is_none());
+    }
+
+    #[test]
+    fn test_total_raw_copper_cable() {
+        // 1 craft: 1 copper plate -> 2 cables; copper plate is raw.
+        let tr = total_raw_of(Item::CopperCable).unwrap();
+        assert_eq!(tr.items.len(), 1);
+        assert_eq!(tr.items.head, (Item::CopperPlate, 1.0));
+        assert_eq!(tr.time, 0.5);
+    }
+
+    #[test]
+    fn test_total_raw_electronic_circuit() {
+        // 3 cable + 1 iron plate. 3 cables = 1.5 crafts -> 1.5 copper plate,
+        // 0.75s; the circuit itself is 0.5s -> 1.25s total.
+        let tr = total_raw_of(Item::ElectronicCircuit).unwrap();
+        let raw: HashMap<Item, f64> = tr.items.iter().copied().collect();
+        assert_eq!(raw.get(&Item::CopperPlate), Some(&1.5));
+        assert_eq!(raw.get(&Item::IronPlate), Some(&1.0));
+        assert_eq!(raw.len(), 2);
+        assert_eq!(tr.time, 1.25);
+    }
+
+    #[test]
+    fn test_total_raw_merges_across_depth() {
+        // Inserter = 1 EC + 1 IGW + 1 iron plate. Iron plate appears at three
+        // depths (raw, via the gear wheel, via the circuit) and must sum:
+        // 1 (direct) + 2 (gear wheel) + 1 (circuit) = 4.
+        let tr = total_raw_of(Item::Inserter).unwrap();
+        let raw: HashMap<Item, f64> = tr.items.iter().copied().collect();
+        assert_eq!(raw.get(&Item::IronPlate), Some(&4.0));
+        assert_eq!(raw.get(&Item::CopperPlate), Some(&1.5));
+        assert_eq!(raw.len(), 2);
+        // 0.5 inserter + 1.25 circuit + 0.5 gear wheel = 2.25.
+        assert_eq!(tr.time, 2.25);
     }
 
     #[test]

--- a/factorion_rs/src/types.rs
+++ b/factorion_rs/src/types.rs
@@ -264,9 +264,6 @@ pub enum Item {
     DischargeDefenseRemote = 83,
     PersonalRoboport = 84,
     FlamethrowerTurret = 85,
-    // Higher assembler tiers aren't agent-placeable; they exist as items so
-    // recipes can name them in `produced_by` (a `crafting` recipe is made by
-    // assembling machine 1/2/3, `advanced-crafting` by 2/3 only).
     AssemblingMachine3 = 86,
     // Env-spawned, not agent-placeable — must remain the LAST two ids so
     // the policy's entity head can be sized to `len(items) - 2` and
@@ -664,11 +661,7 @@ pub struct Recipe {
     pub consumes: NonEmpty<(Item, f64)>,
     pub produces: NonEmpty<(Item, f64)>,
     pub crafting_time: f64,
-    /// Machines that can craft this recipe (hand-crafting excluded, so the
-    /// list is `NonEmpty` of real entities). Every recipe in this fluid-free
-    /// set is made in assembling machines: tiers 1/2/3 for a `crafting`
-    /// recipe, tiers 2/3 for an `advanced-crafting` one (machine 1 can't).
-    pub produced_by: NonEmpty<Item>,
+    pub produced_by: &'static [Item],
 }
 
 /// The fully-expanded raw-material cost of one craft of a recipe: every
@@ -767,14 +760,14 @@ fn raw_expand(item: Item, qty: f64, index: &HashMap<Item, Recipe>) -> (NonEmpty<
     (items, time)
 }
 
-/// The total raw cost of a single item's recipe, if it has one. Convenience
-/// wrapper that builds the recipe index from [`all_recipes`]; callers doing
-/// this in bulk should build the index once and call [`Recipe::total_raw`].
-#[allow(dead_code)]
-pub fn total_raw_of(item: Item) -> Option<TotalRaw> {
-    let index: HashMap<Item, Recipe> = all_recipes().into_iter().collect();
-    index.get(&item).map(|recipe| recipe.total_raw(&index))
-}
+/// The assembling machines that craft a standard recipe. The one
+/// `advanced-crafting` recipe (engine_unit) can't use tier 1, so it lists
+/// tiers 2/3 inline at its call site.
+const ASSEMBLING_MACHINES: &[Item] = &[
+    Item::AssemblingMachine1,
+    Item::AssemblingMachine2,
+    Item::AssemblingMachine3,
+];
 
 /// All crafting recipes in the game. The single source of truth — both
 /// `get_recipe` and the Python-facing PyO3 binding read from this.
@@ -787,21 +780,6 @@ pub fn total_raw_of(item: Item) -> Option<TotalRaw> {
 /// MEMORISE_N_INGREDIENT_RECIPES bucket holds an equal 15 recipes; the
 /// parked ones are redundant tier/duplicate variants, kept in source so
 /// they can be restored by deleting the comment markers.
-/// The assembling machines that craft a standard `crafting`-category recipe.
-fn crafting() -> NonEmpty<Item> {
-    nonempty![
-        Item::AssemblingMachine1,
-        Item::AssemblingMachine2,
-        Item::AssemblingMachine3
-    ]
-}
-
-/// The assembling machines that craft an `advanced-crafting` recipe —
-/// assembling machine 1 can't reach it, so only tiers 2 and 3.
-fn advanced_crafting() -> NonEmpty<Item> {
-    nonempty![Item::AssemblingMachine2, Item::AssemblingMachine3]
-}
-
 pub fn all_recipes() -> Vec<(Item, Recipe)> {
     vec![
         // 1 copper plate -> 2 copper cables, 0.5s
@@ -811,7 +789,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::CopperPlate, 1.0)],
                 produces: nonempty![(Item::CopperCable, 2.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 3 copper cable + 1 iron plate -> 1 electronic circuit, 0.5s
@@ -821,7 +799,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::CopperCable, 3.0), (Item::IronPlate, 1.0)],
                 produces: nonempty![(Item::ElectronicCircuit, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 2 iron plates -> 1 iron gear wheel, 0.5s
@@ -831,7 +809,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronPlate, 2.0)],
                 produces: nonempty![(Item::IronGearWheel, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 1 iron gear wheel + 1 iron plate -> 2 transport belts, 0.5s
@@ -841,7 +819,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronGearWheel, 1.0), (Item::IronPlate, 1.0)],
                 produces: nonempty![(Item::TransportBelt, 2.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 1 EC + 1 IGW + 1 iron plate -> 1 inserter, 0.5s
@@ -855,7 +833,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::Inserter, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 3 EC + 5 IGW + 9 iron plates -> 1 assembling machine 1, 0.5s
@@ -869,7 +847,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::AssemblingMachine1, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // ===========================================================
@@ -889,7 +867,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronPlate, 1.0)],
                 produces: nonempty![(Item::IronStick, 2.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 4 cable + 2 EC + 2 plastic -> 1 advanced_circuit, 6s
@@ -903,7 +881,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::AdvancedCircuit, 1.0)],
                 crafting_time: 6.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 1 IGW + 2 pipe + 1 steel_plate -> 1 engine_unit, 10s
@@ -917,7 +895,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::EngineUnit, 1.0)],
                 crafting_time: 10.0,
-                produced_by: advanced_crafting(),
+                produced_by: &[Item::AssemblingMachine2, Item::AssemblingMachine3],
             },
         ),
         // Storage
@@ -928,7 +906,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::Wood, 2.0)],
                 produces: nonempty![(Item::WoodenChest, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 8 iron_plate -> 1 iron_chest, 0.5s
@@ -938,7 +916,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronPlate, 8.0)],
                 produces: nonempty![(Item::IronChest, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 20 iron_plate + 5 steel_plate -> 1 storage_tank, 3s
@@ -948,7 +926,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronPlate, 20.0), (Item::SteelPlate, 5.0)],
                 produces: nonempty![(Item::StorageTank, 1.0)],
                 crafting_time: 3.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // Fast belt tier
@@ -960,7 +938,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronGearWheel, 5.0), (Item::TransportBelt, 1.0)],
                 produces: nonempty![(Item::FastTransportBelt, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         */
@@ -972,7 +950,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronGearWheel, 40.0), (Item::UndergroundBelt, 2.0)],
                 produces: nonempty![(Item::FastUndergroundBelt, 2.0)],
                 crafting_time: 2.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         */
@@ -988,7 +966,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::FastSplitter, 1.0)],
                 crafting_time: 2.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         */
@@ -1000,7 +978,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronGearWheel, 1.0), (Item::IronPlate, 1.0)],
                 produces: nonempty![(Item::BurnerInserter, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // parked (bucket balance): 1 inserter + 1 IGW + 1 iron_plate -> 1 long_handed_inserter, 0.5s
@@ -1015,7 +993,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::LongHandedInserter, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         */
@@ -1031,7 +1009,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::FastInserter, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         */
@@ -1043,7 +1021,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::CopperCable, 2.0), (Item::Wood, 1.0)],
                 produces: nonempty![(Item::SmallElectricPole, 2.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 2 cable + 4 iron_stick + 2 steel_plate -> 1 medium_electric_pole, 0.5s
@@ -1057,7 +1035,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::MediumElectricPole, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // parked (bucket balance): 4 cable + 8 iron_stick + 5 steel_plate -> 1 big_electric_pole, 0.5s
@@ -1072,7 +1050,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::BigElectricPole, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         */
@@ -1087,7 +1065,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::Substation, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 1 iron_plate -> 1 pipe, 0.5s
@@ -1097,7 +1075,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronPlate, 1.0)],
                 produces: nonempty![(Item::Pipe, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 5 iron_plate + 10 pipe -> 2 pipe_to_ground, 0.5s
@@ -1107,7 +1085,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronPlate, 5.0), (Item::Pipe, 10.0)],
                 produces: nonempty![(Item::PipeToGround, 2.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 1 engine_unit + 1 pipe + 1 steel_plate -> 1 pump, 2s
@@ -1121,7 +1099,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::Pump, 1.0)],
                 crafting_time: 2.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // Production buildings + modules
@@ -1132,7 +1110,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::Battery, 5.0), (Item::IronPlate, 2.0)],
                 produces: nonempty![(Item::Accumulator, 1.0)],
                 crafting_time: 10.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 20 advanced + 10 cable + 20 EC + 10 steel_plate -> 1 beacon, 15s
@@ -1147,7 +1125,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::Beacon, 1.0)],
                 crafting_time: 15.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 4 pipe + 1 stone_furnace -> 1 boiler, 0.5s
@@ -1157,7 +1135,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::Pipe, 4.0), (Item::StoneFurnace, 1.0)],
                 produces: nonempty![(Item::Boiler, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 3 IGW + 3 iron_plate + 1 stone_furnace -> 1 burner_mining_drill, 2s
@@ -1171,7 +1149,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::BurnerMiningDrill, 1.0)],
                 crafting_time: 2.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 5 EC + 5 IGW + 5 pipe + 5 steel_plate -> 1 chemical_plant, 5s
@@ -1186,7 +1164,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::ChemicalPlant, 1.0)],
                 crafting_time: 5.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // parked (bucket balance): 5 advanced + 5 EC -> 1 efficiency_module, 15s
@@ -1198,7 +1176,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::AdvancedCircuit, 5.0), (Item::ElectronicCircuit, 5.0)],
                 produces: nonempty![(Item::EfficiencyModule, 1.0)],
                 crafting_time: 15.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         */
@@ -1213,7 +1191,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::ElectricFurnace, 1.0)],
                 crafting_time: 5.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 100 copper_plate + 10 pipe + 10 steel_plate -> 1 heat_exchanger, 3s
@@ -1227,7 +1205,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::HeatExchanger, 1.0)],
                 crafting_time: 3.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 20 copper_plate + 10 steel_plate -> 1 heat_pipe, 1s
@@ -1237,7 +1215,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::CopperPlate, 20.0), (Item::SteelPlate, 10.0)],
                 produces: nonempty![(Item::HeatPipe, 1.0)],
                 crafting_time: 1.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 10 EC + 10 IGW + 4 transport_belt -> 1 lab, 2s
@@ -1251,7 +1229,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::Lab, 1.0)],
                 crafting_time: 2.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 500 advanced + 500 concrete + 500 copper_plate + 500 steel_plate -> 1 nuclear_reactor, 8s
@@ -1266,7 +1244,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::NuclearReactor, 1.0)],
                 crafting_time: 8.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 2 IGW + 3 pipe -> 1 offshore_pump, 0.5s
@@ -1276,7 +1254,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronGearWheel, 2.0), (Item::Pipe, 3.0)],
                 produces: nonempty![(Item::OffshorePump, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 10 EC + 10 IGW + 10 pipe + 15 steel_plate + 10 stone_brick -> 1 oil_refinery, 8s
@@ -1292,7 +1270,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::OilRefinery, 1.0)],
                 crafting_time: 8.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // parked (bucket balance): 5 advanced + 5 EC -> 1 productivity_module, 15s
@@ -1303,7 +1281,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::AdvancedCircuit, 5.0), (Item::ElectronicCircuit, 5.0)],
                 produces: nonempty![(Item::ProductivityModule, 1.0)],
                 crafting_time: 15.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         */
@@ -1319,7 +1297,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::Pumpjack, 1.0)],
                 crafting_time: 5.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // parked (bucket balance): 5 advanced + 5 EC -> 1 quality_module, 15s
@@ -1330,7 +1308,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::AdvancedCircuit, 5.0), (Item::ElectronicCircuit, 5.0)],
                 produces: nonempty![(Item::QualityModule, 1.0)],
                 crafting_time: 15.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         */
@@ -1341,7 +1319,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::ElectronicCircuit, 2.0), (Item::IronGearWheel, 2.0)],
                 produces: nonempty![(Item::RepairPack, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 5 copper_plate + 15 EC + 5 steel_plate -> 1 solar_panel, 10s
@@ -1355,7 +1333,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::SolarPanel, 1.0)],
                 crafting_time: 10.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 5 advanced + 5 EC -> 1 speed_module, 15s
@@ -1365,7 +1343,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::AdvancedCircuit, 5.0), (Item::ElectronicCircuit, 5.0)],
                 produces: nonempty![(Item::SpeedModule, 1.0)],
                 crafting_time: 15.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 8 IGW + 10 iron_plate + 5 pipe -> 1 steam_engine, 0.5s
@@ -1379,7 +1357,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::SteamEngine, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // parked (bucket balance): 50 copper_plate + 50 IGW + 20 pipe -> 1 steam_turbine, 3s
@@ -1394,7 +1372,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::SteamTurbine, 1.0)],
                 crafting_time: 3.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         */
@@ -1405,7 +1383,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::SteelPlate, 6.0), (Item::StoneBrick, 10.0)],
                 produces: nonempty![(Item::SteelFurnace, 1.0)],
                 crafting_time: 3.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         // 5 stone -> 1 stone_furnace, 0.5s
@@ -1415,7 +1393,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::Stone, 5.0)],
                 produces: nonempty![(Item::StoneFurnace, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         (
@@ -1424,7 +1402,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::SteelPlate, 1.0)],
                 produces: nonempty![(Item::Barrel, 1.0)],
                 crafting_time: 1.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         (
@@ -1433,7 +1411,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronPlate, 4.0)],
                 produces: nonempty![(Item::FirearmMagazine, 1.0)],
                 crafting_time: 1.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         (
@@ -1442,7 +1420,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::StoneBrick, 5.0)],
                 produces: nonempty![(Item::StoneWall, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         (
@@ -1451,7 +1429,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::SteelPlate, 8.0)],
                 produces: nonempty![(Item::SteelChest, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         (
@@ -1460,7 +1438,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::Concrete, 10.0)],
                 produces: nonempty![(Item::HazardConcrete, 10.0)],
                 crafting_time: 0.25,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         (
@@ -1469,7 +1447,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::Stone, 20.0)],
                 produces: nonempty![(Item::Landfill, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         (
@@ -1478,7 +1456,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronPlate, 10.0), (Item::TransportBelt, 5.0)],
                 produces: nonempty![(Item::UndergroundBelt, 2.0)],
                 crafting_time: 1.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         (
@@ -1487,7 +1465,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::CopperPlate, 1.0), (Item::IronGearWheel, 1.0)],
                 produces: nonempty![(Item::AutomationSciencePack, 1.0)],
                 crafting_time: 5.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         (
@@ -1500,7 +1478,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::Splitter, 1.0)],
                 crafting_time: 1.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         (
@@ -1513,7 +1491,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::Radar, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         (
@@ -1527,7 +1505,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::Shotgun, 1.0)],
                 crafting_time: 10.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         (
@@ -1541,7 +1519,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::CombatShotgun, 1.0)],
                 crafting_time: 10.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         (
@@ -1555,7 +1533,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::TrainStop, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         (
@@ -1569,7 +1547,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::AssemblingMachine2, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         (
@@ -1583,7 +1561,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::Centrifuge, 1.0)],
                 crafting_time: 4.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         (
@@ -1597,7 +1575,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::Tank, 1.0)],
                 crafting_time: 5.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         (
@@ -1611,7 +1589,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::ArtilleryTurret, 1.0)],
                 crafting_time: 40.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         (
@@ -1625,7 +1603,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::ProgrammableSpeaker, 1.0)],
                 crafting_time: 2.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         (
@@ -1639,7 +1617,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::FluidWagon, 1.0)],
                 crafting_time: 1.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         (
@@ -1648,7 +1626,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::IronPlate, 40.0)],
                 produces: nonempty![(Item::LightArmor, 1.0)],
                 crafting_time: 3.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         (
@@ -1657,7 +1635,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 consumes: nonempty![(Item::ElectronicCircuit, 1.0)],
                 produces: nonempty![(Item::DischargeDefenseRemote, 1.0)],
                 crafting_time: 0.5,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         (
@@ -1671,7 +1649,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::PersonalRoboport, 1.0)],
                 crafting_time: 10.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
         (
@@ -1685,7 +1663,7 @@ pub fn all_recipes() -> Vec<(Item, Recipe)> {
                 ],
                 produces: nonempty![(Item::FlamethrowerTurret, 1.0)],
                 crafting_time: 20.0,
-                produced_by: crafting(),
+                produced_by: ASSEMBLING_MACHINES,
             },
         ),
     ]
@@ -1748,6 +1726,14 @@ impl NodeId {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+
+    /// The total raw cost of a single item's recipe, if it has one; builds a
+    /// fresh index each call. The bulk callers ([`Recipe::total_raw`] via the
+    /// PyO3 binding) share one index instead.
+    fn total_raw_of(item: Item) -> Option<TotalRaw> {
+        let index: HashMap<Item, Recipe> = all_recipes().into_iter().collect();
+        index.get(&item).map(|recipe| recipe.total_raw(&index))
+    }
 
     #[test]
     fn test_direction_from_i64() {

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -237,6 +237,60 @@ class TestPyRecipesBinding:
         assert rs["advanced_circuit"]["crafting_time"] == 6.0
         assert rs["engine_unit"]["crafting_time"] == 10.0
 
+    def test_produced_by(self):
+        rs = factorion_rs.py_recipes()
+        # Standard crafting recipe: all three assembler tiers (hand excluded).
+        assert rs["electronic_circuit"]["produced_by"] == [
+            "assembling_machine_1",
+            "assembling_machine_2",
+            "assembling_machine_3",
+        ]
+        # engine_unit is advanced-crafting — assembling machine 1 can't make it.
+        assert rs["engine_unit"]["produced_by"] == [
+            "assembling_machine_2",
+            "assembling_machine_3",
+        ]
+
+    def test_every_recipe_produced_by_assemblers(self):
+        rs = factorion_rs.py_recipes()
+        assemblers = {
+            "assembling_machine_1",
+            "assembling_machine_2",
+            "assembling_machine_3",
+        }
+        for name, data in rs.items():
+            assert data["produced_by"], f"{name} has empty produced_by"
+            assert set(data["produced_by"]) <= assemblers, (
+                f"{name} produced_by non-assembler: {data['produced_by']}"
+            )
+
+    def test_total_raw_expands_to_raw_items(self):
+        rs = factorion_rs.py_recipes()
+        # 1 copper plate -> 2 cables; copper plate is raw.
+        assert rs["copper_cable"]["total_raw"] == {"copper_plate": 1.0}
+        # 3 cable (=1.5 copper plate) + 1 iron plate.
+        assert rs["electronic_circuit"]["total_raw"] == {
+            "copper_plate": 1.5,
+            "iron_plate": 1.0,
+        }
+
+    def test_total_raw_time_is_cumulative(self):
+        rs = factorion_rs.py_recipes()
+        # Own craft (0.5s) + the 1.5 copper-cable crafts (0.75s) = 1.25s;
+        # strictly greater than the recipe's own crafting_time.
+        ec = rs["electronic_circuit"]
+        assert ec["total_raw_time"] == 1.25
+        assert ec["total_raw_time"] > ec["crafting_time"]
+
+    def test_every_recipe_has_total_raw(self):
+        rs = factorion_rs.py_recipes()
+        for name, data in rs.items():
+            assert data["total_raw"], f"{name} has empty total_raw"
+            assert data["total_raw_time"] > 0, f"{name} total_raw_time not positive"
+            # Raws bottom out at items that have no recipe of their own.
+            for raw in data["total_raw"]:
+                assert raw not in rs, f"{name} total_raw lists craftable {raw}"
+
 
 class TestPythonRecipesDict:
     def test_recipe_is_dataclass_with_attributes(self):
@@ -244,6 +298,9 @@ class TestPythonRecipesDict:
         assert hasattr(ec, "consumes")
         assert hasattr(ec, "produces")
         assert hasattr(ec, "crafting_time")
+        assert hasattr(ec, "produced_by")
+        assert hasattr(ec, "total_raw")
+        assert hasattr(ec, "total_raw_time")
 
     def test_canonical_electronic_circuit(self):
         ec = recipes["electronic_circuit"]
@@ -269,4 +326,13 @@ class TestRustPythonRecipeParity:
             )
             assert py_recipe.crafting_time == rs[name]["crafting_time"], (
                 f"{name}.crafting_time mismatch"
+            )
+            assert py_recipe.produced_by == rs[name]["produced_by"], (
+                f"{name}.produced_by mismatch"
+            )
+            assert py_recipe.total_raw == rs[name]["total_raw"], (
+                f"{name}.total_raw mismatch"
+            )
+            assert py_recipe.total_raw_time == rs[name]["total_raw_time"], (
+                f"{name}.total_raw_time mismatch"
             )


### PR DESCRIPTION
## Summary

Extends the recipe system with two new derived fields that enable better factory analysis and planning:

1. **`produced_by`**: Lists the assembling machines that can craft each recipe (e.g., tiers 1/2/3 for standard `crafting` recipes, tiers 2/3 only for `advanced-crafting`). This replaces implicit knowledge about machine capabilities.

2. **`total_raw`**: Fully-expanded raw material cost of one craft, recursively reducing every ingredient through the recipe DAG until bottoming out at items with no recipe (plates, ore, wood). Includes cumulative crafting time across the entire tree, answering "how much craft-time from raws" rather than just the recipe's own time.

Also adds `AssemblingMachine3` as an item (id 86) so recipes can reference it in `produced_by`, with `Sink`/`Source` shifted to ids 87/88.

## Key Changes

- **`types.rs`**:
  - Added `AssemblingMachine3` item (id 86); renumbered `Sink`/`Source` to 87/88
  - Added `produced_by: NonEmpty<Item>` field to `Recipe` struct
  - New `TotalRaw` struct holding expanded items and cumulative time
  - Implemented `Recipe::total_raw(&self, index: &HashMap<Item, Recipe>) -> TotalRaw` to recursively expand ingredients
  - Helper functions `raw_expand()` and `add_raw()` for the expansion algorithm
  - Convenience function `total_raw_of(item: Item) -> Option<TotalRaw>` for single-item lookups
  - Added `crafting()` and `advanced_crafting()` helper functions returning the appropriate machine lists
  - Updated all 60+ recipe definitions to include `produced_by` field
  - Comprehensive tests for `produced_by` consistency and `total_raw` correctness (copper cable, electronic circuit, inserter with multi-depth merging)

- **`lib.rs`** (Python bindings):
  - Updated `py_recipes()` to compute and expose `produced_by`, `total_raw`, and `total_raw_time` in the recipe dict
  - Built recipe index once and shared across all expansions for efficiency

- **`factorion.py`**:
  - Extended `Recipe` dataclass with `produced_by`, `total_raw`, and `total_raw_time` fields
  - Updated recipe dict construction to unpack these new fields

- **`factorion_rs/__init__.pyi`**:
  - Added type hints for the three new recipe fields in `RecipeData` TypedDict

- **`tests/test_recipes.py`**:
  - Tests for `produced_by` field presence and correctness (standard vs. advanced-crafting)
  - Tests for `total_raw` expansion (raw items only, copper cable, electronic circuit)
  - Tests for cumulative time (strictly greater than recipe's own crafting_time)
  - Validation that all recipes bottom out at non-craftable items

## Implementation Details

- The recipe DAG is guaranteed acyclic (no item consumes its own output transitively), so recursive expansion always terminates
- `total_raw` merges duplicate items across multiple recipe depths (e.g., iron plate appears in inserter via both the gear wheel and the circuit; amounts sum correctly)
- The expansion is computed once per recipe at module load and cached in the Python dict, avoiding repeated traversals
- All 60+ existing recipes now explicitly declare which assembling machines can craft them, making the constraint visible and testable

https://claude.ai/code/session_01BGqMpRkruXnx6ptHkHwpPM