### PR TITLE
Add GRPO (Dr. GRPO) RL finetuning

### DIFF
--- a/grpo.py
+++ b/grpo.py
@@ -462,7 +462,11 @@ def collect_rollout(
                 if not active[lane]:
                     continue
 
-                obs_rows.append(obs_batch[lane].cpu())
+                # .clone() is load-bearing: on a CPU device obs_batch shares
+                # memory with the obs_B numpy buffer (when dtypes match), and
+                # obs_B[lane] is overwritten in place below — without the copy
+                # every stored row for a lane would collapse to its final obs.
+                obs_rows.append(obs_batch[lane].clone().cpu())
                 act_rows.append(action_B7[lane].cpu())
                 old_lp.append(logp_B[lane].cpu())
                 ref_lp.append(ref_logp_B[lane].cpu())
@@ -791,14 +795,19 @@ def grpo_update(
 
 
 def _select_eval_grids(args: GRPOArgs) -> list[tuple[int, LessonKind, int]]:
-    """Build the fixed held-out eval set once, from a seed stream independent
-    of the per-iteration training stream (collisions over the 2**31 seed space
-    are vanishingly unlikely for ~eval_max_seeds grids)."""
+    """Build the fixed held-out eval set once, from a seed stream disjoint from
+    the per-iteration training stream.
+
+    Training seeds each iteration with the integer `args.seed*1_000_003 +
+    iteration` (see train_grpo). We seed eval with a *string* so its RNG stream
+    can never coincide with any of those integers — an earlier integer offset
+    (e.g. + 7) collided with training iteration 7, leaking 25% of the held-out
+    grids into training."""
     if args.eval_every <= 0 or args.n_held_out_seeds <= 0:
         return []
     n = min(args.eval_max_seeds, args.n_held_out_seeds)
     eval_args = replace(args, num_grids=n)
-    return select_grids(eval_args, random.Random(args.seed * 1_000_003 + 7))
+    return select_grids(eval_args, random.Random(f"grpo-eval:{args.seed}"))
 
 
 def _rollout_metrics(batch: RolloutBatch, R_B: torch.Tensor, A_N: torch.Tensor) -> dict:

--- a/grpo.py
+++ b/grpo.py
@@ -130,16 +130,16 @@ class GRPOArgs:
     [num_missing_min, cap] so groups straddle the success boundary."""
 
     # ── end-of-turn (EOT) ────────────────────────────────────────────────
-    # EOT is a real action (Discrete(2)) the env consumes: terminated when the
-    # agent emits eot=1, else truncated at max_steps. With the per-step penalty
-    # the env *can* now reward stopping early (once the factory can't improve),
-    # so EOT is genuinely learnable here — unlike the pre-rebase reward. v1
-    # keeps it OFF (honor_eot=False): eot is forced to 0, excluded from the
-    # objective, episodes run to max_steps and collect the terminal throughput
-    # reward on truncation. Flip --honor-eot to sample+train it. Tracking +
-    # rationale: https://github.com/beyarkay/factorion/issues/181
-    honor_eot: bool = False
+    # EOT is a real action (Discrete(2)) the env consumes: the episode
+    # terminates when the agent emits eot=1, else truncates at max_steps. We
+    # always obey it — eot is sampled as part of the action, its log-prob is
+    # part of the GRPO objective, and the env stops on it. Because the reward
+    # charges a per-step penalty and pays the terminal throughput reward, the
+    # policy is incentivised to emit eot as soon as the factory can't improve,
+    # so learning *when* to stop is part of the task.
     eot_threshold: float = 0.5
+    """greedy-eval only: stop when sigmoid(eot_logit) > threshold (argmax of
+    the Bernoulli). Training samples eot, so the threshold doesn't apply there."""
 
     # ── held-out eval ────────────────────────────────────────────────────
     eval_every: int = 10
@@ -222,7 +222,6 @@ def policy_step(
     temperature: float = 1.0,
     action_B7: Optional[torch.Tensor] = None,
     generator: Optional[torch.Generator] = None,
-    include_eot: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Temperature-aware replication of AgentCNN.get_action_and_value's action
     path. Sampling (action_B7=None) and scoring (action_B7 given) share ONE
@@ -231,16 +230,14 @@ def policy_step(
     new-logp and ref-logp describe the same temperature-T policy.
 
     We deliberately do NOT call agent.get_action_and_value: it has no
-    temperature knob and also computes the (unused) value head. At T=1.0 with
-    include_eot=True this is numerically identical to get_action_and_value's
-    logp/entropy.
+    temperature knob and also computes the (unused) value head. At T=1.0 this
+    is numerically identical to get_action_and_value's logp/entropy.
 
     Action layout (B, 7) int columns: [x, y, entity, direction, item, misc, eot]
     — the convention the env's step() and get_action_and_value's scoring path
-    use. logp/entropy sum the 5 categorical heads (tile, entity, dir, item,
-    misc) plus, iff include_eot, the EOT Bernoulli. With include_eot=False the
-    EOT column is forced to 0 and left out of the objective entirely (v1
-    behaviour: the agent never stops early and eot is never RL-trained).
+    use. logp/entropy sum all 6 heads: the 5 categorical heads (tile, entity,
+    dir, item, misc) plus the EOT Bernoulli — EOT is always part of the action
+    and the objective.
     """
     encoded_BCWH = agent.encoder(obs_BCWH)
     B = encoded_BCWH.shape[0]
@@ -277,10 +274,7 @@ def policy_step(
         dir_B = _sample_categorical(dir_logits, generator)
         item_B = _sample_categorical(item_logits, generator)
         misc_B = _sample_categorical(misc_logits, generator)
-        if include_eot:
-            eot_B = _sample_bernoulli(eot_logit_B, generator)
-        else:
-            eot_B = torch.zeros(B, device=encoded_BCWH.device)
+        eot_B = _sample_bernoulli(eot_logit_B, generator)
     else:
         ent_B = action_B7[:, 2]
         dir_B = action_B7[:, 3]
@@ -294,6 +288,7 @@ def policy_step(
         + dist_d.log_prob(dir_B)
         + dist_i.log_prob(item_B)
         + dist_m.log_prob(misc_B)
+        + dist_eot.log_prob(eot_B)
     )
     entropy_B = (
         dist_tile.entropy()
@@ -301,10 +296,8 @@ def policy_step(
         + dist_d.entropy()
         + dist_i.entropy()
         + dist_m.entropy()
+        + dist_eot.entropy()
     )
-    if include_eot:
-        logp_B = logp_B + dist_eot.log_prob(eot_B)
-        entropy_B = entropy_B + dist_eot.entropy()
 
     out_B7 = torch.stack(
         [x_B, y_B, ent_B, dir_B, item_B, misc_B, eot_B.long()], dim=1
@@ -409,8 +402,8 @@ def collect_rollout(
     belongs to grid g, so the Dr. GRPO baseline is computed over completions of
     the *same* grid. Finished lanes are masked out — they keep getting fed
     through the batched forward (cheap; episodes are short) but store no further
-    transitions and are never stepped again. Episodes end on eot (only when
-    honor_eot) or max_steps; either way the env pays the terminal throughput
+    transitions and are never stepped again. Episodes end when the agent emits
+    eot=1 or at max_steps; either way the env pays the terminal throughput
     reward, so the summed reward R_i is a complete episode return."""
     G = args.group_size
     B = len(grids) * G
@@ -459,18 +452,10 @@ def collect_rollout(
                 break
             obs_batch = torch.as_tensor(obs_B, dtype=torch.float32, device=device)
             action_B7, logp_B, _ent = policy_step(
-                policy,
-                obs_batch,
-                temperature=T,
-                generator=generator,
-                include_eot=args.honor_eot,
+                policy, obs_batch, temperature=T, generator=generator
             )
             _a, ref_logp_B, _e = policy_step(
-                ref,
-                obs_batch,
-                temperature=T,
-                action_B7=action_B7,
-                include_eot=args.honor_eot,
+                ref, obs_batch, temperature=T, action_B7=action_B7
             )
 
             for lane in range(B):
@@ -644,9 +629,8 @@ def greedy_eval(
     """Batched greedy rollout on held-out grids (argmax every head), mirroring
     sft.run_rollout_eval but self-contained and using the GRPO horizon.
 
-    EOT is emitted (argmax → eot_prob>threshold) only when args.honor_eot, so
-    the regime matches training; otherwise the env truncates at max_steps.
-    Reports:
+    EOT is emitted greedily (eot_prob > eot_threshold), so the policy decides
+    when to stop just as in training (which samples it). Reports:
       - eval/throughput: mean final thput_normed (the real objective)
       - eval/success_rate: fraction that fully rebuild (thput_normed>=1)
       - eval/dir_acc_vs_ref: mean tile_match_direction (REPORTED, NOT a target
@@ -692,10 +676,7 @@ def greedy_eval(
                 dir_ = policy.dir_head(feats).argmax(dim=1)
                 item = policy.item_head(feats).argmax(dim=1)
                 misc = policy.misc_head(feats).argmax(dim=1)
-                if args.honor_eot:
-                    eot = torch.sigmoid(policy.eot_head(encoded).squeeze(-1)) > args.eot_threshold
-                else:
-                    eot = torch.zeros(n, dtype=torch.bool)
+                eot = torch.sigmoid(policy.eot_head(encoded).squeeze(-1)) > args.eot_threshold
 
                 for i in range(n):
                     if not active[i]:
@@ -750,10 +731,10 @@ def grpo_update(
 
         kl = exp(ref - new) - (ref - new) - 1   (>= 0, estimates KL(pi||ref))
 
-    where `new` carries gradient and the stored `ref` is constant. include_eot
-    matches the rollout (args.honor_eot) so logp is computed over exactly the
-    action components that were sampled. No critic, no minibatching — the batch
-    is small (sim-bound), so each epoch is a full-batch step."""
+    where `new` carries gradient and the stored `ref` is constant. logp covers
+    all 6 heads including EOT, exactly as sampled in the rollout. No critic, no
+    minibatching — the batch is small (sim-bound), so each epoch is a full-batch
+    step."""
     N = batch.obs_NCWH.shape[0]
     if N == 0:
         return {"loss/total": float("nan"), "grpo/n_transitions": 0}
@@ -769,7 +750,6 @@ def grpo_update(
             batch.obs_NCWH,
             temperature=args.temperature,
             action_B7=batch.actions_N7,
-            include_eot=args.honor_eot,
         )
         logratio_N = new_logp_N - old_logp_N
         ratio_N = logratio_N.exp()
@@ -941,7 +921,6 @@ def train_grpo(args: GRPOArgs) -> AgentCNN:
         "temperature": args.temperature,
         "beta_kl": args.beta_kl,
         "learning_rate": args.learning_rate,
-        "honor_eot": args.honor_eot,
         "samples_seen": samples_seen,
         "final_eval_throughput": final_eval.get("eval/throughput"),
         "final_eval_success_rate": final_eval.get("eval/success_rate"),

--- a/grpo.py
+++ b/grpo.py
@@ -31,7 +31,7 @@ import os
 import random
 import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
@@ -275,6 +275,245 @@ def policy_step(
     )
     out_B6 = torch.stack([x_B, y_B, ent_B, dir_B, item_B, misc_B], dim=1)
     return out_B6, logp_B, entropy_B
+
+
+def _max_steps(args: GRPOArgs) -> int:
+    # Short horizon ("one entity per step over a belt chain"), matching ppo.py's
+    # make_env. NOT FactorioEnv's default of size*size, which would make
+    # episodes (and the completion bonus) ~size times longer.
+    return 2 * args.size
+
+
+def _make_rollout_env(args: GRPOArgs) -> FactorioEnv:
+    # idx=0 so reset(seed) is an exact pass-through: the grid is a pure
+    # function of (size, kind, seed), letting a group of lanes share one grid.
+    return FactorioEnv(size=args.size, max_steps=_max_steps(args), idx=0)
+
+
+def select_grids(
+    args: GRPOArgs, rng: random.Random
+) -> list[tuple[int, LessonKind, int]]:
+    """Pick `num_grids` distinct, pre-validated grids `(seed, kind, num_missing)`.
+
+    Each grid gets a random LessonKind and a random num_missing in
+    [num_missing_min, cap] so a batch straddles the success boundary (some
+    groups all-connect, some none — that's where group-relative advantage has
+    signal). We probe build_factory once per candidate and skip seeds it can't
+    realise (rejection sampling exhausts on tight grids / hard kinds), because
+    FactorioEnv.reset *raises* on a None factory when the kind is pinned."""
+    cap = args.num_missing_max if args.num_missing_max > 0 else 2 * args.size
+    lo = max(1, args.num_missing_min)
+    hi = max(lo, cap)
+    kinds = list(LessonKind)
+    grids: list[tuple[int, LessonKind, int]] = []
+    seed = rng.randrange(1, 2**31 - args.num_grids * 64 - 1)
+    attempts = 0
+    max_attempts = args.num_grids * 64
+    while len(grids) < args.num_grids and attempts < max_attempts:
+        attempts += 1
+        seed += 1
+        kind = kinds[rng.randrange(len(kinds))]
+        try:
+            ok = build_factory(size=args.size, kind=kind, seed=seed) is not None
+        except Exception:
+            ok = False
+        if not ok:
+            continue
+        grids.append((seed, kind, rng.randint(lo, hi)))
+    if len(grids) < args.num_grids:
+        raise RuntimeError(
+            f"select_grids: only validated {len(grids)}/{args.num_grids} grids "
+            f"in {attempts} attempts (size={args.size})"
+        )
+    return grids
+
+
+@dataclass
+class RolloutBatch:
+    """Flattened transitions from one GRPO rollout, plus the per-lane reward
+    ingredients and final/solved worlds the reward + diversity stages consume.
+
+    N = total transitions across all lanes (variable, since episodes vary in
+    length). B = num_grids * group_size lanes. A transition is one placement
+    step; a lane that terminated early simply contributes fewer rows."""
+
+    obs_NCWH: torch.Tensor
+    actions_N6: torch.Tensor
+    old_logp_N: torch.Tensor
+    ref_logp_N: torch.Tensor
+    lane_of_N: torch.Tensor  # (N,) which lane each transition came from
+    group_of_lane_B: torch.Tensor  # (B,) lane -> group id (lane // G)
+    # per-lane reward ingredients
+    thp_final_B: torch.Tensor  # (B,) last throughput the env reported
+    terminated_B: torch.Tensor  # (B,) 1.0 if the lane connected (throughput>=1)
+    completion_bonus_B: torch.Tensor  # (B,) max_steps - steps_at_terminal
+    steps_B: torch.Tensor  # (B,) episode length (transitions stored)
+    # per-lane worlds for diversity metrics
+    final_world_B: list = field(default_factory=list)
+    solved_world_B: list = field(default_factory=list)
+
+
+def collect_rollout(
+    policy: AgentCNN,
+    ref: AgentCNN,
+    args: GRPOArgs,
+    grids: list[tuple[int, LessonKind, int]],
+    device,
+    generator: Optional[torch.Generator] = None,
+) -> RolloutBatch:
+    """Sample a GROUP of `group_size` complete episodes for each grid, in
+    lockstep across all B = num_grids*group_size lanes.
+
+    Lockstep (not a refill queue) keeps groups intact: lane g*G+j always
+    belongs to grid g, so the Dr. GRPO baseline is computed over completions of
+    the *same* grid. Finished lanes are masked out — they keep getting fed
+    through the batched forward (cheap; episodes are short) but store no further
+    transitions and are never stepped again."""
+    G = args.group_size
+    B = len(grids) * G
+    T = args.temperature
+    H = args.size
+
+    envs = [_make_rollout_env(args) for _ in range(B)]
+
+    # Reset ALL lanes before any sampling. build_factory/blank_entities reseed
+    # the global RNG on each reset; doing them up front (then sampling via the
+    # explicit `generator`) keeps action draws independent of grid seeds.
+    obs_B = [None] * B
+    last_thp = [0.0] * B
+    solved_world_B = [None] * B
+    for g, (seed, kind, num_missing) in enumerate(grids):
+        for j in range(G):
+            lane = g * G + j
+            o, info = envs[lane].reset(
+                seed=seed,
+                options={"num_missing_entities": num_missing, "kind": kind},
+            )
+            obs_B[lane] = o
+            last_thp[lane] = float(info.get("throughput", 0.0))
+            solved_world_B[lane] = envs[lane]._solved_world_CWH.clone()
+
+    active = [True] * B
+    n_trans = [0] * B
+    terminated_B = [0.0] * B
+    completion_bonus_B = [0.0] * B
+    final_world_B = [None] * B
+    steps_B = [0] * B
+
+    obs_rows: list[torch.Tensor] = []
+    act_rows: list[torch.Tensor] = []
+    old_lp: list[torch.Tensor] = []
+    ref_lp: list[torch.Tensor] = []
+    lane_ids: list[int] = []
+
+    max_steps = _max_steps(args)
+    with torch.no_grad():
+        # Loop until every lane has terminated/truncated. The env truncates
+        # when steps>max_steps (checked pre-increment), so a non-connecting
+        # lane needs up to max_steps+2 steps; +4 leaves margin so truncation
+        # always fires inside the loop, never via the fallback below.
+        for _t in range(max_steps + 4):
+            if not any(active):
+                break
+            obs_batch = torch.as_tensor(
+                np.stack(obs_B), dtype=torch.float32, device=device
+            )
+            action_B6, logp_B, _ent = policy_step(
+                policy, obs_batch, temperature=T, generator=generator
+            )
+            _a, ref_logp_B, _e = policy_step(
+                ref, obs_batch, temperature=T, action_B6=action_B6
+            )
+
+            # ── EOT stop signal — OFF in v1 (honor_eot defaults False) ──
+            # Under this reward, connecting auto-terminates the episode
+            # (throughput>=1) and stopping early is never beneficial, so the
+            # SFT eot head is a pure confound here: honoring it can truncate a
+            # near-complete factory and inject reward variance for no gain. We
+            # therefore neither stop on it nor RL-train it in v1. `--honor-eot`
+            # flips it on for later experiments. Tracking: see the EOT GitHub
+            # issue referenced in the project notes.
+            eot_stop = [False] * B
+            if args.honor_eot:
+                encoded = policy.encoder(obs_batch)
+                eot_prob_B = torch.sigmoid(policy.eot_head(encoded).squeeze(-1))
+                eot_stop = (eot_prob_B > args.eot_threshold).tolist()
+
+            for lane in range(B):
+                if not active[lane]:
+                    continue
+                if eot_stop[lane]:
+                    # Agent chose to stop without an env step: no transition,
+                    # episode ends with whatever it has placed so far.
+                    active[lane] = False
+                    terminated_B[lane] = 0.0
+                    completion_bonus_B[lane] = 0.0
+                    final_world_B[lane] = envs[lane]._world_CWH.clone()
+                    steps_B[lane] = n_trans[lane]
+                    continue
+
+                obs_rows.append(obs_batch[lane].cpu())
+                act_rows.append(action_B6[lane].cpu())
+                old_lp.append(logp_B[lane].cpu())
+                ref_lp.append(ref_logp_B[lane].cpu())
+                lane_ids.append(lane)
+                n_trans[lane] += 1
+
+                act = action_B6[lane].tolist()
+                action_dict = {
+                    "xy": np.array([act[0], act[1]], dtype=int),
+                    "entity": int(act[2]),
+                    "direction": int(act[3]),
+                    "item": int(act[4]),
+                    "misc": int(act[5]),
+                }
+                next_obs, _r, terminated, truncated, info = envs[lane].step(action_dict)
+                last_thp[lane] = float(info.get("throughput", 0.0))
+                if terminated or truncated:
+                    active[lane] = False
+                    terminated_B[lane] = 1.0 if terminated else 0.0
+                    completion_bonus_B[lane] = float(info.get("completion_bonus", 0.0))
+                    final_world_B[lane] = envs[lane]._world_CWH.clone()
+                    steps_B[lane] = n_trans[lane]
+                else:
+                    obs_B[lane] = next_obs
+
+    # Lanes that somehow never deactivated (shouldn't happen) get closed out.
+    for lane in range(B):
+        if final_world_B[lane] is None:
+            final_world_B[lane] = envs[lane]._world_CWH.clone()
+            steps_B[lane] = n_trans[lane]
+    for e in envs:
+        e.close()
+
+    group_of_lane = torch.tensor([lane // G for lane in range(B)], dtype=torch.long)
+    if obs_rows:
+        obs_NCWH = torch.stack(obs_rows).to(device)
+        actions_N6 = torch.stack(act_rows).to(device)
+        old_logp_N = torch.stack(old_lp).to(device)
+        ref_logp_N = torch.stack(ref_lp).to(device)
+        lane_of_N = torch.tensor(lane_ids, dtype=torch.long, device=device)
+    else:
+        obs_NCWH = torch.empty((0, len(Channel), H, H), device=device)
+        actions_N6 = torch.empty((0, 6), dtype=torch.long, device=device)
+        old_logp_N = torch.empty((0,), device=device)
+        ref_logp_N = torch.empty((0,), device=device)
+        lane_of_N = torch.empty((0,), dtype=torch.long, device=device)
+
+    return RolloutBatch(
+        obs_NCWH=obs_NCWH,
+        actions_N6=actions_N6,
+        old_logp_N=old_logp_N,
+        ref_logp_N=ref_logp_N,
+        lane_of_N=lane_of_N,
+        group_of_lane_B=group_of_lane,
+        thp_final_B=torch.tensor(last_thp, dtype=torch.float32),
+        terminated_B=torch.tensor(terminated_B, dtype=torch.float32),
+        completion_bonus_B=torch.tensor(completion_bonus_B, dtype=torch.float32),
+        steps_B=torch.tensor(steps_B, dtype=torch.float32),
+        final_world_B=final_world_B,
+        solved_world_B=solved_world_B,
+    )
 
 
 def train_grpo(args: GRPOArgs) -> AgentCNN:

--- a/grpo.py
+++ b/grpo.py
@@ -38,6 +38,7 @@ from typing import Optional
 import gymnasium as gym
 import numpy as np
 import torch
+import torch.nn as nn
 import torch.optim as optim
 import tyro
 from torch.distributions import Categorical
@@ -580,6 +581,80 @@ def broadcast_advantages(
 ) -> torch.Tensor:
     """Scatter each lane's scalar advantage onto all of its transitions."""
     return A_B.to(lane_of_N.device)[lane_of_N]
+
+
+def grpo_update(
+    policy: AgentCNN,
+    optimizer: optim.Optimizer,
+    batch: RolloutBatch,
+    A_N: torch.Tensor,
+    args: GRPOArgs,
+) -> dict:
+    """One GRPO optimisation pass: update_epochs inner epochs of PPO-style
+    clipping plus a k3 KL penalty toward the frozen reference.
+
+    pi_theta_old is the rollout-time logp (batch.old_logp_N), fixed across the
+    inner epochs; ratio = exp(new_logp - old_logp). The KL uses the k3
+    estimator on the summed joint logps:
+
+        kl = exp(ref - new) - (ref - new) - 1   (>= 0, estimates KL(pi||ref))
+
+    where `new` carries gradient and the stored `ref` is constant. There is no
+    critic and no minibatching — the batch is small (sim-bound), so each epoch
+    is a full-batch step."""
+    N = batch.obs_NCWH.shape[0]
+    if N == 0:
+        return {"loss/total": float("nan"), "grpo/n_transitions": 0}
+
+    eps = args.clip_coef
+    old_logp_N = batch.old_logp_N
+    ref_logp_N = batch.ref_logp_N
+
+    last: dict = {}
+    for _epoch in range(args.update_epochs):
+        _a, new_logp_N, entropy_N = policy_step(
+            policy,
+            batch.obs_NCWH,
+            temperature=args.temperature,
+            action_B6=batch.actions_N6,
+        )
+        logratio_N = new_logp_N - old_logp_N
+        ratio_N = logratio_N.exp()
+
+        # clipped surrogate (maximise advantage-weighted ratio => minimise -min)
+        pg1 = -A_N * ratio_N
+        pg2 = -A_N * torch.clamp(ratio_N, 1 - eps, 1 + eps)
+        pg_loss = torch.max(pg1, pg2).mean()
+
+        # k3 KL(pi_theta || pi_ref)
+        ref_logratio_N = ref_logp_N - new_logp_N
+        kl_N = ref_logratio_N.exp() - ref_logratio_N - 1.0
+        kl_loss = kl_N.mean()
+
+        entropy = entropy_N.mean()
+        loss = pg_loss + args.beta_kl * kl_loss - args.ent_coef * entropy
+
+        optimizer.zero_grad()
+        loss.backward()
+        grad_norm = nn.utils.clip_grad_norm_(policy.parameters(), args.max_grad_norm)
+        optimizer.step()
+
+        with torch.no_grad():
+            # Schulman's low-variance approx of KL(old || new); ~0 early.
+            approx_kl = ((ratio_N - 1) - logratio_N).mean()
+            clipfrac = ((ratio_N - 1.0).abs() > eps).float().mean()
+        last = {
+            "loss/total": loss.item(),
+            "loss/policy": pg_loss.item(),
+            "loss/kl_ref": kl_loss.item(),
+            "loss/entropy": entropy.item(),
+            "grpo/ratio_mean": ratio_N.mean().item(),
+            "grpo/clipfrac": clipfrac.item(),
+            "grpo/approx_kl": approx_kl.item(),
+            "grpo/grad_norm": float(grad_norm),
+            "grpo/n_transitions": N,
+        }
+    return last
 
 
 def train_grpo(args: GRPOArgs) -> AgentCNN:

--- a/grpo.py
+++ b/grpo.py
@@ -1,0 +1,264 @@
+"""GRPO (Group Relative Policy Optimization) RL finetuning for AgentCNN.
+
+This is the *Dr. GRPO* variant (Liu et al., "Understanding R1-Zero-Like
+Training"): the group-relative advantage is `R_i - mean_group(R)` with **no**
+division by the group std and **no** per-response length normalization. Both of
+those terms inject bias — std-normalization especially blows up the gradient on
+easy/hard grids where reward variance is tiny.
+
+Why GRPO instead of PPO here? The reward is verifiable and outcome-dominated
+(throughput jumps to ~1 the moment source connects to sink, plus a terminal
+completion bonus). A learned value function buys little against a near-terminal
+step-function reward, and the critic is the main source of PPO's tuning surface
+and failure modes (value clip, GAE lambda, value-loss coef, shared-encoder
+corruption). GRPO deletes the critic entirely: it samples a *group* of G
+completions on the *same* seeded grid, scores each by final reward, and
+normalizes within the group. Two distinct valid belt paths both score ~1 and
+both get non-negative advantage — the baseline is diversity-neutral, which is
+exactly the path-agnostic objective we want.
+
+Pipeline position: SFT pretraining gives the policy a strong placement prior
+(~0.68 throughput / ~0.78 dir_acc); GRPO finetunes it. Load an SFT checkpoint
+with --start-from.
+
+Usage:
+    python sft.py --size 8 --checkpoint-path sft.pt ...   # produce the prior
+    python grpo.py --start-from sft.pt --size 8 --track ...
+"""
+
+import json
+import os
+import random
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import gymnasium as gym
+import numpy as np
+import torch
+import torch.optim as optim
+import tyro
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
+import factorion_rs  # noqa: F401,E402  (imported for its side-effect: the env's solver)
+from factorion import (  # noqa: E402
+    Channel,
+    LessonKind,
+    blank_entities,
+    build_factory,
+)
+
+from ppo import AgentCNN, FactorioEnv, make_env  # noqa: E402
+
+GRPO_ENV_ID = "factorion/FactorioEnv-v0-grpo"
+
+
+@dataclass
+class GRPOArgs:
+    # ── experiment / tracking ────────────────────────────────────────────
+    seed: int = 1
+    size: int = 12
+    """grid width/height"""
+    env_id: str = "factorion/FactorioEnv-v0"
+    start_from: str = ""
+    """path to the SFT checkpoint to finetune. REQUIRED — GRPO finetunes a
+    pretrained actor, it does not train from scratch."""
+    track: bool = False
+    wandb_project_name: str = "factorion"
+    wandb_entity: Optional[str] = None
+    wandb_group: Optional[str] = None
+    tags: Optional[list[str]] = None
+
+    # ── network (must match the SFT checkpoint) ──────────────────────────
+    chan1: int = 48
+    chan2: int = 48
+    chan3: int = 64
+    flat_dim: int = 128
+    """unused by AgentCNN (it recomputes chan3*W*H); kept for ctor compat"""
+    tile_head_std: float = 0.02208
+
+    # ── GRPO sampling ────────────────────────────────────────────────────
+    num_iterations: int = 200
+    """outer optimisation iterations"""
+    num_grids: int = 16
+    """distinct seeded grids sampled per iteration. Keep enough that the
+    group baseline isn't dominated by one grid's difficulty."""
+    group_size: int = 8
+    """G — completions sampled per grid. Suggest 8; sweep {4, 8, 16}."""
+    temperature: float = 1.0
+    """sampling temperature; >1 widens the group so it covers distinct paths.
+    Applied identically to old-logp, new-logp and ref-logp so the ratio stays
+    a clean importance ratio of the temperature-T policy."""
+
+    # ── GRPO loss ────────────────────────────────────────────────────────
+    clip_coef: float = 0.2
+    """PPO-style ratio clip epsilon"""
+    beta_kl: float = 0.02
+    """KL(pi_theta || pi_ref) penalty. Main guardrail against drifting off the
+    SFT manifold. Too high: can't escape the single-path bias. Too low: risk
+    collapse / reward hacking. Tune in [0.01, 0.04]."""
+    learning_rate: float = 2e-6
+    """RL on a pretrained net wants a *much* smaller LR than SFT."""
+    update_epochs: int = 2
+    """inner PPO-style update epochs per outer batch (1-4)"""
+    max_grad_norm: float = 1.0
+    ent_coef: float = 0.0
+    """small entropy bonus; raise only if the policy collapses prematurely"""
+    adam_epsilon: float = 1e-8
+
+    # ── reward (outcome-only by default) ─────────────────────────────────
+    reward_mode: str = "outcome"
+    """"outcome": R_i = scale*(thp_final + bonus_coef*bonus). "per_step": the
+    PPO-faithful sum of per-step (throughput+validity) reward (minus shaping
+    when drop_shaping). Outcome is the v1 default — standard GRPO, and the
+    advantage is dominated by the same connect/not-connect signal anyway."""
+    reward_scale: float = 0.1
+    """multiplies R_i. Dr. GRPO drops std-normalization, so we lose its
+    automatic scale-invariance; reward_scale keeps |advantage| ~ O(1) against
+    a completion bonus that can reach ~2*size."""
+    completion_bonus_coef: float = 1.0
+    """weight on the terminal (max_steps - steps) bonus inside R_i"""
+    drop_shaping: bool = True
+    """drop potential-based shaping from R_i (only affects reward_mode=
+    "per_step"; shaping is policy-invariant so it ~cancels in the group
+    baseline — kept as a knob to verify that empirically, per spec)"""
+
+    # ── grid difficulty ──────────────────────────────────────────────────
+    num_missing_min: int = 1
+    num_missing_max: int = 0
+    """0 => auto-cap at 2*size. Each grid samples num_missing uniformly in
+    [num_missing_min, cap] so groups straddle the success boundary."""
+
+    # ── end-of-turn (EOT) ────────────────────────────────────────────────
+    # See the rollout stop-condition for the rationale. v1: episodes end only
+    # on connection or max_steps; EOT is neither used to stop nor RL-trained.
+    honor_eot: bool = False
+    eot_threshold: float = 0.5
+
+    # ── held-out eval ────────────────────────────────────────────────────
+    eval_every: int = 10
+    """run greedy held-out eval every N iterations (0 disables)"""
+    eval_max_seeds: int = 64
+    eval_num_envs: int = 8
+    n_held_out_seeds: int = 256
+    """size of the held-out seed pool (disjoint from training seeds)"""
+
+    # ── io ───────────────────────────────────────────────────────────────
+    checkpoint_path: str = "grpo_checkpoint.pt"
+    summary_path: Optional[str] = None
+
+
+def _device() -> torch.device:
+    dev = torch.device(
+        "cuda"
+        if torch.cuda.is_available()
+        else "mps"
+        if torch.backends.mps.is_available()
+        else "cpu"
+    )
+    if dev.type == "mps":
+        # metal only likes f32
+        torch.set_default_dtype(torch.float32)
+    return dev
+
+
+def _build_agent(args: GRPOArgs, envs, device) -> AgentCNN:
+    """Construct an AgentCNN sized to match the SFT checkpoint and load it.
+
+    Used for both the trainable policy and the frozen reference — both start
+    from the *same* SFT weights (we never deepcopy a mid-training policy)."""
+    agent = AgentCNN(
+        envs,
+        chan1=args.chan1,
+        chan2=args.chan2,
+        chan3=args.chan3,
+        flat_dim=args.flat_dim,
+        tile_head_std=args.tile_head_std,
+    )
+    if not args.start_from:
+        raise ValueError(
+            "GRPO finetunes a pretrained actor: pass --start-from <sft_checkpoint.pt>"
+        )
+    print(f"Loading SFT weights from {args.start_from}")
+    agent.load_state_dict(torch.load(args.start_from, map_location=device))
+    return agent.to(device)
+
+
+def train_grpo(args: GRPOArgs) -> AgentCNN:
+    """GRPO finetuning entry point. Mirrors sft.train_sft's contract: callable
+    directly with a GRPOArgs, returns the trained agent, and writes a
+    checkpoint + summary JSON.
+
+    NOTE: this is the skeleton (checkpoint/reference plumbing only). The
+    rollout → advantage → update loop is added in subsequent commits."""
+    t0 = time.time()
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+
+    device = _device()
+    print(f"running GRPO on {device}")
+
+    # AgentCNN needs a vector env to read grid size / catalog sizes at init.
+    if GRPO_ENV_ID not in gym.registry:
+        gym.register(id=GRPO_ENV_ID, entry_point=FactorioEnv)
+    envs = gym.vector.SyncVectorEnv(
+        [make_env(GRPO_ENV_ID, 0, False, args.size, "grpo")]
+    )
+
+    policy = _build_agent(args, envs, device)
+    # Reference policy: a frozen copy of the SFT prior for KL regularization.
+    ref = _build_agent(args, envs, device)
+    ref.eval()
+    ref.requires_grad_(False)
+    envs.close()
+
+    optimizer = optim.Adam(  # noqa: F841  (used by the training loop in later commits)
+        policy.parameters(), lr=args.learning_rate, eps=args.adam_epsilon
+    )
+
+    run = None
+    if args.track:
+        import wandb
+
+        run = wandb.init(
+            project=args.wandb_project_name,
+            entity=args.wandb_entity,
+            config=vars(args),
+            name=f"grpo-{args.size}x{args.size}",
+            group=args.wandb_group,
+            tags=["grpo"] + (args.tags or []),
+        )
+
+    # ── (training loop added in later commits) ───────────────────────────
+
+    torch.save(policy.state_dict(), args.checkpoint_path)
+    runtime = time.time() - t0
+    print(f"Checkpoint saved to {args.checkpoint_path}")
+
+    summary = {
+        "seed": args.seed,
+        "size": args.size,
+        "num_iterations": args.num_iterations,
+        "num_grids": args.num_grids,
+        "group_size": args.group_size,
+        "start_from": args.start_from,
+        "checkpoint_path": args.checkpoint_path,
+        "runtime_seconds": round(runtime, 1),
+        "wandb_url": run.url if run is not None else None,
+    }
+    summary_path = args.summary_path or str(Path(__file__).parent / "grpo_summary.json")
+    with open(summary_path, "w") as f:
+        json.dump(summary, f, indent=2)
+    print(f"Summary written to {summary_path}")
+
+    if args.track and run is not None:
+        run.finish()
+
+    return policy
+
+
+if __name__ == "__main__":
+    train_grpo(tyro.cli(GRPOArgs))

--- a/grpo.py
+++ b/grpo.py
@@ -583,6 +583,105 @@ def broadcast_advantages(
     return A_B.to(lane_of_N.device)[lane_of_N]
 
 
+def greedy_eval(
+    policy: AgentCNN,
+    args: GRPOArgs,
+    val_grids: list[tuple[int, LessonKind, int]],
+    device,
+) -> dict:
+    """Batched greedy rollout on held-out grids (argmax every head), mirroring
+    sft.run_rollout_eval but self-contained and using the GRPO horizon.
+
+    Episodes end on connection (throughput>=1) or max_steps; EOT is honored
+    only when args.honor_eot, so the regime matches training. Reports:
+      - eval/throughput: mean final throughput (the real objective)
+      - eval/success_rate: fraction that fully connect source->sink
+      - eval/dir_acc_vs_ref: mean tile_match_direction (REPORTED, NOT a target
+        — under working GRPO this may fall while throughput rises, because the
+        actor produces valid OFF-reference paths)."""
+    was_training = policy.training
+    policy.eval()
+    max_steps = _max_steps(args)
+    K = max(1, args.eval_num_envs)
+    thps: list[float] = []
+    dir_accs: list[float] = []
+
+    with torch.no_grad():
+        for start in range(0, len(val_grids), K):
+            chunk = val_grids[start : start + K]
+            n = len(chunk)
+            envs = [_make_rollout_env(args) for _ in range(n)]
+            obs = [None] * n
+            last_thp = [0.0] * n
+            last_dir = [0.0] * n
+            for i, (seed, kind, num_missing) in enumerate(chunk):
+                o, info = envs[i].reset(
+                    seed=seed,
+                    options={"num_missing_entities": num_missing, "kind": kind},
+                )
+                obs[i] = o
+                last_thp[i] = float(info.get("throughput", 0.0))
+                last_dir[i] = float(info.get("tile_match_direction", 0.0))
+
+            active = [True] * n
+            for _t in range(max_steps + 4):
+                if not any(active):
+                    break
+                obs_b = torch.as_tensor(np.stack(obs), dtype=torch.float32, device=device)
+                encoded = policy.encoder(obs_b)
+                tile = policy.tile_logits(encoded).reshape(n, -1).argmax(dim=1)
+                x = tile // args.size
+                y = tile % args.size
+                bidx = torch.arange(n, device=device)
+                feats = encoded[bidx, :, x, y]
+                ent = policy.ent_head(feats).argmax(dim=1)
+                dir_ = policy.dir_head(feats).argmax(dim=1)
+                item = policy.item_head(feats).argmax(dim=1)
+                misc = policy.misc_head(feats).argmax(dim=1)
+                if args.honor_eot:
+                    eot = torch.sigmoid(policy.eot_head(encoded).squeeze(-1)) > args.eot_threshold
+                else:
+                    eot = torch.zeros(n, dtype=torch.bool)
+
+                for i in range(n):
+                    if not active[i]:
+                        continue
+                    if bool(eot[i]):
+                        active[i] = False
+                        continue
+                    action = {
+                        "xy": np.array([int(x[i]), int(y[i])], dtype=int),
+                        "entity": int(ent[i]),
+                        "direction": int(dir_[i]),
+                        "item": int(item[i]),
+                        "misc": int(misc[i]),
+                    }
+                    no, _r, term, trunc, info = envs[i].step(action)
+                    last_thp[i] = float(info.get("throughput", 0.0))
+                    last_dir[i] = float(info.get("tile_match_direction", 0.0))
+                    if term or trunc:
+                        active[i] = False
+                    else:
+                        obs[i] = no
+
+            thps.extend(last_thp)
+            dir_accs.extend(last_dir)
+            for e in envs:
+                e.close()
+
+    if was_training:
+        policy.train()
+
+    mean_thp = float(np.mean(thps)) if thps else 0.0
+    success = float(np.mean([1.0 if t >= 1.0 else 0.0 for t in thps])) if thps else 0.0
+    return {
+        "eval/throughput": mean_thp,
+        "eval/success_rate": success,
+        "eval/dir_acc_vs_ref": float(np.mean(dir_accs)) if dir_accs else 0.0,
+        "eval/n": len(thps),
+    }
+
+
 def grpo_update(
     policy: AgentCNN,
     optimizer: optim.Optimizer,

--- a/grpo.py
+++ b/grpo.py
@@ -40,6 +40,7 @@ import numpy as np
 import torch
 import torch.optim as optim
 import tyro
+from torch.distributions import Categorical
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
 import factorion_rs  # noqa: F401,E402  (imported for its side-effect: the env's solver)
@@ -184,6 +185,96 @@ def _build_agent(args: GRPOArgs, envs, device) -> AgentCNN:
     print(f"Loading SFT weights from {args.start_from}")
     agent.load_state_dict(torch.load(args.start_from, map_location=device))
     return agent.to(device)
+
+
+def _sample(dist: Categorical, generator: Optional[torch.Generator]) -> torch.Tensor:
+    """Sample category indices, optionally from an explicit Generator.
+
+    A dedicated generator decouples action sampling from the global torch RNG,
+    which build_factory()/blank_entities() reseed on every env.reset — without
+    it, action draws would correlate with grid seeds. multinomial runs on CPU
+    so the generator works regardless of the policy's device (mps generators
+    are finicky)."""
+    if generator is None:
+        return dist.sample()
+    idx = torch.multinomial(dist.probs.to("cpu"), 1, generator=generator).squeeze(-1)
+    return idx.to(dist.probs.device)
+
+
+def policy_step(
+    agent: AgentCNN,
+    obs_BCWH: torch.Tensor,
+    temperature: float = 1.0,
+    action_B6: Optional[torch.Tensor] = None,
+    generator: Optional[torch.Generator] = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Temperature-aware replication of AgentCNN.get_action_and_value's action
+    path. Sampling (action_B6=None) and scoring (action_B6 given) share ONE
+    code path so the temperature is applied identically — to the tile logits
+    AND all four per-tile head logits — guaranteeing old-logp, new-logp and
+    ref-logp describe the same temperature-T policy and the ratio stays a clean
+    importance ratio.
+
+    We deliberately do NOT call agent.get_action_and_value: it has no
+    temperature knob and also computes the (unused) value head. At T=1.0 this
+    is numerically identical to get_action_and_value's logp/entropy.
+
+    Action layout (B, 6) int columns: [x, y, entity, direction, item, misc] —
+    the same convention the env's step() and get_action_and_value's scoring
+    path use. Returns (action_B6, logp_B, entropy_B); logp/entropy are SUMS
+    over the 5 categorical heads (tile, entity, dir, item, misc). EOT is a
+    separate head and is intentionally excluded.
+    """
+    encoded_BCWH = agent.encoder(obs_BCWH)
+    B = encoded_BCWH.shape[0]
+    H = agent.height
+
+    # ── tile selection (joint x,y via 1x1 conv) ──
+    tile_logits_BN = agent.tile_logits(encoded_BCWH).reshape(B, -1) / temperature
+    dist_tile = Categorical(logits=tile_logits_BN)
+    if action_B6 is None:
+        tile_idx_B = _sample(dist_tile, generator)
+    else:
+        # Reconstruct tile index from stored (x, y) exactly as
+        # get_action_and_value does (ppo.py:915): tile = x*height + y.
+        tile_idx_B = action_B6[:, 0] * H + action_B6[:, 1]
+    x_B = tile_idx_B // H
+    y_B = tile_idx_B % H
+
+    # ── per-tile heads conditioned on features at the selected tile ──
+    batch_idx = torch.arange(B, device=encoded_BCWH.device)
+    feats_BC = encoded_BCWH[batch_idx, :, x_B, y_B]
+    dist_e = Categorical(logits=agent.ent_head(feats_BC) / temperature)
+    dist_d = Categorical(logits=agent.dir_head(feats_BC) / temperature)
+    dist_i = Categorical(logits=agent.item_head(feats_BC) / temperature)
+    dist_m = Categorical(logits=agent.misc_head(feats_BC) / temperature)
+    if action_B6 is None:
+        ent_B = _sample(dist_e, generator)
+        dir_B = _sample(dist_d, generator)
+        item_B = _sample(dist_i, generator)
+        misc_B = _sample(dist_m, generator)
+    else:
+        ent_B = action_B6[:, 2]
+        dir_B = action_B6[:, 3]
+        item_B = action_B6[:, 4]
+        misc_B = action_B6[:, 5]
+
+    logp_B = (
+        dist_tile.log_prob(tile_idx_B)
+        + dist_e.log_prob(ent_B)
+        + dist_d.log_prob(dir_B)
+        + dist_i.log_prob(item_B)
+        + dist_m.log_prob(misc_B)
+    )
+    entropy_B = (
+        dist_tile.entropy()
+        + dist_e.entropy()
+        + dist_d.entropy()
+        + dist_i.entropy()
+        + dist_m.entropy()
+    )
+    out_B6 = torch.stack([x_B, y_B, ent_B, dir_B, item_B, misc_B], dim=1)
+    return out_B6, logp_B, entropy_B
 
 
 def train_grpo(args: GRPOArgs) -> AgentCNN:

--- a/grpo.py
+++ b/grpo.py
@@ -7,23 +7,22 @@ those terms inject bias — std-normalization especially blows up the gradient o
 easy/hard grids where reward variance is tiny.
 
 Why GRPO instead of PPO here? The reward is verifiable and outcome-dominated
-(throughput jumps to ~1 the moment source connects to sink, plus a terminal
-completion bonus). A learned value function buys little against a near-terminal
-step-function reward, and the critic is the main source of PPO's tuning surface
-and failure modes (value clip, GAE lambda, value-loss coef, shared-encoder
-corruption). GRPO deletes the critic entirely: it samples a *group* of G
-completions on the *same* seeded grid, scores each by final reward, and
-normalizes within the group. Two distinct valid belt paths both score ~1 and
-both get non-negative advantage — the baseline is diversity-neutral, which is
-exactly the path-agnostic objective we want.
+(the terminal throughput reward dominates the small per-step penalty). A learned
+value function buys little against a near-terminal reward, and the critic is the
+main source of PPO's tuning surface and failure modes (value clip, GAE lambda,
+value-loss coef, shared-encoder corruption). GRPO deletes the critic entirely:
+it samples a *group* of G completions on the *same* seeded grid, scores each by
+its episode return, and normalizes within the group. Two distinct valid belt
+paths both score ~1 and both get non-negative advantage — the baseline is
+diversity-neutral, which is exactly the path-agnostic objective we want.
 
-Pipeline position: SFT pretraining gives the policy a strong placement prior
-(~0.68 throughput / ~0.78 dir_acc); GRPO finetunes it. Load an SFT checkpoint
-with --start-from.
+Pipeline position: SFT pretraining gives the policy a strong placement prior;
+GRPO finetunes it. Load an SFT checkpoint with --start-from (a local .pt; the
+network shape must match via --layers/--kernel-size).
 
 Usage:
-    python sft.py --size 8 --checkpoint-path sft.pt ...   # produce the prior
-    python grpo.py --start-from sft.pt --size 8 --track ...
+    python sft.py --size 8 --layer1 48 --layer2 48 --layer3 64 ...   # the prior
+    python grpo.py --start-from sft.pt --size 8 --layers 48 48 64 --track ...
 """
 
 import json
@@ -42,18 +41,16 @@ import torch.nn as nn
 import torch.optim as optim
 import tqdm
 import tyro
-from torch.distributions import Categorical
+from torch.distributions import Bernoulli, Categorical
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
 import factorion_rs  # noqa: F401,E402  (imported for its side-effect: the env's solver)
 from factorion import (  # noqa: E402
     Channel,
     LessonKind,
-    blank_entities,
     build_factory,
 )
 
-from ppo import Args as PPOArgs  # noqa: E402  (env reward coeffs live as its class defaults)
 from ppo import AgentCNN, FactorioEnv, make_env  # noqa: E402
 
 GRPO_ENV_ID = "factorion/FactorioEnv-v0-grpo"
@@ -75,13 +72,27 @@ class GRPOArgs:
     wandb_group: Optional[str] = None
     tags: Optional[list[str]] = None
 
-    # ── network (must match the SFT checkpoint) ──────────────────────────
-    chan1: int = 48
-    chan2: int = 48
-    chan3: int = 64
-    flat_dim: int = 128
-    """unused by AgentCNN (it recomputes chan3*W*H); kept for ctor compat"""
+    # ── network (must match the SFT checkpoint's shape) ──────────────────
+    layers: tuple[int, ...] = (93, 69, 96)
+    """encoder conv widths, one conv per entry — must match the checkpoint.
+    Default is the canonical SFT base (run j0s5y2mc)."""
+    kernel_size: int = 3
+    """conv kernel size (odd); must match the checkpoint"""
+    dropout: float = 0.0
+    """encoder Dropout2d. Off for RL finetuning; the value does not affect
+    state_dict loading (Dropout2d has no params)."""
     tile_head_std: float = 0.02208
+
+    # ── reward (env paid: -step_penalty/step + throughput_reward_scale*thput) ──
+    throughput_reward_scale: float = 1.0
+    """terminal throughput reward scale (paid on eot or max_steps); thput is
+    in [0, 1] so this is the max terminal reward. Matches the env default."""
+    step_penalty: float = 0.01
+    """per-step penalty. Matches the env default."""
+    reward_scale: float = 1.0
+    """extra multiplier on the episode return R_i before advantages. The env
+    reward is already O(1), so 1.0 is the faithful default; raise it to scale
+    up the (Dr. GRPO, un-normalized) advantage magnitude."""
 
     # ── GRPO sampling ────────────────────────────────────────────────────
     num_iterations: int = 200
@@ -112,23 +123,6 @@ class GRPOArgs:
     """small entropy bonus; raise only if the policy collapses prematurely"""
     adam_epsilon: float = 1e-8
 
-    # ── reward (outcome-only by default) ─────────────────────────────────
-    reward_mode: str = "outcome"
-    """"outcome": R_i = scale*(thp_final + bonus_coef*bonus). "per_step": the
-    PPO-faithful sum of per-step (throughput+validity) reward (minus shaping
-    when drop_shaping). Outcome is the v1 default — standard GRPO, and the
-    advantage is dominated by the same connect/not-connect signal anyway."""
-    reward_scale: float = 0.1
-    """multiplies R_i. Dr. GRPO drops std-normalization, so we lose its
-    automatic scale-invariance; reward_scale keeps |advantage| ~ O(1) against
-    a completion bonus that can reach ~2*size."""
-    completion_bonus_coef: float = 1.0
-    """weight on the terminal (max_steps - steps) bonus inside R_i"""
-    drop_shaping: bool = True
-    """drop potential-based shaping from R_i (only affects reward_mode=
-    "per_step"; shaping is policy-invariant so it ~cancels in the group
-    baseline — kept as a knob to verify that empirically, per spec)"""
-
     # ── grid difficulty ──────────────────────────────────────────────────
     num_missing_min: int = 1
     num_missing_max: int = 0
@@ -136,8 +130,14 @@ class GRPOArgs:
     [num_missing_min, cap] so groups straddle the success boundary."""
 
     # ── end-of-turn (EOT) ────────────────────────────────────────────────
-    # See the rollout stop-condition for the rationale. v1: episodes end only
-    # on connection or max_steps; EOT is neither used to stop nor RL-trained.
+    # EOT is a real action (Discrete(2)) the env consumes: terminated when the
+    # agent emits eot=1, else truncated at max_steps. With the per-step penalty
+    # the env *can* now reward stopping early (once the factory can't improve),
+    # so EOT is genuinely learnable here — unlike the pre-rebase reward. v1
+    # keeps it OFF (honor_eot=False): eot is forced to 0, excluded from the
+    # objective, episodes run to max_steps and collect the terminal throughput
+    # reward on truncation. Flip --honor-eot to sample+train it. Tracking +
+    # rationale: https://github.com/beyarkay/factorion/issues/181
     honor_eot: bool = False
     eot_threshold: float = 0.5
 
@@ -175,11 +175,10 @@ def _build_agent(args: GRPOArgs, envs, device) -> AgentCNN:
     from the *same* SFT weights (we never deepcopy a mid-training policy)."""
     agent = AgentCNN(
         envs,
-        chan1=args.chan1,
-        chan2=args.chan2,
-        chan3=args.chan3,
-        flat_dim=args.flat_dim,
+        layers=list(args.layers),
+        kernel_size=args.kernel_size,
         tile_head_std=args.tile_head_std,
+        dropout=args.dropout,
     )
     if not args.start_from:
         raise ValueError(
@@ -190,8 +189,11 @@ def _build_agent(args: GRPOArgs, envs, device) -> AgentCNN:
     return agent.to(device)
 
 
-def _sample(dist: Categorical, generator: Optional[torch.Generator]) -> torch.Tensor:
-    """Sample category indices, optionally from an explicit Generator.
+def _sample_categorical(
+    logits_BN: torch.Tensor, generator: Optional[torch.Generator]
+) -> torch.Tensor:
+    """Sample category indices from logits, optionally via an explicit
+    Generator.
 
     A dedicated generator decouples action sampling from the global torch RNG,
     which build_factory()/blank_entities() reseed on every env.reset — without
@@ -199,34 +201,46 @@ def _sample(dist: Categorical, generator: Optional[torch.Generator]) -> torch.Te
     so the generator works regardless of the policy's device (mps generators
     are finicky)."""
     if generator is None:
-        return dist.sample()
-    idx = torch.multinomial(dist.probs.to("cpu"), 1, generator=generator).squeeze(-1)
-    return idx.to(dist.probs.device)
+        return Categorical(logits=logits_BN).sample()
+    probs = torch.softmax(logits_BN, dim=-1)
+    idx = torch.multinomial(probs.to("cpu"), 1, generator=generator).squeeze(-1)
+    return idx.to(logits_BN.device)
+
+
+def _sample_bernoulli(
+    logit_B: torch.Tensor, generator: Optional[torch.Generator]
+) -> torch.Tensor:
+    if generator is None:
+        return Bernoulli(logits=logit_B).sample()
+    bits = torch.bernoulli(torch.sigmoid(logit_B).to("cpu"), generator=generator)
+    return bits.to(logit_B.device)
 
 
 def policy_step(
     agent: AgentCNN,
     obs_BCWH: torch.Tensor,
     temperature: float = 1.0,
-    action_B6: Optional[torch.Tensor] = None,
+    action_B7: Optional[torch.Tensor] = None,
     generator: Optional[torch.Generator] = None,
+    include_eot: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Temperature-aware replication of AgentCNN.get_action_and_value's action
-    path. Sampling (action_B6=None) and scoring (action_B6 given) share ONE
-    code path so the temperature is applied identically — to the tile logits
-    AND all four per-tile head logits — guaranteeing old-logp, new-logp and
-    ref-logp describe the same temperature-T policy and the ratio stays a clean
-    importance ratio.
+    path. Sampling (action_B7=None) and scoring (action_B7 given) share ONE
+    code path so the temperature is applied identically — to the tile logits,
+    all four per-tile head logits, AND the EOT logit — guaranteeing old-logp,
+    new-logp and ref-logp describe the same temperature-T policy.
 
     We deliberately do NOT call agent.get_action_and_value: it has no
-    temperature knob and also computes the (unused) value head. At T=1.0 this
-    is numerically identical to get_action_and_value's logp/entropy.
+    temperature knob and also computes the (unused) value head. At T=1.0 with
+    include_eot=True this is numerically identical to get_action_and_value's
+    logp/entropy.
 
-    Action layout (B, 6) int columns: [x, y, entity, direction, item, misc] —
-    the same convention the env's step() and get_action_and_value's scoring
-    path use. Returns (action_B6, logp_B, entropy_B); logp/entropy are SUMS
-    over the 5 categorical heads (tile, entity, dir, item, misc). EOT is a
-    separate head and is intentionally excluded.
+    Action layout (B, 7) int columns: [x, y, entity, direction, item, misc, eot]
+    — the convention the env's step() and get_action_and_value's scoring path
+    use. logp/entropy sum the 5 categorical heads (tile, entity, dir, item,
+    misc) plus, iff include_eot, the EOT Bernoulli. With include_eot=False the
+    EOT column is forced to 0 and left out of the objective entirely (v1
+    behaviour: the agent never stops early and eot is never RL-trained).
     """
     encoded_BCWH = agent.encoder(obs_BCWH)
     B = encoded_BCWH.shape[0]
@@ -235,32 +249,44 @@ def policy_step(
     # ── tile selection (joint x,y via 1x1 conv) ──
     tile_logits_BN = agent.tile_logits(encoded_BCWH).reshape(B, -1) / temperature
     dist_tile = Categorical(logits=tile_logits_BN)
-    if action_B6 is None:
-        tile_idx_B = _sample(dist_tile, generator)
+    if action_B7 is None:
+        tile_idx_B = _sample_categorical(tile_logits_BN, generator)
     else:
         # Reconstruct tile index from stored (x, y) exactly as
-        # get_action_and_value does (ppo.py:915): tile = x*height + y.
-        tile_idx_B = action_B6[:, 0] * H + action_B6[:, 1]
+        # get_action_and_value does (ppo.py): tile = x*height + y.
+        tile_idx_B = action_B7[:, 0] * H + action_B7[:, 1]
     x_B = tile_idx_B // H
     y_B = tile_idx_B % H
 
     # ── per-tile heads conditioned on features at the selected tile ──
     batch_idx = torch.arange(B, device=encoded_BCWH.device)
     feats_BC = encoded_BCWH[batch_idx, :, x_B, y_B]
-    dist_e = Categorical(logits=agent.ent_head(feats_BC) / temperature)
-    dist_d = Categorical(logits=agent.dir_head(feats_BC) / temperature)
-    dist_i = Categorical(logits=agent.item_head(feats_BC) / temperature)
-    dist_m = Categorical(logits=agent.misc_head(feats_BC) / temperature)
-    if action_B6 is None:
-        ent_B = _sample(dist_e, generator)
-        dir_B = _sample(dist_d, generator)
-        item_B = _sample(dist_i, generator)
-        misc_B = _sample(dist_m, generator)
+    ent_logits = agent.ent_head(feats_BC) / temperature
+    dir_logits = agent.dir_head(feats_BC) / temperature
+    item_logits = agent.item_head(feats_BC) / temperature
+    misc_logits = agent.misc_head(feats_BC) / temperature
+    eot_logit_B = agent.eot_head(encoded_BCWH).squeeze(-1) / temperature
+    dist_e = Categorical(logits=ent_logits)
+    dist_d = Categorical(logits=dir_logits)
+    dist_i = Categorical(logits=item_logits)
+    dist_m = Categorical(logits=misc_logits)
+    dist_eot = Bernoulli(logits=eot_logit_B)
+
+    if action_B7 is None:
+        ent_B = _sample_categorical(ent_logits, generator)
+        dir_B = _sample_categorical(dir_logits, generator)
+        item_B = _sample_categorical(item_logits, generator)
+        misc_B = _sample_categorical(misc_logits, generator)
+        if include_eot:
+            eot_B = _sample_bernoulli(eot_logit_B, generator)
+        else:
+            eot_B = torch.zeros(B, device=encoded_BCWH.device)
     else:
-        ent_B = action_B6[:, 2]
-        dir_B = action_B6[:, 3]
-        item_B = action_B6[:, 4]
-        misc_B = action_B6[:, 5]
+        ent_B = action_B7[:, 2]
+        dir_B = action_B7[:, 3]
+        item_B = action_B7[:, 4]
+        misc_B = action_B7[:, 5]
+        eot_B = action_B7[:, 6].float()
 
     logp_B = (
         dist_tile.log_prob(tile_idx_B)
@@ -276,21 +302,33 @@ def policy_step(
         + dist_i.entropy()
         + dist_m.entropy()
     )
-    out_B6 = torch.stack([x_B, y_B, ent_B, dir_B, item_B, misc_B], dim=1)
-    return out_B6, logp_B, entropy_B
+    if include_eot:
+        logp_B = logp_B + dist_eot.log_prob(eot_B)
+        entropy_B = entropy_B + dist_eot.entropy()
+
+    out_B7 = torch.stack(
+        [x_B, y_B, ent_B, dir_B, item_B, misc_B, eot_B.long()], dim=1
+    )
+    return out_B7, logp_B, entropy_B
 
 
 def _max_steps(args: GRPOArgs) -> int:
     # Short horizon ("one entity per step over a belt chain"), matching ppo.py's
     # make_env. NOT FactorioEnv's default of size*size, which would make
-    # episodes (and the completion bonus) ~size times longer.
+    # episodes ~size times longer.
     return 2 * args.size
 
 
 def _make_rollout_env(args: GRPOArgs) -> FactorioEnv:
     # idx=0 so reset(seed) is an exact pass-through: the grid is a pure
     # function of (size, kind, seed), letting a group of lanes share one grid.
-    return FactorioEnv(size=args.size, max_steps=_max_steps(args), idx=0)
+    return FactorioEnv(
+        size=args.size,
+        max_steps=_max_steps(args),
+        idx=0,
+        throughput_reward_scale=args.throughput_reward_scale,
+        step_penalty=args.step_penalty,
+    )
 
 
 def select_grids(
@@ -338,20 +376,19 @@ class RolloutBatch:
 
     N = total transitions across all lanes (variable, since episodes vary in
     length). B = num_grids * group_size lanes. A transition is one placement
-    step; a lane that terminated early simply contributes fewer rows."""
+    step; a lane that emitted eot early simply contributes fewer rows."""
 
     obs_NCWH: torch.Tensor
-    actions_N6: torch.Tensor
+    actions_N7: torch.Tensor
     old_logp_N: torch.Tensor
     ref_logp_N: torch.Tensor
     lane_of_N: torch.Tensor  # (N,) which lane each transition came from
     group_of_lane_B: torch.Tensor  # (B,) lane -> group id (lane // G)
     # per-lane reward ingredients
-    thp_final_B: torch.Tensor  # (B,) last throughput the env reported
-    terminated_B: torch.Tensor  # (B,) 1.0 if the lane connected (throughput>=1)
-    completion_bonus_B: torch.Tensor  # (B,) max_steps - steps_at_terminal
+    cum_reward_B: torch.Tensor  # (B,) summed env reward over the episode
+    thput_final_B: torch.Tensor  # (B,) last thput_normed the env reported
+    eot_terminated_B: torch.Tensor  # (B,) 1.0 if the agent emitted eot
     steps_B: torch.Tensor  # (B,) episode length (transitions stored)
-    per_step_reward_B: torch.Tensor  # (B,) sum of PPO-style per-step reward
     # per-lane worlds for diversity metrics
     final_world_B: list = field(default_factory=list)
     solved_world_B: list = field(default_factory=list)
@@ -372,20 +409,21 @@ def collect_rollout(
     belongs to grid g, so the Dr. GRPO baseline is computed over completions of
     the *same* grid. Finished lanes are masked out — they keep getting fed
     through the batched forward (cheap; episodes are short) but store no further
-    transitions and are never stepped again."""
+    transitions and are never stepped again. Episodes end on eot (only when
+    honor_eot) or max_steps; either way the env pays the terminal throughput
+    reward, so the summed reward R_i is a complete episode return."""
     G = args.group_size
     B = len(grids) * G
     T = args.temperature
-    H = args.size
 
     envs = [_make_rollout_env(args) for _ in range(B)]
 
     # Reset ALL lanes before any sampling. build_factory/blank_entities reseed
     # the global RNG on each reset; doing them up front (then sampling via the
     # explicit `generator`) keeps action draws independent of grid seeds.
-    obs_B = [None] * B
+    init_obs: list[np.ndarray] = []
     last_thp = [0.0] * B
-    solved_world_B = [None] * B
+    solved_world_B: list = [None] * B
     for g, (seed, kind, num_missing) in enumerate(grids):
         for j in range(G):
             lane = g * G + j
@@ -393,22 +431,17 @@ def collect_rollout(
                 seed=seed,
                 options={"num_missing_entities": num_missing, "kind": kind},
             )
-            obs_B[lane] = o
-            last_thp[lane] = float(info.get("throughput", 0.0))
+            init_obs.append(o)  # appended in lane order (lane = g*G + j)
+            last_thp[lane] = float(info.get("thput_normed", 0.0))
             solved_world_B[lane] = envs[lane]._solved_world_CWH.clone()
+    obs_B = np.stack(init_obs)  # (B, C, W, H); rows updated in-place per step
 
     active = [True] * B
     n_trans = [0] * B
-    terminated_B = [0.0] * B
-    completion_bonus_B = [0.0] * B
-    final_world_B = [None] * B
+    cum_reward = [0.0] * B
+    eot_terminated = [0.0] * B
+    final_world_B: list = [None] * B
     steps_B = [0] * B
-    # Σ of the env's PPO-style per-step reward, captured so reward_mode=
-    # "per_step" is a faithful reconstruction. The env reads its coeffs from
-    # the Args *class* defaults (the `'args' not in locals()` branch in
-    # FactorioEnv.step), so we read the same attrs here.
-    per_step_sum = [0.0] * B
-    _ct, _cv = PPOArgs.coeff_throughput, PPOArgs.coeff_validity
 
     obs_rows: list[torch.Tensor] = []
     act_rows: list[torch.Tensor] = []
@@ -418,87 +451,56 @@ def collect_rollout(
 
     max_steps = _max_steps(args)
     with torch.no_grad():
-        # Loop until every lane has terminated/truncated. The env truncates
-        # when steps>max_steps (checked pre-increment), so a non-connecting
-        # lane needs up to max_steps+2 steps; +4 leaves margin so truncation
-        # always fires inside the loop, never via the fallback below.
+        # The env truncates when steps>max_steps (checked pre-increment), so a
+        # non-eot lane needs up to max_steps+2 steps; +4 leaves margin so every
+        # lane terminates inside the loop, never via the fallback below.
         for _t in range(max_steps + 4):
             if not any(active):
                 break
-            obs_batch = torch.as_tensor(
-                np.stack(obs_B), dtype=torch.float32, device=device
-            )
-            action_B6, logp_B, _ent = policy_step(
-                policy, obs_batch, temperature=T, generator=generator
+            obs_batch = torch.as_tensor(obs_B, dtype=torch.float32, device=device)
+            action_B7, logp_B, _ent = policy_step(
+                policy,
+                obs_batch,
+                temperature=T,
+                generator=generator,
+                include_eot=args.honor_eot,
             )
             _a, ref_logp_B, _e = policy_step(
-                ref, obs_batch, temperature=T, action_B6=action_B6
+                ref,
+                obs_batch,
+                temperature=T,
+                action_B7=action_B7,
+                include_eot=args.honor_eot,
             )
-
-            # ── EOT stop signal — OFF in v1 (honor_eot defaults False) ──
-            # Under this reward, connecting auto-terminates the episode
-            # (throughput>=1) and stopping early is never beneficial, so the
-            # SFT eot head is a pure confound here: honoring it can truncate a
-            # near-complete factory and inject reward variance for no gain. We
-            # therefore neither stop on it nor RL-train it in v1. `--honor-eot`
-            # flips it on for later experiments. Tracking:
-            # https://github.com/beyarkay/factorion/issues/181
-            eot_stop = [False] * B
-            if args.honor_eot:
-                encoded = policy.encoder(obs_batch)
-                eot_prob_B = torch.sigmoid(policy.eot_head(encoded).squeeze(-1))
-                eot_stop = (eot_prob_B > args.eot_threshold).tolist()
 
             for lane in range(B):
                 if not active[lane]:
                     continue
-                if eot_stop[lane]:
-                    # Agent chose to stop without an env step: no transition,
-                    # episode ends with whatever it has placed so far.
-                    active[lane] = False
-                    terminated_B[lane] = 0.0
-                    completion_bonus_B[lane] = 0.0
-                    final_world_B[lane] = envs[lane]._world_CWH.clone()
-                    steps_B[lane] = n_trans[lane]
-                    continue
 
                 obs_rows.append(obs_batch[lane].cpu())
-                act_rows.append(action_B6[lane].cpu())
+                act_rows.append(action_B7[lane].cpu())
                 old_lp.append(logp_B[lane].cpu())
                 ref_lp.append(ref_logp_B[lane].cpu())
                 lane_ids.append(lane)
                 n_trans[lane] += 1
 
-                act = action_B6[lane].tolist()
+                act = action_B7[lane].tolist()
                 action_dict = {
                     "xy": np.array([act[0], act[1]], dtype=int),
                     "entity": int(act[2]),
                     "direction": int(act[3]),
                     "item": int(act[4]),
                     "misc": int(act[5]),
+                    "eot": int(act[6]),
                 }
-                next_obs, _r, terminated, truncated, info = envs[lane].step(action_dict)
-                last_thp[lane] = float(info.get("throughput", 0.0))
-
-                # PPO-style per-step reward (throughput+validity, normalized),
-                # + shaping deltas unless drop_shaping. Shaping is
-                # potential-based so its episode sum telescopes to a path-
-                # independent constant that ~cancels in the group baseline.
-                valid_t = 0.0 if any(info.get("invalid_reason", {}).values()) else 1.0
-                per_step_sum[lane] += (
-                    _ct * last_thp[lane] + _cv * valid_t
-                ) / (_ct + _cv)
-                if not args.drop_shaping:
-                    per_step_sum[lane] += (
-                        float(info.get("shaping_location_delta", 0.0))
-                        + float(info.get("shaping_entity_delta", 0.0))
-                        + float(info.get("shaping_direction_delta", 0.0))
-                    )
-
+                next_obs, reward, terminated, truncated, info = envs[lane].step(
+                    action_dict
+                )
+                cum_reward[lane] += float(reward)
+                last_thp[lane] = float(info.get("thput_normed", 0.0))
                 if terminated or truncated:
                     active[lane] = False
-                    terminated_B[lane] = 1.0 if terminated else 0.0
-                    completion_bonus_B[lane] = float(info.get("completion_bonus", 0.0))
+                    eot_terminated[lane] = 1.0 if terminated else 0.0
                     final_world_B[lane] = envs[lane]._world_CWH.clone()
                     steps_B[lane] = n_trans[lane]
                 else:
@@ -515,29 +517,28 @@ def collect_rollout(
     group_of_lane = torch.tensor([lane // G for lane in range(B)], dtype=torch.long)
     if obs_rows:
         obs_NCWH = torch.stack(obs_rows).to(device)
-        actions_N6 = torch.stack(act_rows).to(device)
+        actions_N7 = torch.stack(act_rows).to(device)
         old_logp_N = torch.stack(old_lp).to(device)
         ref_logp_N = torch.stack(ref_lp).to(device)
         lane_of_N = torch.tensor(lane_ids, dtype=torch.long, device=device)
     else:
-        obs_NCWH = torch.empty((0, len(Channel), H, H), device=device)
-        actions_N6 = torch.empty((0, 6), dtype=torch.long, device=device)
+        obs_NCWH = torch.empty((0, len(Channel), args.size, args.size), device=device)
+        actions_N7 = torch.empty((0, 7), dtype=torch.long, device=device)
         old_logp_N = torch.empty((0,), device=device)
         ref_logp_N = torch.empty((0,), device=device)
         lane_of_N = torch.empty((0,), dtype=torch.long, device=device)
 
     return RolloutBatch(
         obs_NCWH=obs_NCWH,
-        actions_N6=actions_N6,
+        actions_N7=actions_N7,
         old_logp_N=old_logp_N,
         ref_logp_N=ref_logp_N,
         lane_of_N=lane_of_N,
         group_of_lane_B=group_of_lane,
-        thp_final_B=torch.tensor(last_thp, dtype=torch.float32),
-        terminated_B=torch.tensor(terminated_B, dtype=torch.float32),
-        completion_bonus_B=torch.tensor(completion_bonus_B, dtype=torch.float32),
+        cum_reward_B=torch.tensor(cum_reward, dtype=torch.float32),
+        thput_final_B=torch.tensor(last_thp, dtype=torch.float32),
+        eot_terminated_B=torch.tensor(eot_terminated, dtype=torch.float32),
         steps_B=torch.tensor(steps_B, dtype=torch.float32),
-        per_step_reward_B=torch.tensor(per_step_sum, dtype=torch.float32),
         final_world_B=final_world_B,
         solved_world_B=solved_world_B,
     )
@@ -546,21 +547,12 @@ def collect_rollout(
 def compute_rewards(batch: RolloutBatch, args: GRPOArgs) -> torch.Tensor:
     """Scalar episode return R_i per lane (B,).
 
-    "outcome" (default, standard GRPO): R_i = scale*(thp_final + bonus_coef *
-    bonus), where bonus is the terminal (max_steps - steps) only when the lane
-    connected. Pure outcome reward — no per-step bookkeeping.
-
-    "per_step" (PPO-faithful, opt-in): the env's summed per-step
-    (throughput+validity) reward (with shaping unless drop_shaping) plus the
-    same terminal bonus — for an apples-to-apples comparison with PPO."""
-    bonus = args.completion_bonus_coef * batch.terminated_B * batch.completion_bonus_B
-    if args.reward_mode == "outcome":
-        core = batch.thp_final_B + bonus
-    elif args.reward_mode == "per_step":
-        core = batch.per_step_reward_B + bonus
-    else:
-        raise ValueError(f"unknown reward_mode {args.reward_mode!r}")
-    return args.reward_scale * core
+    R_i = reward_scale * (summed env reward over the episode), i.e. the env's
+    own reward — `throughput_reward_scale * thput_normed_final - steps *
+    step_penalty`. This is the cleanest, most PPO-faithful signal: the env's
+    reward is already outcome-dominated and O(1), so no bespoke reward shaping
+    is needed in GRPO."""
+    return args.reward_scale * batch.cum_reward_B
 
 
 def compute_advantages(R_B: torch.Tensor, group_size: int) -> torch.Tensor:
@@ -577,9 +569,7 @@ def compute_advantages(R_B: torch.Tensor, group_size: int) -> torch.Tensor:
     return (grouped - baseline).reshape(-1)
 
 
-def broadcast_advantages(
-    A_B: torch.Tensor, lane_of_N: torch.Tensor
-) -> torch.Tensor:
+def broadcast_advantages(A_B: torch.Tensor, lane_of_N: torch.Tensor) -> torch.Tensor:
     """Scatter each lane's scalar advantage onto all of its transitions."""
     return A_B.to(lane_of_N.device)[lane_of_N]
 
@@ -602,10 +592,11 @@ def compute_diversity(batch: RolloutBatch, R_B: torch.Tensor, args: GRPOArgs) ->
         ~0); raise temperature / lower beta_kl.
       - diversity/unique_path_frac: mean fraction of DISTINCT final layouts
         within a group. GRPO should push this UP vs SFT.
-      - diversity/off_reference_success: of the WORKING (connected) factories,
-        the fraction whose layout differs from the SFT reference solution. The
-        cleanest single number for "did RL escape the single-path anchor."
-      - diversity/working_frac: fraction of lanes that connected.
+      - diversity/off_reference_success: of the WORKING (thput_normed>=1)
+        factories, the fraction whose layout differs from the SFT reference
+        solution. The cleanest single number for "did RL escape the single-path
+        anchor."
+      - diversity/working_frac: fraction of lanes that fully rebuilt.
       - diversity/dir_acc_vs_ref: mean full-grid direction match to reference
         (REPORTED, not a target — see greedy_eval)."""
     G = args.group_size
@@ -629,7 +620,7 @@ def compute_diversity(batch: RolloutBatch, R_B: torch.Tensor, args: GRPOArgs) ->
         fe, se = fw[Channel.ENTITIES.value], sw[Channel.ENTITIES.value]
         fd, sd = fw[Channel.DIRECTION.value], sw[Channel.DIRECTION.value]
         dir_accs.append((fd == sd).float().mean().item())
-        if batch.terminated_B[lane] >= 1.0:
+        if batch.thput_final_B[lane] >= 1.0:
             working += 1
             on_reference = torch.equal(fe, se) and torch.equal(fd, sd)
             if not on_reference:
@@ -653,10 +644,11 @@ def greedy_eval(
     """Batched greedy rollout on held-out grids (argmax every head), mirroring
     sft.run_rollout_eval but self-contained and using the GRPO horizon.
 
-    Episodes end on connection (throughput>=1) or max_steps; EOT is honored
-    only when args.honor_eot, so the regime matches training. Reports:
-      - eval/throughput: mean final throughput (the real objective)
-      - eval/success_rate: fraction that fully connect source->sink
+    EOT is emitted (argmax → eot_prob>threshold) only when args.honor_eot, so
+    the regime matches training; otherwise the env truncates at max_steps.
+    Reports:
+      - eval/throughput: mean final thput_normed (the real objective)
+      - eval/success_rate: fraction that fully rebuild (thput_normed>=1)
       - eval/dir_acc_vs_ref: mean tile_match_direction (REPORTED, NOT a target
         — under working GRPO this may fall while throughput rises, because the
         actor produces valid OFF-reference paths)."""
@@ -672,7 +664,7 @@ def greedy_eval(
             chunk = val_grids[start : start + K]
             n = len(chunk)
             envs = [_make_rollout_env(args) for _ in range(n)]
-            obs = [None] * n
+            init_obs: list[np.ndarray] = []
             last_thp = [0.0] * n
             last_dir = [0.0] * n
             for i, (seed, kind, num_missing) in enumerate(chunk):
@@ -680,15 +672,16 @@ def greedy_eval(
                     seed=seed,
                     options={"num_missing_entities": num_missing, "kind": kind},
                 )
-                obs[i] = o
-                last_thp[i] = float(info.get("throughput", 0.0))
+                init_obs.append(o)
+                last_thp[i] = float(info.get("thput_normed", 0.0))
                 last_dir[i] = float(info.get("tile_match_direction", 0.0))
+            obs = np.stack(init_obs)  # (n, C, W, H); rows updated per step
 
             active = [True] * n
             for _t in range(max_steps + 4):
                 if not any(active):
                     break
-                obs_b = torch.as_tensor(np.stack(obs), dtype=torch.float32, device=device)
+                obs_b = torch.as_tensor(obs, dtype=torch.float32, device=device)
                 encoded = policy.encoder(obs_b)
                 tile = policy.tile_logits(encoded).reshape(n, -1).argmax(dim=1)
                 x = tile // args.size
@@ -707,18 +700,16 @@ def greedy_eval(
                 for i in range(n):
                     if not active[i]:
                         continue
-                    if bool(eot[i]):
-                        active[i] = False
-                        continue
                     action = {
                         "xy": np.array([int(x[i]), int(y[i])], dtype=int),
                         "entity": int(ent[i]),
                         "direction": int(dir_[i]),
                         "item": int(item[i]),
                         "misc": int(misc[i]),
+                        "eot": int(bool(eot[i])),
                     }
                     no, _r, term, trunc, info = envs[i].step(action)
-                    last_thp[i] = float(info.get("throughput", 0.0))
+                    last_thp[i] = float(info.get("thput_normed", 0.0))
                     last_dir[i] = float(info.get("tile_match_direction", 0.0))
                     if term or trunc:
                         active[i] = False
@@ -759,9 +750,10 @@ def grpo_update(
 
         kl = exp(ref - new) - (ref - new) - 1   (>= 0, estimates KL(pi||ref))
 
-    where `new` carries gradient and the stored `ref` is constant. There is no
-    critic and no minibatching — the batch is small (sim-bound), so each epoch
-    is a full-batch step."""
+    where `new` carries gradient and the stored `ref` is constant. include_eot
+    matches the rollout (args.honor_eot) so logp is computed over exactly the
+    action components that were sampled. No critic, no minibatching — the batch
+    is small (sim-bound), so each epoch is a full-batch step."""
     N = batch.obs_NCWH.shape[0]
     if N == 0:
         return {"loss/total": float("nan"), "grpo/n_transitions": 0}
@@ -776,7 +768,8 @@ def grpo_update(
             policy,
             batch.obs_NCWH,
             temperature=args.temperature,
-            action_B6=batch.actions_N6,
+            action_B7=batch.actions_N7,
+            include_eot=args.honor_eot,
         )
         logratio_N = new_logp_N - old_logp_N
         ratio_N = logratio_N.exp()
@@ -817,9 +810,7 @@ def grpo_update(
     return last
 
 
-def _select_eval_grids(
-    args: GRPOArgs,
-) -> list[tuple[int, LessonKind, int]]:
+def _select_eval_grids(args: GRPOArgs) -> list[tuple[int, LessonKind, int]]:
     """Build the fixed held-out eval set once, from a seed stream independent
     of the per-iteration training stream (collisions over the 2**31 seed space
     are vanishingly unlikely for ~eval_max_seeds grids)."""
@@ -835,8 +826,9 @@ def _rollout_metrics(batch: RolloutBatch, R_B: torch.Tensor, A_N: torch.Tensor) 
         "reward/mean": R_B.mean().item() if R_B.numel() else 0.0,
         "reward/std": R_B.std(unbiased=False).item() if R_B.numel() > 1 else 0.0,
         "advantage/abs_mean": A_N.abs().mean().item() if A_N.numel() else 0.0,
-        "rollout/mean_throughput": batch.thp_final_B.mean().item(),
-        "rollout/success_rate": (batch.terminated_B >= 1.0).float().mean().item(),
+        "rollout/mean_throughput": batch.thput_final_B.mean().item(),
+        "rollout/success_rate": (batch.thput_final_B >= 1.0).float().mean().item(),
+        "rollout/eot_terminated_frac": batch.eot_terminated_B.mean().item(),
         "rollout/mean_episode_len": batch.steps_B.mean().item(),
     }
 
@@ -847,10 +839,10 @@ def train_grpo(args: GRPOArgs) -> AgentCNN:
     checkpoint + summary JSON.
 
     Each outer iteration: select grids → sample a group per grid → score with
-    outcome reward → Dr. GRPO advantages → clipped+KL update → (periodically)
-    greedy held-out eval. We deliberately do NOT torch.compile: the dual-policy
-    setup and the per-iteration-variable flattened batch size would thrash the
-    compile cache for no win (the simulator dominates wall-clock)."""
+    the env's episode return → Dr. GRPO advantages → clipped+KL update →
+    (periodically) greedy held-out eval. We deliberately do NOT torch.compile:
+    the dual-policy setup and the per-iteration-variable flattened batch size
+    would thrash the compile cache for no win (the simulator dominates)."""
     t0 = time.time()
     random.seed(args.seed)
     np.random.seed(args.seed)
@@ -860,11 +852,10 @@ def train_grpo(args: GRPOArgs) -> AgentCNN:
     print(f"running GRPO on {device}")
 
     # AgentCNN needs a vector env to read grid size / catalog sizes at init.
+    # String entry_point (like sft.py) so the registration type-checks.
     if GRPO_ENV_ID not in gym.registry:
-        gym.register(id=GRPO_ENV_ID, entry_point=FactorioEnv)
-    envs = gym.vector.SyncVectorEnv(
-        [make_env(GRPO_ENV_ID, 0, False, args.size, "grpo")]
-    )
+        gym.register(id=GRPO_ENV_ID, entry_point="ppo:FactorioEnv")
+    envs = gym.vector.SyncVectorEnv([make_env(GRPO_ENV_ID, 0, False, args.size, "grpo")])
 
     policy = _build_agent(args, envs, device)
     # Reference policy: a frozen copy of the SFT prior for KL regularization.
@@ -950,7 +941,7 @@ def train_grpo(args: GRPOArgs) -> AgentCNN:
         "temperature": args.temperature,
         "beta_kl": args.beta_kl,
         "learning_rate": args.learning_rate,
-        "reward_mode": args.reward_mode,
+        "honor_eot": args.honor_eot,
         "samples_seen": samples_seen,
         "final_eval_throughput": final_eval.get("eval/throughput"),
         "final_eval_success_rate": final_eval.get("eval/success_rate"),

--- a/grpo.py
+++ b/grpo.py
@@ -929,6 +929,14 @@ def train_grpo(args: GRPOArgs) -> AgentCNN:
             f"Rvar={metrics.get('diversity/reward_var', 0):.3f}"
         )
 
+    # Always run a final held-out eval so the summary reflects the trained
+    # policy regardless of whether the last iteration landed on eval_every.
+    final_eval: dict = {}
+    if eval_grids:
+        final_eval = greedy_eval(policy, args, eval_grids, device)
+        if run is not None:
+            run.log(final_eval, step=samples_seen)
+
     torch.save(policy.state_dict(), args.checkpoint_path)
     runtime = time.time() - t0
     print(f"Checkpoint saved to {args.checkpoint_path}")
@@ -944,8 +952,9 @@ def train_grpo(args: GRPOArgs) -> AgentCNN:
         "learning_rate": args.learning_rate,
         "reward_mode": args.reward_mode,
         "samples_seen": samples_seen,
-        "final_eval_throughput": last_metrics.get("eval/throughput"),
-        "final_eval_success_rate": last_metrics.get("eval/success_rate"),
+        "final_eval_throughput": final_eval.get("eval/throughput"),
+        "final_eval_success_rate": final_eval.get("eval/success_rate"),
+        "final_eval_dir_acc_vs_ref": final_eval.get("eval/dir_acc_vs_ref"),
         "final_rollout_throughput": last_metrics.get("rollout/mean_throughput"),
         "final_kl_ref": last_metrics.get("loss/kl_ref"),
         "final_off_reference_success": last_metrics.get("diversity/off_reference_success"),

--- a/grpo.py
+++ b/grpo.py
@@ -51,6 +51,7 @@ from factorion import (  # noqa: E402
     build_factory,
 )
 
+from ppo import Args as PPOArgs  # noqa: E402  (env reward coeffs live as its class defaults)
 from ppo import AgentCNN, FactorioEnv, make_env  # noqa: E402
 
 GRPO_ENV_ID = "factorion/FactorioEnv-v0-grpo"
@@ -348,6 +349,7 @@ class RolloutBatch:
     terminated_B: torch.Tensor  # (B,) 1.0 if the lane connected (throughput>=1)
     completion_bonus_B: torch.Tensor  # (B,) max_steps - steps_at_terminal
     steps_B: torch.Tensor  # (B,) episode length (transitions stored)
+    per_step_reward_B: torch.Tensor  # (B,) sum of PPO-style per-step reward
     # per-lane worlds for diversity metrics
     final_world_B: list = field(default_factory=list)
     solved_world_B: list = field(default_factory=list)
@@ -399,6 +401,12 @@ def collect_rollout(
     completion_bonus_B = [0.0] * B
     final_world_B = [None] * B
     steps_B = [0] * B
+    # Σ of the env's PPO-style per-step reward, captured so reward_mode=
+    # "per_step" is a faithful reconstruction. The env reads its coeffs from
+    # the Args *class* defaults (the `'args' not in locals()` branch in
+    # FactorioEnv.step), so we read the same attrs here.
+    per_step_sum = [0.0] * B
+    _ct, _cv = PPOArgs.coeff_throughput, PPOArgs.coeff_validity
 
     obs_rows: list[torch.Tensor] = []
     act_rows: list[torch.Tensor] = []
@@ -469,6 +477,22 @@ def collect_rollout(
                 }
                 next_obs, _r, terminated, truncated, info = envs[lane].step(action_dict)
                 last_thp[lane] = float(info.get("throughput", 0.0))
+
+                # PPO-style per-step reward (throughput+validity, normalized),
+                # + shaping deltas unless drop_shaping. Shaping is
+                # potential-based so its episode sum telescopes to a path-
+                # independent constant that ~cancels in the group baseline.
+                valid_t = 0.0 if any(info.get("invalid_reason", {}).values()) else 1.0
+                per_step_sum[lane] += (
+                    _ct * last_thp[lane] + _cv * valid_t
+                ) / (_ct + _cv)
+                if not args.drop_shaping:
+                    per_step_sum[lane] += (
+                        float(info.get("shaping_location_delta", 0.0))
+                        + float(info.get("shaping_entity_delta", 0.0))
+                        + float(info.get("shaping_direction_delta", 0.0))
+                    )
+
                 if terminated or truncated:
                     active[lane] = False
                     terminated_B[lane] = 1.0 if terminated else 0.0
@@ -511,9 +535,51 @@ def collect_rollout(
         terminated_B=torch.tensor(terminated_B, dtype=torch.float32),
         completion_bonus_B=torch.tensor(completion_bonus_B, dtype=torch.float32),
         steps_B=torch.tensor(steps_B, dtype=torch.float32),
+        per_step_reward_B=torch.tensor(per_step_sum, dtype=torch.float32),
         final_world_B=final_world_B,
         solved_world_B=solved_world_B,
     )
+
+
+def compute_rewards(batch: RolloutBatch, args: GRPOArgs) -> torch.Tensor:
+    """Scalar episode return R_i per lane (B,).
+
+    "outcome" (default, standard GRPO): R_i = scale*(thp_final + bonus_coef *
+    bonus), where bonus is the terminal (max_steps - steps) only when the lane
+    connected. Pure outcome reward — no per-step bookkeeping.
+
+    "per_step" (PPO-faithful, opt-in): the env's summed per-step
+    (throughput+validity) reward (with shaping unless drop_shaping) plus the
+    same terminal bonus — for an apples-to-apples comparison with PPO."""
+    bonus = args.completion_bonus_coef * batch.terminated_B * batch.completion_bonus_B
+    if args.reward_mode == "outcome":
+        core = batch.thp_final_B + bonus
+    elif args.reward_mode == "per_step":
+        core = batch.per_step_reward_B + bonus
+    else:
+        raise ValueError(f"unknown reward_mode {args.reward_mode!r}")
+    return args.reward_scale * core
+
+
+def compute_advantages(R_B: torch.Tensor, group_size: int) -> torch.Tensor:
+    """Dr. GRPO advantage: A_i = R_i - mean_group(R).
+
+    NO division by the group std and NO per-response length normalization —
+    both inject bias (Liu et al.). std-normalization in particular blows up the
+    gradient on easy/hard grids where reward variance is tiny. Lanes are
+    group-contiguous (lane = g*G + j, guaranteed by collect_rollout), so a
+    reshape recovers the groups."""
+    num_groups = R_B.shape[0] // group_size
+    grouped = R_B.view(num_groups, group_size)
+    baseline = grouped.mean(dim=1, keepdim=True)
+    return (grouped - baseline).reshape(-1)
+
+
+def broadcast_advantages(
+    A_B: torch.Tensor, lane_of_N: torch.Tensor
+) -> torch.Tensor:
+    """Scatter each lane's scalar advantage onto all of its transitions."""
+    return A_B.to(lane_of_N.device)[lane_of_N]
 
 
 def train_grpo(args: GRPOArgs) -> AgentCNN:

--- a/grpo.py
+++ b/grpo.py
@@ -583,6 +583,66 @@ def broadcast_advantages(
     return A_B.to(lane_of_N.device)[lane_of_N]
 
 
+def _layout_key(world: torch.Tensor) -> tuple:
+    """Hashable identity of a factory layout: its entity + direction channels.
+    Two completions with the same key placed the same things facing the same
+    way (same path); different keys = genuinely different layouts."""
+    ent = world[Channel.ENTITIES.value].reshape(-1).to(torch.int64).tolist()
+    dirc = world[Channel.DIRECTION.value].reshape(-1).to(torch.int64).tolist()
+    return (tuple(ent), tuple(dirc))
+
+
+def compute_diversity(batch: RolloutBatch, R_B: torch.Tensor, args: GRPOArgs) -> dict:
+    """Diversity + off-reference metrics — where GRPO should distinguish itself
+    from SFT and from a reference-anchored critic.
+
+      - diversity/reward_var: mean intra-group reward variance. ~0 across most
+        groups means the learning signal is dead (group collapse → advantages
+        ~0); raise temperature / lower beta_kl.
+      - diversity/unique_path_frac: mean fraction of DISTINCT final layouts
+        within a group. GRPO should push this UP vs SFT.
+      - diversity/off_reference_success: of the WORKING (connected) factories,
+        the fraction whose layout differs from the SFT reference solution. The
+        cleanest single number for "did RL escape the single-path anchor."
+      - diversity/working_frac: fraction of lanes that connected.
+      - diversity/dir_acc_vs_ref: mean full-grid direction match to reference
+        (REPORTED, not a target — see greedy_eval)."""
+    G = args.group_size
+    B = len(batch.final_world_B)
+    num_groups = B // G
+
+    grouped = R_B.view(num_groups, G)
+    reward_var = grouped.var(dim=1, unbiased=False).mean().item()
+
+    unique_fracs = []
+    for g in range(num_groups):
+        keys = {_layout_key(batch.final_world_B[g * G + j]) for j in range(G)}
+        unique_fracs.append(len(keys) / G)
+
+    working = 0
+    off_ref = 0
+    dir_accs = []
+    for lane in range(B):
+        fw = batch.final_world_B[lane]
+        sw = batch.solved_world_B[lane]
+        fe, se = fw[Channel.ENTITIES.value], sw[Channel.ENTITIES.value]
+        fd, sd = fw[Channel.DIRECTION.value], sw[Channel.DIRECTION.value]
+        dir_accs.append((fd == sd).float().mean().item())
+        if batch.terminated_B[lane] >= 1.0:
+            working += 1
+            on_reference = torch.equal(fe, se) and torch.equal(fd, sd)
+            if not on_reference:
+                off_ref += 1
+
+    return {
+        "diversity/reward_var": reward_var,
+        "diversity/unique_path_frac": float(np.mean(unique_fracs)) if unique_fracs else 0.0,
+        "diversity/off_reference_success": (off_ref / working) if working else 0.0,
+        "diversity/working_frac": working / B if B else 0.0,
+        "diversity/dir_acc_vs_ref": float(np.mean(dir_accs)) if dir_accs else 0.0,
+    }
+
+
 def greedy_eval(
     policy: AgentCNN,
     args: GRPOArgs,

--- a/grpo.py
+++ b/grpo.py
@@ -31,7 +31,7 @@ import os
 import random
 import sys
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Optional
 
@@ -40,6 +40,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.optim as optim
+import tqdm
 import tyro
 from torch.distributions import Categorical
 
@@ -440,8 +441,8 @@ def collect_rollout(
             # SFT eot head is a pure confound here: honoring it can truncate a
             # near-complete factory and inject reward variance for no gain. We
             # therefore neither stop on it nor RL-train it in v1. `--honor-eot`
-            # flips it on for later experiments. Tracking: see the EOT GitHub
-            # issue referenced in the project notes.
+            # flips it on for later experiments. Tracking:
+            # https://github.com/beyarkay/factorion/issues/181
             eot_stop = [False] * B
             if args.honor_eot:
                 encoded = policy.encoder(obs_batch)
@@ -816,13 +817,40 @@ def grpo_update(
     return last
 
 
+def _select_eval_grids(
+    args: GRPOArgs,
+) -> list[tuple[int, LessonKind, int]]:
+    """Build the fixed held-out eval set once, from a seed stream independent
+    of the per-iteration training stream (collisions over the 2**31 seed space
+    are vanishingly unlikely for ~eval_max_seeds grids)."""
+    if args.eval_every <= 0 or args.n_held_out_seeds <= 0:
+        return []
+    n = min(args.eval_max_seeds, args.n_held_out_seeds)
+    eval_args = replace(args, num_grids=n)
+    return select_grids(eval_args, random.Random(args.seed * 1_000_003 + 7))
+
+
+def _rollout_metrics(batch: RolloutBatch, R_B: torch.Tensor, A_N: torch.Tensor) -> dict:
+    return {
+        "reward/mean": R_B.mean().item() if R_B.numel() else 0.0,
+        "reward/std": R_B.std(unbiased=False).item() if R_B.numel() > 1 else 0.0,
+        "advantage/abs_mean": A_N.abs().mean().item() if A_N.numel() else 0.0,
+        "rollout/mean_throughput": batch.thp_final_B.mean().item(),
+        "rollout/success_rate": (batch.terminated_B >= 1.0).float().mean().item(),
+        "rollout/mean_episode_len": batch.steps_B.mean().item(),
+    }
+
+
 def train_grpo(args: GRPOArgs) -> AgentCNN:
     """GRPO finetuning entry point. Mirrors sft.train_sft's contract: callable
     directly with a GRPOArgs, returns the trained agent, and writes a
     checkpoint + summary JSON.
 
-    NOTE: this is the skeleton (checkpoint/reference plumbing only). The
-    rollout → advantage → update loop is added in subsequent commits."""
+    Each outer iteration: select grids → sample a group per grid → score with
+    outcome reward → Dr. GRPO advantages → clipped+KL update → (periodically)
+    greedy held-out eval. We deliberately do NOT torch.compile: the dual-policy
+    setup and the per-iteration-variable flattened batch size would thrash the
+    compile cache for no win (the simulator dominates wall-clock)."""
     t0 = time.time()
     random.seed(args.seed)
     np.random.seed(args.seed)
@@ -845,7 +873,7 @@ def train_grpo(args: GRPOArgs) -> AgentCNN:
     ref.requires_grad_(False)
     envs.close()
 
-    optimizer = optim.Adam(  # noqa: F841  (used by the training loop in later commits)
+    optimizer = optim.Adam(
         policy.parameters(), lr=args.learning_rate, eps=args.adam_epsilon
     )
 
@@ -862,7 +890,44 @@ def train_grpo(args: GRPOArgs) -> AgentCNN:
             tags=["grpo"] + (args.tags or []),
         )
 
-    # ── (training loop added in later commits) ───────────────────────────
+    eval_grids = _select_eval_grids(args)
+
+    samples_seen = 0
+    last_metrics: dict = {}
+    pbar = tqdm.trange(1, args.num_iterations + 1)
+    for iteration in pbar:
+        # Independent RNG streams: grid selection per iteration, action
+        # sampling via its own Generator (decoupled from grid-seed reseeds).
+        grid_rng = random.Random(args.seed * 1_000_003 + iteration)
+        sample_gen = torch.Generator().manual_seed((args.seed * 7919 + iteration) % (2**31))
+
+        grids = select_grids(args, grid_rng)
+        batch = collect_rollout(policy, ref, args, grids, device, sample_gen)
+        R_B = compute_rewards(batch, args)
+        A_N = broadcast_advantages(
+            compute_advantages(R_B, args.group_size), batch.lane_of_N
+        )
+        update_metrics = grpo_update(policy, optimizer, batch, A_N, args)
+        samples_seen += int(batch.obs_NCWH.shape[0])
+
+        metrics = {"train/iteration": iteration, "train/samples_seen": samples_seen}
+        metrics.update(update_metrics)
+        metrics.update(_rollout_metrics(batch, R_B, A_N))
+        metrics.update(compute_diversity(batch, R_B, args))
+        if eval_grids and (iteration % args.eval_every == 0 or iteration == 1):
+            metrics.update(greedy_eval(policy, args, eval_grids, device))
+
+        # x-axis = optimisation pressure (samples_seen), not iteration index,
+        # so runs with different num_grids/group_size stay comparable.
+        if run is not None:
+            run.log(metrics, step=samples_seen)
+        last_metrics = metrics
+        pbar.set_description(
+            f"it{iteration} thp={metrics.get('rollout/mean_throughput', 0):.2f} "
+            f"succ={metrics.get('rollout/success_rate', 0):.2f} "
+            f"klref={metrics.get('loss/kl_ref', 0):.3f} "
+            f"Rvar={metrics.get('diversity/reward_var', 0):.3f}"
+        )
 
     torch.save(policy.state_dict(), args.checkpoint_path)
     runtime = time.time() - t0
@@ -874,6 +939,16 @@ def train_grpo(args: GRPOArgs) -> AgentCNN:
         "num_iterations": args.num_iterations,
         "num_grids": args.num_grids,
         "group_size": args.group_size,
+        "temperature": args.temperature,
+        "beta_kl": args.beta_kl,
+        "learning_rate": args.learning_rate,
+        "reward_mode": args.reward_mode,
+        "samples_seen": samples_seen,
+        "final_eval_throughput": last_metrics.get("eval/throughput"),
+        "final_eval_success_rate": last_metrics.get("eval/success_rate"),
+        "final_rollout_throughput": last_metrics.get("rollout/mean_throughput"),
+        "final_kl_ref": last_metrics.get("loss/kl_ref"),
+        "final_off_reference_success": last_metrics.get("diversity/off_reference_success"),
         "start_from": args.start_from,
         "checkpoint_path": args.checkpoint_path,
         "runtime_seconds": round(runtime, 1),

--- a/tests/test_grpo.py
+++ b/tests/test_grpo.py
@@ -88,6 +88,10 @@ class TestTrainGRPOEndToEnd:
             s = json.load(f)
         assert s["size"] == size
         assert s["start_from"] == sft_ckpt
+        assert s["num_iterations"] == 2
+        # the loop actually ran and recorded optimisation pressure
+        assert "samples_seen" in s and s["samples_seen"] > 0
+        assert "final_rollout_throughput" in s
 
         # The saved checkpoint must load back into a fresh AgentCNN (so
         # ppo.py --start_from and a follow-up GRPO run can both consume it).

--- a/tests/test_grpo.py
+++ b/tests/test_grpo.py
@@ -15,7 +15,7 @@ os.environ["WANDB_DISABLED"] = "true"
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from ppo import AgentCNN, FactorioEnv, make_env  # noqa: E402
-from grpo import GRPOArgs, train_grpo  # noqa: E402
+from grpo import GRPOArgs, policy_step, train_grpo  # noqa: E402
 
 ENV_ID = "factorion/FactorioEnv-v0-grpo-test"
 
@@ -82,3 +82,77 @@ class TestTrainGRPOEndToEnd:
         agent = AgentCNN(envs, **TINY)
         agent.load_state_dict(torch.load(out_ckpt))
         envs.close()
+
+
+class TestPolicyStep:
+    """policy_step must be a faithful, temperature-aware reimplementation of
+    AgentCNN.get_action_and_value's action path."""
+
+    def _agent_and_obs(self, size=5, batch=6, seed=0):
+        envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, size, "grpo-test")])
+        agent = AgentCNN(envs, **TINY)
+        envs.close()
+        torch.manual_seed(seed)
+        # plausible integer observation in the catalog id range
+        obs = torch.randint(
+            0, 3, (batch, len(agent_channels()), size, size), dtype=torch.float32
+        )
+        return agent, obs
+
+    def test_t1_matches_native_logp_and_entropy(self, registered_env):
+        """At T=1.0, scoring an action with policy_step yields the same logp
+        and entropy that get_action_and_value reports for that same action."""
+        agent, obs = self._agent_and_obs()
+        agent.eval()
+        with torch.no_grad():
+            torch.manual_seed(123)
+            action_d, logp_native, ent_native, _v = agent.get_action_and_value(obs)
+            # native action dict -> (B, 6) [x, y, ent, dir, item, misc]
+            x, y = action_d["xy"].unbind(dim=1)
+            action_B6 = torch.stack(
+                [x, y, action_d["entity"], action_d["direction"], action_d["item"], action_d["misc"]],
+                dim=1,
+            )
+            _out, logp_mine, ent_mine = policy_step(
+                agent, obs, temperature=1.0, action_B6=action_B6
+            )
+        assert torch.allclose(logp_mine, logp_native, atol=1e-5), (
+            logp_mine,
+            logp_native,
+        )
+        assert torch.allclose(ent_mine, ent_native, atol=1e-5)
+
+    def test_scoring_roundtrips_sampled_action(self, registered_env):
+        """Sampling then scoring the returned action reproduces its logp
+        (the (x,y)->tile_idx reconstruction is exact)."""
+        agent, obs = self._agent_and_obs(seed=1)
+        agent.eval()
+        gen = torch.Generator().manual_seed(7)
+        with torch.no_grad():
+            action_B6, logp_sampled, _e = policy_step(
+                agent, obs, temperature=1.3, generator=gen
+            )
+            _out, logp_scored, _e2 = policy_step(
+                agent, obs, temperature=1.3, action_B6=action_B6
+            )
+        assert torch.allclose(logp_sampled, logp_scored, atol=1e-6)
+
+    def test_temperature_increases_entropy(self, registered_env):
+        """Higher temperature flattens the head distributions -> more entropy."""
+        agent, obs = self._agent_and_obs(seed=2)
+        agent.eval()
+        with torch.no_grad():
+            _a, _lp, ent_cold = policy_step(agent, obs, temperature=0.5, action_B6=_dummy_action(obs))
+            _a, _lp, ent_hot = policy_step(agent, obs, temperature=2.0, action_B6=_dummy_action(obs))
+        assert (ent_hot > ent_cold).all()
+
+
+def agent_channels():
+    from factorion import Channel
+
+    return list(Channel)
+
+
+def _dummy_action(obs):
+    B = obs.shape[0]
+    return torch.zeros((B, 6), dtype=torch.long)

--- a/tests/test_grpo.py
+++ b/tests/test_grpo.py
@@ -128,8 +128,9 @@ class TestPolicyStep:
         return agent, obs
 
     def test_t1_matches_native_logp_and_entropy(self, registered_env):
-        """At T=1.0 with include_eot, scoring an action with policy_step yields
-        the same logp/entropy get_action_and_value reports for that action."""
+        """At T=1.0, scoring an action with policy_step yields the same
+        logp/entropy get_action_and_value reports for that action (both include
+        the EOT Bernoulli)."""
         agent, obs = self._agent_and_obs()
         agent.eval()
         with torch.no_grad():
@@ -149,7 +150,7 @@ class TestPolicyStep:
                 dim=1,
             )
             _out, logp_mine, ent_mine = policy_step(
-                agent, obs, temperature=1.0, action_B7=action_B7, include_eot=True
+                agent, obs, temperature=1.0, action_B7=action_B7
             )
         assert torch.allclose(logp_mine, logp_native, atol=1e-5), (logp_mine, logp_native)
         assert torch.allclose(ent_mine, ent_native, atol=1e-5)
@@ -161,38 +162,31 @@ class TestPolicyStep:
         gen = torch.Generator().manual_seed(7)
         with torch.no_grad():
             action_B7, logp_sampled, _e = policy_step(
-                agent, obs, temperature=1.3, generator=gen, include_eot=True
+                agent, obs, temperature=1.3, generator=gen
             )
             _out, logp_scored, _e2 = policy_step(
-                agent, obs, temperature=1.3, action_B7=action_B7, include_eot=True
+                agent, obs, temperature=1.3, action_B7=action_B7
             )
         assert torch.allclose(logp_sampled, logp_scored, atol=1e-6)
 
-    def test_action_is_7_wide(self, registered_env):
+    def test_action_is_7_wide_with_eot(self, registered_env):
         agent, obs = self._agent_and_obs(seed=4)
         with torch.no_grad():
-            action_B7, _lp, _e = policy_step(agent, obs, include_eot=True)
+            action_B7, _lp, _e = policy_step(agent, obs)
         assert action_B7.shape == (obs.shape[0], 7)
+        assert set(action_B7[:, 6].tolist()) <= {0, 1}  # eot column is binary
 
-    def test_include_eot_false_forces_eot_zero_and_excludes_it(self, registered_env):
-        """With include_eot=False the sampled eot column is 0 and the logp
-        excludes the EOT term (so it equals the 5-head sum)."""
+    def test_logp_depends_on_eot(self, registered_env):
+        """EOT is always part of the objective: flipping the scored eot bit
+        changes the logp (the EOT Bernoulli term is included)."""
         agent, obs = self._agent_and_obs(seed=5)
+        a0 = _dummy_action(obs)  # eot=0
+        a1 = a0.clone()
+        a1[:, 6] = 1  # eot=1
         with torch.no_grad():
-            action_B7, logp_no_eot, _e = policy_step(
-                agent, obs, include_eot=False, generator=torch.Generator().manual_seed(1)
-            )
-            # score the SAME action with and without the eot term
-            _o, logp_with_eot, _e2 = policy_step(
-                agent, obs, action_B7=action_B7, include_eot=True
-            )
-            _o, logp_excl_eot, _e3 = policy_step(
-                agent, obs, action_B7=action_B7, include_eot=False
-            )
-        assert (action_B7[:, 6] == 0).all()
-        assert torch.allclose(logp_no_eot, logp_excl_eot, atol=1e-6)
-        # the eot term is nonzero in general, so including it changes logp
-        assert not torch.allclose(logp_with_eot, logp_excl_eot)
+            _o, logp0, _e = policy_step(agent, obs, action_B7=a0)
+            _o, logp1, _e2 = policy_step(agent, obs, action_B7=a1)
+        assert not torch.allclose(logp0, logp1)
 
     def test_temperature_increases_entropy(self, registered_env):
         agent, obs = self._agent_and_obs(seed=2)
@@ -219,14 +213,13 @@ class TestSelectGrids:
 
 
 class TestCollectRollout:
-    def _rollout(self, size=5, num_grids=2, group_size=3, seed=0, honor_eot=False):
+    def _rollout(self, size=5, num_grids=2, group_size=3, seed=0):
         args = GRPOArgs(
             size=size,
             num_grids=num_grids,
             group_size=group_size,
             num_missing_max=2,
             temperature=1.2,
-            honor_eot=honor_eot,
             start_from="x",
             layers=TINY_LAYERS,
         )
@@ -260,10 +253,24 @@ class TestCollectRollout:
             assert 1 <= n <= max_transitions
         assert batch.obs_NCWH.shape[0] == int(batch.steps_B.sum())
 
-    def test_eot_off_runs_to_max_steps(self, registered_env):
-        """With honor_eot=False no lane terminates via eot."""
-        _args, batch = self._rollout(honor_eot=False)
-        assert float(batch.eot_terminated_B.sum()) == 0.0
+    def test_eot_is_always_obeyed(self, registered_env):
+        """Force the eot head to always fire -> every lane terminates via eot
+        on its first step (the env stops on eot=1)."""
+        size = 5
+        policy = _tiny_agent(size)
+        ref = _tiny_agent(size)
+        with torch.no_grad():
+            policy.eot_head[1].bias.fill_(50.0)  # sigmoid(50) ~ 1 -> eot=1
+        args = GRPOArgs(
+            size=size, num_grids=2, group_size=2, num_missing_max=2,
+            start_from="x", layers=TINY_LAYERS,
+        )
+        grids = select_grids(args, random.Random(0))
+        gen = torch.Generator().manual_seed(0)
+        batch = collect_rollout(policy, ref, args, grids, torch.device("cpu"), gen)
+        B = args.num_grids * args.group_size
+        assert float(batch.eot_terminated_B.sum()) == B  # all stopped via eot
+        assert int(batch.steps_B.max()) == 1  # eot fired on the first step
 
     def test_shapes_consistent(self, registered_env):
         args, batch = self._rollout()

--- a/tests/test_grpo.py
+++ b/tests/test_grpo.py
@@ -21,6 +21,7 @@ from grpo import (  # noqa: E402
     broadcast_advantages,
     collect_rollout,
     compute_advantages,
+    compute_diversity,
     compute_rewards,
     greedy_eval,
     grpo_update,
@@ -409,3 +410,97 @@ class TestGreedyEval:
         m = greedy_eval(policy, args, [], torch.device("cpu"))
         assert m["eval/n"] == 0
         assert m["eval/throughput"] == 0.0
+
+
+def _world(size, fill=0):
+    from factorion import Channel
+
+    return torch.full((len(Channel), size, size), fill, dtype=torch.float32)
+
+
+def _batch_with_worlds(final_worlds, solved_worlds, terminated):
+    B = len(final_worlds)
+    z = torch.zeros((0,), dtype=torch.long)
+    return RolloutBatch(
+        obs_NCWH=torch.empty((0, 5, 5, 5)),
+        actions_N6=torch.empty((0, 6), dtype=torch.long),
+        old_logp_N=torch.empty((0,)),
+        ref_logp_N=torch.empty((0,)),
+        lane_of_N=z,
+        group_of_lane_B=torch.arange(B),
+        thp_final_B=torch.zeros(B),
+        terminated_B=torch.tensor(terminated, dtype=torch.float32),
+        completion_bonus_B=torch.zeros(B),
+        steps_B=torch.zeros(B),
+        per_step_reward_B=torch.zeros(B),
+        final_world_B=final_worlds,
+        solved_world_B=solved_worlds,
+    )
+
+
+class TestDiversity:
+    def test_off_reference_and_unique_paths(self):
+        from factorion import Channel
+
+        size = 5
+        solved = _world(size)
+        solved[Channel.ENTITIES.value, 0, 0] = 1  # the "reference" layout
+
+        on_ref = solved.clone()  # identical to reference
+        off_ref = solved.clone()
+        off_ref[Channel.ENTITIES.value, 0, 1] = 1  # a different (but working) path
+
+        # 1 group of 2: lane0 on-reference, lane1 off-reference, both connected
+        batch = _batch_with_worlds(
+            final_worlds=[on_ref, off_ref],
+            solved_worlds=[solved, solved],
+            terminated=[1.0, 1.0],
+        )
+        args = GRPOArgs(size=size, group_size=2, start_from="x", **TINY)
+        R_B = torch.tensor([1.0, 3.0])
+        m = compute_diversity(batch, R_B, args)
+
+        # intra-group var of [1,3] (population) = 1.0
+        assert abs(m["diversity/reward_var"] - 1.0) < 1e-6
+        # two distinct layouts in the group
+        assert m["diversity/unique_path_frac"] == 1.0
+        # 1 of 2 working factories is off-reference
+        assert abs(m["diversity/off_reference_success"] - 0.5) < 1e-6
+        assert m["diversity/working_frac"] == 1.0
+
+    def test_identical_group_has_zero_variance_and_no_diversity(self):
+        size = 5
+        w = _world(size)
+        batch = _batch_with_worlds(
+            final_worlds=[w.clone(), w.clone()],
+            solved_worlds=[w.clone(), w.clone()],
+            terminated=[1.0, 1.0],
+        )
+        args = GRPOArgs(size=size, group_size=2, start_from="x", **TINY)
+        m = compute_diversity(batch, torch.tensor([2.0, 2.0]), args)
+        assert m["diversity/reward_var"] == 0.0
+        assert m["diversity/unique_path_frac"] == 0.5  # 1 unique / 2
+        # final == solved everywhere -> all working factories are on-reference
+        assert m["diversity/off_reference_success"] == 0.0
+
+    def test_runs_on_real_rollout(self, registered_env):
+        import random
+
+        args = GRPOArgs(
+            size=5, num_grids=2, group_size=3, num_missing_max=2, start_from="x", **TINY
+        )
+        grids = select_grids(args, random.Random(3))
+        policy, ref = _tiny_agent(5), _tiny_agent(5)
+        gen = torch.Generator().manual_seed(3)
+        batch = collect_rollout(policy, ref, args, grids, torch.device("cpu"), gen)
+        R_B = compute_rewards(batch, args)
+        m = compute_diversity(batch, R_B, args)
+        for k in (
+            "diversity/reward_var",
+            "diversity/unique_path_frac",
+            "diversity/off_reference_success",
+            "diversity/working_frac",
+            "diversity/dir_acc_vs_ref",
+        ):
+            assert k in m and np.isfinite(m[k])
+        assert 0.0 <= m["diversity/unique_path_frac"] <= 1.0

--- a/tests/test_grpo.py
+++ b/tests/test_grpo.py
@@ -18,9 +18,11 @@ from ppo import AgentCNN, FactorioEnv, make_env  # noqa: E402
 from grpo import (  # noqa: E402
     GRPOArgs,
     RolloutBatch,
+    broadcast_advantages,
     collect_rollout,
     compute_advantages,
     compute_rewards,
+    grpo_update,
     policy_step,
     select_grids,
     train_grpo,
@@ -319,3 +321,66 @@ class TestAdvantages:
         A = compute_advantages(R, group_size=2)
         for g in range(3):
             assert abs(float(A[2 * g] + A[2 * g + 1])) < 1e-6
+
+
+class TestGRPOUpdate:
+    def _setup(self, size=5, seed=0, **arg_overrides):
+        import random
+
+        base = dict(
+            size=size,
+            num_grids=2,
+            group_size=3,
+            num_missing_max=2,
+            temperature=1.1,
+            start_from="x",
+        )
+        base.update(arg_overrides)
+        args = GRPOArgs(**base, **TINY)
+        grids = select_grids(args, random.Random(seed))
+        policy = _tiny_agent(size)
+        ref = _tiny_agent(size)
+        gen = torch.Generator().manual_seed(seed)
+        batch = collect_rollout(policy, ref, args, grids, torch.device("cpu"), gen)
+        R = compute_rewards(batch, args)
+        A_N = broadcast_advantages(compute_advantages(R, args.group_size), batch.lane_of_N)
+        return args, policy, batch, A_N
+
+    def test_ratio_one_and_finite_loss_with_zero_lr(self):
+        """With lr=0 and one inner epoch the policy is unchanged, so ratio==1,
+        approx_kl==0, the loss is finite and the k3 KL to ref is >= 0."""
+        args, policy, batch, A_N = self._setup(learning_rate=0.0, update_epochs=1)
+        opt = torch.optim.Adam(policy.parameters(), lr=0.0)
+        m = grpo_update(policy, opt, batch, A_N, args)
+        assert abs(m["grpo/ratio_mean"] - 1.0) < 1e-5
+        assert abs(m["grpo/approx_kl"]) < 1e-5
+        assert m["loss/kl_ref"] >= -1e-6
+        assert np.isfinite(m["loss/total"])
+
+    def test_update_changes_weights(self):
+        """A real step (lr>0) with nonzero advantages moves the policy params.
+        Advantages are injected synthetically so the test never depends on a
+        rollout happening to have reward variance."""
+        args, policy, batch, _A = self._setup(learning_rate=1e-2, update_epochs=2)
+        N = batch.obs_NCWH.shape[0]
+        assert N > 0
+        # alternating +1/-1 advantages — guaranteed nonzero gradient signal
+        A_N = torch.where(
+            torch.arange(N) % 2 == 0, torch.ones(N), -torch.ones(N)
+        )
+        before = [p.detach().clone() for p in policy.parameters()]
+        opt = torch.optim.Adam(policy.parameters(), lr=1e-2)
+        m = grpo_update(policy, opt, batch, A_N, args)
+        after = list(policy.parameters())
+        moved = any(not torch.equal(b, a) for b, a in zip(before, after))
+        assert moved, "expected the policy weights to change after an update"
+        assert np.isfinite(m["loss/total"])
+        assert m["loss/kl_ref"] >= -1e-6
+
+    def test_empty_batch_is_safe(self):
+        args = GRPOArgs(size=5, group_size=2, start_from="x", **TINY)
+        policy = _tiny_agent(5)
+        empty = _fake_batch(thp=[], terminated=[], bonus=[])
+        opt = torch.optim.Adam(policy.parameters(), lr=1e-3)
+        m = grpo_update(policy, opt, empty, torch.empty((0,)), args)
+        assert m["grpo/n_transitions"] == 0

--- a/tests/test_grpo.py
+++ b/tests/test_grpo.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import random
 import sys
 
 import gymnasium as gym
@@ -14,6 +15,7 @@ os.environ["WANDB_DISABLED"] = "true"
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+from factorion import Channel  # noqa: E402
 from ppo import AgentCNN, FactorioEnv, make_env  # noqa: E402
 from grpo import (  # noqa: E402
     GRPOArgs,
@@ -32,31 +34,44 @@ from grpo import (  # noqa: E402
 
 ENV_ID = "factorion/FactorioEnv-v0-grpo-test"
 
-# Tiny network so tests stay fast; these must match across the fake SFT
-# checkpoint and the GRPOArgs that loads it.
-TINY = dict(chan1=16, chan2=16, chan3=16, flat_dim=64)
+# Tiny network so tests stay fast; this must match across the fake SFT
+# checkpoint and the GRPOArgs that loads it. Passed explicitly (not splatted)
+# so the annotated GRPOArgs type-checks cleanly under `ty`.
+TINY_LAYERS = (16, 16)
 
 
 @pytest.fixture(scope="module")
 def registered_env():
     if ENV_ID not in gym.registry:
-        gym.register(id=ENV_ID, entry_point=FactorioEnv)
+        gym.register(id=ENV_ID, entry_point=FactorioEnv)  # ty: ignore[invalid-argument-type]
 
 
 def _make_sft_checkpoint(path: str, size: int) -> None:
     """Stand in for a real SFT checkpoint: a freshly-initialised AgentCNN
     state_dict saved exactly the way sft.train_sft writes it."""
     envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, size, "grpo-test")])
-    agent = AgentCNN(envs, **TINY)
+    agent = AgentCNN(envs, layers=TINY_LAYERS)
     envs.close()
     torch.save(agent.state_dict(), path)
+
+
+def _tiny_agent(size=5):
+    envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, size, "grpo-test")])
+    agent = AgentCNN(envs, layers=TINY_LAYERS)
+    envs.close()
+    return agent
+
+
+def _dummy_action(obs):
+    B = obs.shape[0]
+    return torch.zeros((B, 7), dtype=torch.long)
 
 
 class TestTrainGRPOEndToEnd:
     def test_requires_start_from(self, registered_env):
         """GRPO finetunes a prior — refuse to run without --start-from."""
         with pytest.raises(ValueError):
-            train_grpo(GRPOArgs(seed=1, size=5, start_from="", **TINY))
+            train_grpo(GRPOArgs(seed=1, size=5, start_from="", layers=TINY_LAYERS))
 
     def test_produces_checkpoint_and_summary(self, registered_env, tmp_path):
         """End-to-end: train_grpo() runs, saves a checkpoint + summary, and
@@ -75,9 +90,11 @@ class TestTrainGRPOEndToEnd:
             num_grids=2,
             group_size=2,
             num_missing_max=2,
+            eval_max_seeds=4,
+            n_held_out_seeds=4,
             checkpoint_path=out_ckpt,
             summary_path=summary,
-            **TINY,
+            layers=TINY_LAYERS,
         )
         train_grpo(args)
 
@@ -89,106 +106,111 @@ class TestTrainGRPOEndToEnd:
         assert s["size"] == size
         assert s["start_from"] == sft_ckpt
         assert s["num_iterations"] == 2
-        # the loop actually ran and recorded optimisation pressure
         assert "samples_seen" in s and s["samples_seen"] > 0
         assert "final_rollout_throughput" in s
 
-        # The saved checkpoint must load back into a fresh AgentCNN (so
-        # ppo.py --start_from and a follow-up GRPO run can both consume it).
         envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, size, "grpo-test")])
-        agent = AgentCNN(envs, **TINY)
+        agent = AgentCNN(envs, layers=TINY_LAYERS)
         agent.load_state_dict(torch.load(out_ckpt))
         envs.close()
 
 
 class TestPolicyStep:
     """policy_step must be a faithful, temperature-aware reimplementation of
-    AgentCNN.get_action_and_value's action path."""
+    AgentCNN.get_action_and_value's action path (including the EOT head)."""
 
     def _agent_and_obs(self, size=5, batch=6, seed=0):
-        envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, size, "grpo-test")])
-        agent = AgentCNN(envs, **TINY)
-        envs.close()
+        agent = _tiny_agent(size)
         torch.manual_seed(seed)
-        # plausible integer observation in the catalog id range
         obs = torch.randint(
-            0, 3, (batch, len(agent_channels()), size, size), dtype=torch.float32
+            0, 3, (batch, len(Channel), size, size), dtype=torch.float32
         )
         return agent, obs
 
     def test_t1_matches_native_logp_and_entropy(self, registered_env):
-        """At T=1.0, scoring an action with policy_step yields the same logp
-        and entropy that get_action_and_value reports for that same action."""
+        """At T=1.0 with include_eot, scoring an action with policy_step yields
+        the same logp/entropy get_action_and_value reports for that action."""
         agent, obs = self._agent_and_obs()
         agent.eval()
         with torch.no_grad():
             torch.manual_seed(123)
             action_d, logp_native, ent_native, _v = agent.get_action_and_value(obs)
-            # native action dict -> (B, 6) [x, y, ent, dir, item, misc]
             x, y = action_d["xy"].unbind(dim=1)
-            action_B6 = torch.stack(
-                [x, y, action_d["entity"], action_d["direction"], action_d["item"], action_d["misc"]],
+            action_B7 = torch.stack(
+                [
+                    x,
+                    y,
+                    action_d["entity"],
+                    action_d["direction"],
+                    action_d["item"],
+                    action_d["misc"],
+                    action_d["eot"].long(),
+                ],
                 dim=1,
             )
             _out, logp_mine, ent_mine = policy_step(
-                agent, obs, temperature=1.0, action_B6=action_B6
+                agent, obs, temperature=1.0, action_B7=action_B7, include_eot=True
             )
-        assert torch.allclose(logp_mine, logp_native, atol=1e-5), (
-            logp_mine,
-            logp_native,
-        )
+        assert torch.allclose(logp_mine, logp_native, atol=1e-5), (logp_mine, logp_native)
         assert torch.allclose(ent_mine, ent_native, atol=1e-5)
 
     def test_scoring_roundtrips_sampled_action(self, registered_env):
-        """Sampling then scoring the returned action reproduces its logp
-        (the (x,y)->tile_idx reconstruction is exact)."""
+        """Sampling then scoring the returned action reproduces its logp."""
         agent, obs = self._agent_and_obs(seed=1)
         agent.eval()
         gen = torch.Generator().manual_seed(7)
         with torch.no_grad():
-            action_B6, logp_sampled, _e = policy_step(
-                agent, obs, temperature=1.3, generator=gen
+            action_B7, logp_sampled, _e = policy_step(
+                agent, obs, temperature=1.3, generator=gen, include_eot=True
             )
             _out, logp_scored, _e2 = policy_step(
-                agent, obs, temperature=1.3, action_B6=action_B6
+                agent, obs, temperature=1.3, action_B7=action_B7, include_eot=True
             )
         assert torch.allclose(logp_sampled, logp_scored, atol=1e-6)
 
-    def test_temperature_increases_entropy(self, registered_env):
-        """Higher temperature flattens the head distributions -> more entropy."""
-        agent, obs = self._agent_and_obs(seed=2)
-        agent.eval()
+    def test_action_is_7_wide(self, registered_env):
+        agent, obs = self._agent_and_obs(seed=4)
         with torch.no_grad():
-            _a, _lp, ent_cold = policy_step(agent, obs, temperature=0.5, action_B6=_dummy_action(obs))
-            _a, _lp, ent_hot = policy_step(agent, obs, temperature=2.0, action_B6=_dummy_action(obs))
+            action_B7, _lp, _e = policy_step(agent, obs, include_eot=True)
+        assert action_B7.shape == (obs.shape[0], 7)
+
+    def test_include_eot_false_forces_eot_zero_and_excludes_it(self, registered_env):
+        """With include_eot=False the sampled eot column is 0 and the logp
+        excludes the EOT term (so it equals the 5-head sum)."""
+        agent, obs = self._agent_and_obs(seed=5)
+        with torch.no_grad():
+            action_B7, logp_no_eot, _e = policy_step(
+                agent, obs, include_eot=False, generator=torch.Generator().manual_seed(1)
+            )
+            # score the SAME action with and without the eot term
+            _o, logp_with_eot, _e2 = policy_step(
+                agent, obs, action_B7=action_B7, include_eot=True
+            )
+            _o, logp_excl_eot, _e3 = policy_step(
+                agent, obs, action_B7=action_B7, include_eot=False
+            )
+        assert (action_B7[:, 6] == 0).all()
+        assert torch.allclose(logp_no_eot, logp_excl_eot, atol=1e-6)
+        # the eot term is nonzero in general, so including it changes logp
+        assert not torch.allclose(logp_with_eot, logp_excl_eot)
+
+    def test_temperature_increases_entropy(self, registered_env):
+        agent, obs = self._agent_and_obs(seed=2)
+        with torch.no_grad():
+            _a, _lp, ent_cold = policy_step(
+                agent, obs, temperature=0.5, action_B7=_dummy_action(obs)
+            )
+            _a, _lp, ent_hot = policy_step(
+                agent, obs, temperature=2.0, action_B7=_dummy_action(obs)
+            )
         assert (ent_hot > ent_cold).all()
-
-
-def agent_channels():
-    from factorion import Channel
-
-    return list(Channel)
-
-
-def _dummy_action(obs):
-    B = obs.shape[0]
-    return torch.zeros((B, 6), dtype=torch.long)
-
-
-def _tiny_agent(size=5):
-    envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, size, "grpo-test")])
-    agent = AgentCNN(envs, **TINY)
-    envs.close()
-    return agent
 
 
 class TestSelectGrids:
     def test_all_grids_are_realisable(self, registered_env):
-        import random
-
         from factorion import build_factory
 
-        args = GRPOArgs(size=5, num_grids=6, num_missing_max=3, start_from="x", **TINY)
+        args = GRPOArgs(size=5, num_grids=6, num_missing_max=3, start_from="x", layers=TINY_LAYERS)
         grids = select_grids(args, random.Random(0))
         assert len(grids) == 6
         for seed, kind, num_missing in grids:
@@ -197,18 +219,17 @@ class TestSelectGrids:
 
 
 class TestCollectRollout:
-    def _rollout(self, size=5, num_grids=2, group_size=3, seed=0):
+    def _rollout(self, size=5, num_grids=2, group_size=3, seed=0, honor_eot=False):
         args = GRPOArgs(
             size=size,
             num_grids=num_grids,
             group_size=group_size,
             num_missing_max=2,
             temperature=1.2,
+            honor_eot=honor_eot,
             start_from="x",
-            **TINY,
+            layers=TINY_LAYERS,
         )
-        import random
-
         grids = select_grids(args, random.Random(seed))
         policy = _tiny_agent(size)
         ref = _tiny_agent(size)
@@ -217,106 +238,87 @@ class TestCollectRollout:
         return args, batch
 
     def test_group_shares_initial_grid(self, registered_env):
-        """All group_size lanes of a group must start from the identical grid
-        (same solved world) — the core GRPO precondition."""
         args, batch = self._rollout()
         G = args.group_size
         for g in range(args.num_grids):
             ref_world = batch.solved_world_B[g * G]
             for j in range(1, G):
-                assert torch.equal(batch.solved_world_B[g * G + j], ref_world), (
-                    f"group {g} lane {j} has a different grid"
-                )
+                assert torch.equal(batch.solved_world_B[g * G + j], ref_world)
 
     def test_groups_differ_from_each_other(self, registered_env):
-        """Distinct grids should (almost surely) have distinct solved worlds."""
         args, batch = self._rollout(num_grids=2, group_size=2)
         G = args.group_size
         assert not torch.equal(batch.solved_world_B[0], batch.solved_world_B[G])
 
-    def test_finished_lanes_store_no_extra_transitions(self, registered_env):
-        """Transition count per lane must equal its episode length, and never
-        exceed max_steps (a deactivated lane stores nothing further)."""
+    def test_transition_counts_match_episode_length(self, registered_env):
         args, batch = self._rollout()
         B = args.num_grids * args.group_size
-        # env truncates at steps>max_steps (pre-increment), so a non-connecting
-        # lane stores up to max_steps+2 transitions.
         max_transitions = 2 * args.size + 2
         for lane in range(B):
             n = int((batch.lane_of_N == lane).sum())
-            assert n == int(batch.steps_B[lane]), (
-                f"lane {lane}: {n} transitions != steps_B {int(batch.steps_B[lane])}"
-            )
-            assert 1 <= n <= max_transitions, f"lane {lane} stored {n} transitions"
-        # total transitions accounted for
+            assert n == int(batch.steps_B[lane])
+            assert 1 <= n <= max_transitions
         assert batch.obs_NCWH.shape[0] == int(batch.steps_B.sum())
+
+    def test_eot_off_runs_to_max_steps(self, registered_env):
+        """With honor_eot=False no lane terminates via eot."""
+        _args, batch = self._rollout(honor_eot=False)
+        assert float(batch.eot_terminated_B.sum()) == 0.0
 
     def test_shapes_consistent(self, registered_env):
         args, batch = self._rollout()
         N = batch.obs_NCWH.shape[0]
-        assert batch.actions_N6.shape == (N, 6)
+        assert batch.actions_N7.shape == (N, 7)
         assert batch.old_logp_N.shape == (N,)
         assert batch.ref_logp_N.shape == (N,)
         assert batch.lane_of_N.shape == (N,)
 
 
-def _fake_batch(thp, terminated, bonus, per_step=None):
+def _fake_batch(cum_reward, thput_final=None, eot=None):
     """Minimal RolloutBatch carrying just the reward ingredients."""
-    B = len(thp)
+    B = len(cum_reward)
     z = torch.zeros((0,), dtype=torch.long)
     return RolloutBatch(
         obs_NCWH=torch.empty((0, 5, 5, 5)),
-        actions_N6=torch.empty((0, 6), dtype=torch.long),
+        actions_N7=torch.empty((0, 7), dtype=torch.long),
         old_logp_N=torch.empty((0,)),
         ref_logp_N=torch.empty((0,)),
         lane_of_N=z,
         group_of_lane_B=torch.arange(B),
-        thp_final_B=torch.tensor(thp, dtype=torch.float32),
-        terminated_B=torch.tensor(terminated, dtype=torch.float32),
-        completion_bonus_B=torch.tensor(bonus, dtype=torch.float32),
-        steps_B=torch.zeros(B),
-        per_step_reward_B=torch.tensor(
-            per_step if per_step is not None else [0.0] * B, dtype=torch.float32
+        cum_reward_B=torch.tensor(cum_reward, dtype=torch.float32),
+        thput_final_B=torch.tensor(
+            thput_final if thput_final is not None else [0.0] * B, dtype=torch.float32
         ),
+        eot_terminated_B=torch.tensor(
+            eot if eot is not None else [0.0] * B, dtype=torch.float32
+        ),
+        steps_B=torch.zeros(B),
     )
 
 
 class TestRewards:
-    def test_outcome_reward(self):
-        # lane0 connected (thp=1, bonus=8); lane1 failed (thp=0.4, bonus ignored)
-        batch = _fake_batch(thp=[1.0, 0.4], terminated=[1.0, 0.0], bonus=[8.0, 5.0])
-        args = GRPOArgs(reward_scale=0.1, completion_bonus_coef=1.0, start_from="x")
+    def test_reward_is_scaled_cum_reward(self):
+        batch = _fake_batch(cum_reward=[1.0, -0.2, 0.5])
+        args = GRPOArgs(reward_scale=0.5, start_from="x", layers=TINY_LAYERS)
         R = compute_rewards(batch, args)
-        assert torch.allclose(R, torch.tensor([0.1 * (1.0 + 8.0), 0.1 * 0.4]))
+        assert torch.allclose(R, torch.tensor([0.5, -0.1, 0.25]))
 
-    def test_bonus_only_when_terminated(self):
-        batch = _fake_batch(thp=[0.9], terminated=[0.0], bonus=[8.0])
-        args = GRPOArgs(reward_scale=1.0, start_from="x")
+    def test_unit_scale_is_identity(self):
+        batch = _fake_batch(cum_reward=[0.8, -0.24])
+        args = GRPOArgs(reward_scale=1.0, start_from="x", layers=TINY_LAYERS)
         R = compute_rewards(batch, args)
-        assert torch.allclose(R, torch.tensor([0.9]))  # no bonus
-
-    def test_per_step_mode_uses_accumulated_reward(self):
-        batch = _fake_batch(
-            thp=[1.0], terminated=[1.0], bonus=[8.0], per_step=[3.0]
-        )
-        args = GRPOArgs(
-            reward_mode="per_step", reward_scale=1.0, completion_bonus_coef=1.0, start_from="x"
-        )
-        R = compute_rewards(batch, args)
-        assert torch.allclose(R, torch.tensor([3.0 + 8.0]))
+        assert torch.allclose(R, torch.tensor([0.8, -0.24]))
 
 
 class TestAdvantages:
     def test_per_group_zero_mean(self):
         R = torch.tensor([0.0, 4.0, 1.0, 1.0])  # 2 groups of 2
         A = compute_advantages(R, group_size=2)
-        # group means subtracted within each group
         assert torch.allclose(A, torch.tensor([-2.0, 2.0, 0.0, 0.0]))
 
     def test_no_std_normalization(self):
         """Dr. GRPO does NOT divide by the group std. With group [0, 4]
-        (std=2), std-normalized advantages would be [-1, 1]; we want the raw
-        [-2, 2]."""
+        (std=2), std-normalized advantages would be [-1, 1]; we want [-2, 2]."""
         R = torch.tensor([0.0, 4.0])
         A = compute_advantages(R, group_size=2)
         assert torch.allclose(A, torch.tensor([-2.0, 2.0]))
@@ -330,19 +332,18 @@ class TestAdvantages:
 
 
 class TestGRPOUpdate:
-    def _setup(self, size=5, seed=0, **arg_overrides):
-        import random
-
-        base = dict(
+    def _setup(self, size=5, seed=0, learning_rate=2e-6, update_epochs=2):
+        args = GRPOArgs(
             size=size,
             num_grids=2,
             group_size=3,
             num_missing_max=2,
             temperature=1.1,
             start_from="x",
+            learning_rate=learning_rate,
+            update_epochs=update_epochs,
+            layers=TINY_LAYERS,
         )
-        base.update(arg_overrides)
-        args = GRPOArgs(**base, **TINY)
         grids = select_grids(args, random.Random(seed))
         policy = _tiny_agent(size)
         ref = _tiny_agent(size)
@@ -353,8 +354,6 @@ class TestGRPOUpdate:
         return args, policy, batch, A_N
 
     def test_ratio_one_and_finite_loss_with_zero_lr(self):
-        """With lr=0 and one inner epoch the policy is unchanged, so ratio==1,
-        approx_kl==0, the loss is finite and the k3 KL to ref is >= 0."""
         args, policy, batch, A_N = self._setup(learning_rate=0.0, update_epochs=1)
         opt = torch.optim.Adam(policy.parameters(), lr=0.0)
         m = grpo_update(policy, opt, batch, A_N, args)
@@ -364,16 +363,10 @@ class TestGRPOUpdate:
         assert np.isfinite(m["loss/total"])
 
     def test_update_changes_weights(self):
-        """A real step (lr>0) with nonzero advantages moves the policy params.
-        Advantages are injected synthetically so the test never depends on a
-        rollout happening to have reward variance."""
         args, policy, batch, _A = self._setup(learning_rate=1e-2, update_epochs=2)
         N = batch.obs_NCWH.shape[0]
         assert N > 0
-        # alternating +1/-1 advantages — guaranteed nonzero gradient signal
-        A_N = torch.where(
-            torch.arange(N) % 2 == 0, torch.ones(N), -torch.ones(N)
-        )
+        A_N = torch.where(torch.arange(N) % 2 == 0, torch.ones(N), -torch.ones(N))
         before = [p.detach().clone() for p in policy.parameters()]
         opt = torch.optim.Adam(policy.parameters(), lr=1e-2)
         m = grpo_update(policy, opt, batch, A_N, args)
@@ -384,9 +377,9 @@ class TestGRPOUpdate:
         assert m["loss/kl_ref"] >= -1e-6
 
     def test_empty_batch_is_safe(self):
-        args = GRPOArgs(size=5, group_size=2, start_from="x", **TINY)
+        args = GRPOArgs(size=5, group_size=2, start_from="x", layers=TINY_LAYERS)
         policy = _tiny_agent(5)
-        empty = _fake_batch(thp=[], terminated=[], bonus=[])
+        empty = _fake_batch(cum_reward=[])
         opt = torch.optim.Adam(policy.parameters(), lr=1e-3)
         m = grpo_update(policy, opt, empty, torch.empty((0,)), args)
         assert m["grpo/n_transitions"] == 0
@@ -394,11 +387,9 @@ class TestGRPOUpdate:
 
 class TestGreedyEval:
     def test_metrics_well_formed(self, registered_env):
-        import random
-
         size = 5
         args = GRPOArgs(
-            size=size, num_grids=6, num_missing_max=2, eval_num_envs=3, start_from="x", **TINY
+            size=size, num_grids=6, num_missing_max=2, eval_num_envs=3, start_from="x", layers=TINY_LAYERS
         )
         val_grids = select_grids(args, random.Random(999))
         policy = _tiny_agent(size)
@@ -409,7 +400,7 @@ class TestGreedyEval:
         assert 0.0 <= m["eval/dir_acc_vs_ref"] <= 1.0
 
     def test_empty_val_set_is_safe(self, registered_env):
-        args = GRPOArgs(size=5, start_from="x", **TINY)
+        args = GRPOArgs(size=5, start_from="x", layers=TINY_LAYERS)
         policy = _tiny_agent(5)
         m = greedy_eval(policy, args, [], torch.device("cpu"))
         assert m["eval/n"] == 0
@@ -417,26 +408,23 @@ class TestGreedyEval:
 
 
 def _world(size, fill=0):
-    from factorion import Channel
-
     return torch.full((len(Channel), size, size), fill, dtype=torch.float32)
 
 
-def _batch_with_worlds(final_worlds, solved_worlds, terminated):
+def _batch_with_worlds(final_worlds, solved_worlds, thput_final):
     B = len(final_worlds)
     z = torch.zeros((0,), dtype=torch.long)
     return RolloutBatch(
         obs_NCWH=torch.empty((0, 5, 5, 5)),
-        actions_N6=torch.empty((0, 6), dtype=torch.long),
+        actions_N7=torch.empty((0, 7), dtype=torch.long),
         old_logp_N=torch.empty((0,)),
         ref_logp_N=torch.empty((0,)),
         lane_of_N=z,
         group_of_lane_B=torch.arange(B),
-        thp_final_B=torch.zeros(B),
-        terminated_B=torch.tensor(terminated, dtype=torch.float32),
-        completion_bonus_B=torch.zeros(B),
+        cum_reward_B=torch.zeros(B),
+        thput_final_B=torch.tensor(thput_final, dtype=torch.float32),
+        eot_terminated_B=torch.zeros(B),
         steps_B=torch.zeros(B),
-        per_step_reward_B=torch.zeros(B),
         final_world_B=final_worlds,
         solved_world_B=solved_worlds,
     )
@@ -444,8 +432,6 @@ def _batch_with_worlds(final_worlds, solved_worlds, terminated):
 
 class TestDiversity:
     def test_off_reference_and_unique_paths(self):
-        from factorion import Channel
-
         size = 5
         solved = _world(size)
         solved[Channel.ENTITIES.value, 0, 0] = 1  # the "reference" layout
@@ -454,21 +440,18 @@ class TestDiversity:
         off_ref = solved.clone()
         off_ref[Channel.ENTITIES.value, 0, 1] = 1  # a different (but working) path
 
-        # 1 group of 2: lane0 on-reference, lane1 off-reference, both connected
+        # 1 group of 2: lane0 on-reference, lane1 off-reference, both working
         batch = _batch_with_worlds(
             final_worlds=[on_ref, off_ref],
             solved_worlds=[solved, solved],
-            terminated=[1.0, 1.0],
+            thput_final=[1.0, 1.0],
         )
-        args = GRPOArgs(size=size, group_size=2, start_from="x", **TINY)
+        args = GRPOArgs(size=size, group_size=2, start_from="x", layers=TINY_LAYERS)
         R_B = torch.tensor([1.0, 3.0])
         m = compute_diversity(batch, R_B, args)
 
-        # intra-group var of [1,3] (population) = 1.0
-        assert abs(m["diversity/reward_var"] - 1.0) < 1e-6
-        # two distinct layouts in the group
+        assert abs(m["diversity/reward_var"] - 1.0) < 1e-6  # var([1,3]) = 1.0
         assert m["diversity/unique_path_frac"] == 1.0
-        # 1 of 2 working factories is off-reference
         assert abs(m["diversity/off_reference_success"] - 0.5) < 1e-6
         assert m["diversity/working_frac"] == 1.0
 
@@ -478,20 +461,30 @@ class TestDiversity:
         batch = _batch_with_worlds(
             final_worlds=[w.clone(), w.clone()],
             solved_worlds=[w.clone(), w.clone()],
-            terminated=[1.0, 1.0],
+            thput_final=[1.0, 1.0],
         )
-        args = GRPOArgs(size=size, group_size=2, start_from="x", **TINY)
+        args = GRPOArgs(size=size, group_size=2, start_from="x", layers=TINY_LAYERS)
         m = compute_diversity(batch, torch.tensor([2.0, 2.0]), args)
         assert m["diversity/reward_var"] == 0.0
         assert m["diversity/unique_path_frac"] == 0.5  # 1 unique / 2
-        # final == solved everywhere -> all working factories are on-reference
         assert m["diversity/off_reference_success"] == 0.0
 
-    def test_runs_on_real_rollout(self, registered_env):
-        import random
+    def test_non_working_lanes_excluded_from_off_reference(self):
+        size = 5
+        solved = _world(size)
+        solved[Channel.ENTITIES.value, 0, 0] = 1
+        off = solved.clone()
+        off[Channel.ENTITIES.value, 0, 1] = 1
+        # off-reference layout but thput_final < 1 -> not a working factory
+        batch = _batch_with_worlds([off, off], [solved, solved], thput_final=[0.5, 0.5])
+        args = GRPOArgs(size=size, group_size=2, start_from="x", layers=TINY_LAYERS)
+        m = compute_diversity(batch, torch.tensor([0.0, 0.0]), args)
+        assert m["diversity/working_frac"] == 0.0
+        assert m["diversity/off_reference_success"] == 0.0  # no working factories
 
+    def test_runs_on_real_rollout(self, registered_env):
         args = GRPOArgs(
-            size=5, num_grids=2, group_size=3, num_missing_max=2, start_from="x", **TINY
+            size=5, num_grids=2, group_size=3, num_missing_max=2, start_from="x", layers=TINY_LAYERS
         )
         grids = select_grids(args, random.Random(3))
         policy, ref = _tiny_agent(5), _tiny_agent(5)

--- a/tests/test_grpo.py
+++ b/tests/test_grpo.py
@@ -17,7 +17,10 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from ppo import AgentCNN, FactorioEnv, make_env  # noqa: E402
 from grpo import (  # noqa: E402
     GRPOArgs,
+    RolloutBatch,
     collect_rollout,
+    compute_advantages,
+    compute_rewards,
     policy_step,
     select_grids,
     train_grpo,
@@ -247,3 +250,72 @@ class TestCollectRollout:
         assert batch.old_logp_N.shape == (N,)
         assert batch.ref_logp_N.shape == (N,)
         assert batch.lane_of_N.shape == (N,)
+
+
+def _fake_batch(thp, terminated, bonus, per_step=None):
+    """Minimal RolloutBatch carrying just the reward ingredients."""
+    B = len(thp)
+    z = torch.zeros((0,), dtype=torch.long)
+    return RolloutBatch(
+        obs_NCWH=torch.empty((0, 5, 5, 5)),
+        actions_N6=torch.empty((0, 6), dtype=torch.long),
+        old_logp_N=torch.empty((0,)),
+        ref_logp_N=torch.empty((0,)),
+        lane_of_N=z,
+        group_of_lane_B=torch.arange(B),
+        thp_final_B=torch.tensor(thp, dtype=torch.float32),
+        terminated_B=torch.tensor(terminated, dtype=torch.float32),
+        completion_bonus_B=torch.tensor(bonus, dtype=torch.float32),
+        steps_B=torch.zeros(B),
+        per_step_reward_B=torch.tensor(
+            per_step if per_step is not None else [0.0] * B, dtype=torch.float32
+        ),
+    )
+
+
+class TestRewards:
+    def test_outcome_reward(self):
+        # lane0 connected (thp=1, bonus=8); lane1 failed (thp=0.4, bonus ignored)
+        batch = _fake_batch(thp=[1.0, 0.4], terminated=[1.0, 0.0], bonus=[8.0, 5.0])
+        args = GRPOArgs(reward_scale=0.1, completion_bonus_coef=1.0, start_from="x")
+        R = compute_rewards(batch, args)
+        assert torch.allclose(R, torch.tensor([0.1 * (1.0 + 8.0), 0.1 * 0.4]))
+
+    def test_bonus_only_when_terminated(self):
+        batch = _fake_batch(thp=[0.9], terminated=[0.0], bonus=[8.0])
+        args = GRPOArgs(reward_scale=1.0, start_from="x")
+        R = compute_rewards(batch, args)
+        assert torch.allclose(R, torch.tensor([0.9]))  # no bonus
+
+    def test_per_step_mode_uses_accumulated_reward(self):
+        batch = _fake_batch(
+            thp=[1.0], terminated=[1.0], bonus=[8.0], per_step=[3.0]
+        )
+        args = GRPOArgs(
+            reward_mode="per_step", reward_scale=1.0, completion_bonus_coef=1.0, start_from="x"
+        )
+        R = compute_rewards(batch, args)
+        assert torch.allclose(R, torch.tensor([3.0 + 8.0]))
+
+
+class TestAdvantages:
+    def test_per_group_zero_mean(self):
+        R = torch.tensor([0.0, 4.0, 1.0, 1.0])  # 2 groups of 2
+        A = compute_advantages(R, group_size=2)
+        # group means subtracted within each group
+        assert torch.allclose(A, torch.tensor([-2.0, 2.0, 0.0, 0.0]))
+
+    def test_no_std_normalization(self):
+        """Dr. GRPO does NOT divide by the group std. With group [0, 4]
+        (std=2), std-normalized advantages would be [-1, 1]; we want the raw
+        [-2, 2]."""
+        R = torch.tensor([0.0, 4.0])
+        A = compute_advantages(R, group_size=2)
+        assert torch.allclose(A, torch.tensor([-2.0, 2.0]))
+        assert not torch.allclose(A, torch.tensor([-1.0, 1.0]))
+
+    def test_each_group_sums_to_zero(self):
+        R = torch.tensor([3.0, 1.0, 2.0, 5.0, 9.0, 1.0])  # 3 groups of 2
+        A = compute_advantages(R, group_size=2)
+        for g in range(3):
+            assert abs(float(A[2 * g] + A[2 * g + 1])) < 1e-6

--- a/tests/test_grpo.py
+++ b/tests/test_grpo.py
@@ -20,6 +20,7 @@ from ppo import AgentCNN, FactorioEnv, make_env  # noqa: E402
 from grpo import (  # noqa: E402
     GRPOArgs,
     RolloutBatch,
+    _select_eval_grids,
     broadcast_advantages,
     collect_rollout,
     compute_advantages,
@@ -211,6 +212,24 @@ class TestSelectGrids:
             assert build_factory(size=5, kind=kind, seed=seed) is not None
             assert 1 <= num_missing <= 3
 
+    def test_eval_grids_disjoint_from_training_seeds(self, registered_env):
+        """The held-out eval set must share no grid seed with ANY training
+        iteration — including iteration 7, where an earlier integer eval offset
+        collided exactly with the training stream."""
+        args = GRPOArgs(
+            size=5, num_grids=4, num_missing_max=2,
+            eval_max_seeds=6, n_held_out_seeds=6,
+            start_from="x", layers=TINY_LAYERS,
+        )
+        eval_seeds = {g[0] for g in _select_eval_grids(args)}
+        assert eval_seeds  # non-empty
+        for i in range(1, 12):  # spans the previously-colliding iteration 7
+            train_seeds = {
+                g[0]
+                for g in select_grids(args, random.Random(args.seed * 1_000_003 + i))
+            }
+            assert eval_seeds.isdisjoint(train_seeds), f"iteration {i} overlaps eval"
+
 
 class TestCollectRollout:
     def _rollout(self, size=5, num_grids=2, group_size=3, seed=0):
@@ -271,6 +290,33 @@ class TestCollectRollout:
         B = args.num_grids * args.group_size
         assert float(batch.eot_terminated_B.sum()) == B  # all stopped via eot
         assert int(batch.steps_B.max()) == 1  # eot fired on the first step
+
+    def test_stored_obs_are_per_step_snapshots(self, registered_env):
+        """A multi-step lane's stored observations must be independent per-step
+        snapshots, not all collapsed to the lane's final obs (the failure mode
+        if the stored row aliased the in-place-mutated obs buffer)."""
+        size = 5
+        policy = _tiny_agent(size)
+        ref = _tiny_agent(size)
+        with torch.no_grad():
+            policy.eot_head[1].bias.fill_(-100.0)  # eot never fires -> multi-step lanes
+        args = GRPOArgs(
+            size=size, num_grids=2, group_size=2, num_missing_max=2,
+            start_from="x", layers=TINY_LAYERS,
+        )
+        grids = select_grids(args, random.Random(0))
+        gen = torch.Generator().manual_seed(0)
+        batch = collect_rollout(policy, ref, args, grids, torch.device("cpu"), gen)
+        saw_multistep = False
+        for lane in range(args.num_grids * args.group_size):
+            idx = (batch.lane_of_N == lane).nonzero().flatten()
+            if len(idx) < 2:
+                continue
+            saw_multistep = True
+            rows = batch.obs_NCWH[idx]
+            all_eq_last = all(torch.equal(rows[k], rows[-1]) for k in range(len(rows)))
+            assert not all_eq_last, f"lane {lane}: obs rows collapsed to final obs"
+        assert saw_multistep, "test ineffective: no multi-step lanes produced"
 
     def test_shapes_consistent(self, registered_env):
         args, batch = self._rollout()

--- a/tests/test_grpo.py
+++ b/tests/test_grpo.py
@@ -22,6 +22,7 @@ from grpo import (  # noqa: E402
     collect_rollout,
     compute_advantages,
     compute_rewards,
+    greedy_eval,
     grpo_update,
     policy_step,
     select_grids,
@@ -384,3 +385,27 @@ class TestGRPOUpdate:
         opt = torch.optim.Adam(policy.parameters(), lr=1e-3)
         m = grpo_update(policy, opt, empty, torch.empty((0,)), args)
         assert m["grpo/n_transitions"] == 0
+
+
+class TestGreedyEval:
+    def test_metrics_well_formed(self, registered_env):
+        import random
+
+        size = 5
+        args = GRPOArgs(
+            size=size, num_grids=6, num_missing_max=2, eval_num_envs=3, start_from="x", **TINY
+        )
+        val_grids = select_grids(args, random.Random(999))
+        policy = _tiny_agent(size)
+        m = greedy_eval(policy, args, val_grids, torch.device("cpu"))
+        assert m["eval/n"] == len(val_grids)
+        assert 0.0 <= m["eval/throughput"] <= 1.0
+        assert 0.0 <= m["eval/success_rate"] <= 1.0
+        assert 0.0 <= m["eval/dir_acc_vs_ref"] <= 1.0
+
+    def test_empty_val_set_is_safe(self, registered_env):
+        args = GRPOArgs(size=5, start_from="x", **TINY)
+        policy = _tiny_agent(5)
+        m = greedy_eval(policy, args, [], torch.device("cpu"))
+        assert m["eval/n"] == 0
+        assert m["eval/throughput"] == 0.0

--- a/tests/test_grpo.py
+++ b/tests/test_grpo.py
@@ -15,7 +15,13 @@ os.environ["WANDB_DISABLED"] = "true"
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from ppo import AgentCNN, FactorioEnv, make_env  # noqa: E402
-from grpo import GRPOArgs, policy_step, train_grpo  # noqa: E402
+from grpo import (  # noqa: E402
+    GRPOArgs,
+    collect_rollout,
+    policy_step,
+    select_grids,
+    train_grpo,
+)
 
 ENV_ID = "factorion/FactorioEnv-v0-grpo-test"
 
@@ -156,3 +162,88 @@ def agent_channels():
 def _dummy_action(obs):
     B = obs.shape[0]
     return torch.zeros((B, 6), dtype=torch.long)
+
+
+def _tiny_agent(size=5):
+    envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, size, "grpo-test")])
+    agent = AgentCNN(envs, **TINY)
+    envs.close()
+    return agent
+
+
+class TestSelectGrids:
+    def test_all_grids_are_realisable(self, registered_env):
+        import random
+
+        from factorion import build_factory
+
+        args = GRPOArgs(size=5, num_grids=6, num_missing_max=3, start_from="x", **TINY)
+        grids = select_grids(args, random.Random(0))
+        assert len(grids) == 6
+        for seed, kind, num_missing in grids:
+            assert build_factory(size=5, kind=kind, seed=seed) is not None
+            assert 1 <= num_missing <= 3
+
+
+class TestCollectRollout:
+    def _rollout(self, size=5, num_grids=2, group_size=3, seed=0):
+        args = GRPOArgs(
+            size=size,
+            num_grids=num_grids,
+            group_size=group_size,
+            num_missing_max=2,
+            temperature=1.2,
+            start_from="x",
+            **TINY,
+        )
+        import random
+
+        grids = select_grids(args, random.Random(seed))
+        policy = _tiny_agent(size)
+        ref = _tiny_agent(size)
+        gen = torch.Generator().manual_seed(seed)
+        batch = collect_rollout(policy, ref, args, grids, torch.device("cpu"), gen)
+        return args, batch
+
+    def test_group_shares_initial_grid(self, registered_env):
+        """All group_size lanes of a group must start from the identical grid
+        (same solved world) — the core GRPO precondition."""
+        args, batch = self._rollout()
+        G = args.group_size
+        for g in range(args.num_grids):
+            ref_world = batch.solved_world_B[g * G]
+            for j in range(1, G):
+                assert torch.equal(batch.solved_world_B[g * G + j], ref_world), (
+                    f"group {g} lane {j} has a different grid"
+                )
+
+    def test_groups_differ_from_each_other(self, registered_env):
+        """Distinct grids should (almost surely) have distinct solved worlds."""
+        args, batch = self._rollout(num_grids=2, group_size=2)
+        G = args.group_size
+        assert not torch.equal(batch.solved_world_B[0], batch.solved_world_B[G])
+
+    def test_finished_lanes_store_no_extra_transitions(self, registered_env):
+        """Transition count per lane must equal its episode length, and never
+        exceed max_steps (a deactivated lane stores nothing further)."""
+        args, batch = self._rollout()
+        B = args.num_grids * args.group_size
+        # env truncates at steps>max_steps (pre-increment), so a non-connecting
+        # lane stores up to max_steps+2 transitions.
+        max_transitions = 2 * args.size + 2
+        for lane in range(B):
+            n = int((batch.lane_of_N == lane).sum())
+            assert n == int(batch.steps_B[lane]), (
+                f"lane {lane}: {n} transitions != steps_B {int(batch.steps_B[lane])}"
+            )
+            assert 1 <= n <= max_transitions, f"lane {lane} stored {n} transitions"
+        # total transitions accounted for
+        assert batch.obs_NCWH.shape[0] == int(batch.steps_B.sum())
+
+    def test_shapes_consistent(self, registered_env):
+        args, batch = self._rollout()
+        N = batch.obs_NCWH.shape[0]
+        assert batch.actions_N6.shape == (N, 6)
+        assert batch.old_logp_N.shape == (N,)
+        assert batch.ref_logp_N.shape == (N,)
+        assert batch.lane_of_N.shape == (N,)

--- a/tests/test_grpo.py
+++ b/tests/test_grpo.py
@@ -1,0 +1,84 @@
+"""Tests for the GRPO RL finetuning pipeline."""
+
+import json
+import os
+import sys
+
+import gymnasium as gym
+import numpy as np
+import pytest
+import torch
+
+os.environ["WANDB_MODE"] = "disabled"
+os.environ["WANDB_DISABLED"] = "true"
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from ppo import AgentCNN, FactorioEnv, make_env  # noqa: E402
+from grpo import GRPOArgs, train_grpo  # noqa: E402
+
+ENV_ID = "factorion/FactorioEnv-v0-grpo-test"
+
+# Tiny network so tests stay fast; these must match across the fake SFT
+# checkpoint and the GRPOArgs that loads it.
+TINY = dict(chan1=16, chan2=16, chan3=16, flat_dim=64)
+
+
+@pytest.fixture(scope="module")
+def registered_env():
+    if ENV_ID not in gym.registry:
+        gym.register(id=ENV_ID, entry_point=FactorioEnv)
+
+
+def _make_sft_checkpoint(path: str, size: int) -> None:
+    """Stand in for a real SFT checkpoint: a freshly-initialised AgentCNN
+    state_dict saved exactly the way sft.train_sft writes it."""
+    envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, size, "grpo-test")])
+    agent = AgentCNN(envs, **TINY)
+    envs.close()
+    torch.save(agent.state_dict(), path)
+
+
+class TestTrainGRPOEndToEnd:
+    def test_requires_start_from(self, registered_env):
+        """GRPO finetunes a prior — refuse to run without --start-from."""
+        with pytest.raises(ValueError):
+            train_grpo(GRPOArgs(seed=1, size=5, start_from="", **TINY))
+
+    def test_produces_checkpoint_and_summary(self, registered_env, tmp_path):
+        """End-to-end: train_grpo() runs, saves a checkpoint + summary, and
+        the checkpoint reloads into a fresh AgentCNN."""
+        size = 5
+        sft_ckpt = str(tmp_path / "sft.pt")
+        _make_sft_checkpoint(sft_ckpt, size)
+
+        out_ckpt = str(tmp_path / "grpo.pt")
+        summary = str(tmp_path / "grpo_summary.json")
+        args = GRPOArgs(
+            seed=1,
+            size=size,
+            start_from=sft_ckpt,
+            num_iterations=2,
+            num_grids=2,
+            group_size=2,
+            num_missing_max=2,
+            checkpoint_path=out_ckpt,
+            summary_path=summary,
+            **TINY,
+        )
+        train_grpo(args)
+
+        assert os.path.exists(out_ckpt), "GRPO checkpoint should be saved"
+        assert os.path.exists(summary), "Summary JSON should be saved"
+
+        with open(summary) as f:
+            s = json.load(f)
+        assert s["size"] == size
+        assert s["start_from"] == sft_ckpt
+
+        # The saved checkpoint must load back into a fresh AgentCNN (so
+        # ppo.py --start_from and a follow-up GRPO run can both consume it).
+        envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, size, "grpo-test")])
+        agent = AgentCNN(envs, **TINY)
+        agent.load_state_dict(torch.load(out_ckpt))
+        envs.close()


### PR DESCRIPTION
## What

Adds `grpo.py` — a **Dr. GRPO** (Group Relative Policy Optimization, no std / no length normalization) RL finetuner that takes an SFT-pretrained `AgentCNN` and pushes past what imitation achieves. Standalone, mirroring how `sft.py` imports `AgentCNN`/`FactorioEnv`/`make_env` from `ppo.py` — **no changes to `ppo.py`**.

## Why GRPO here

The reward is verifiable and outcome-dominated (per-step penalty + terminal `throughput_reward_scale·thput_normed`). A learned critic buys little against a near-terminal reward and is PPO's main tuning/failure surface (value clip, GAE λ, vf coef, shared-encoder corruption). GRPO deletes the critic: it samples a **group of G completions on the same seeded grid**, scores each by its episode return, and normalizes **within the group**, so two distinct valid belt paths both get non-negative advantage — a diversity-neutral, path-agnostic baseline.

## How it works

Per iteration: `select_grids` (random kind + num_missing, pre-validated) → `collect_rollout` (a group of G episodes per grid on the *same* `idx=0` seed, lockstep, groups intact) → `compute_rewards` (`reward_scale · summed env reward`) → `compute_advantages` (`R_i − mean_group(R)`, no std / no length norm) → `grpo_update` (PPO clip + k3 `KL(π‖π_ref)` to a frozen SFT copy + optional entropy) → periodic + final greedy held-out eval.

- **`policy_step`** replicates `AgentCNN.get_action_and_value`'s action path with a temperature knob (applied identically to all 6 heads incl. EOT), so old/new/ref logps stay on the same temperature-T policy — a clean importance ratio. Verified equal to the native head at T=1.0.
- **EOT is always obeyed**: it's a first-class `Discrete(2)` action folded into the objective; the episode terminates when the agent emits `eot=1` (else `max_steps`), and the per-step penalty makes learning *when* to stop part of the task.
- **No `torch.compile`** (dual-policy + variable flattened batch would thrash the cache; the simulator dominates).

## Metrics

Held-out throughput + connection success, intra-group reward variance, distinct-path fraction, off-reference success rate, KL-to-ref, and dir_acc-vs-reference (reported, not optimized — it can fall while throughput rises as the actor finds valid off-reference paths).

## Usage

```bash
python sft.py --size 8 --layer1 48 --layer2 48 --layer3 64 --checkpoint-path sft.pt
python grpo.py --start-from sft.pt --size 8 --layers 48 48 64 --track
```

## Tests / checklist

- `tests/test_grpo.py`: 29 tests — T=1.0 policy parity, group-sharing, no-std advantages, k3 KL, diversity arithmetic, EOT-always-obeyed, eval/training seed disjointness, per-step obs snapshots, and an end-to-end `train_grpo` run.
- Full pre-push checklist green: `cargo fmt`/`test`/`clippy`, `maturin`, `pytest` (3304 passed), `ruff`, **`ty`**, and PPO/SFT/GRPO smokes.

## Review notes

Includes a self-review that caught and fixed two issues before this PR:
- an eval/training **grid-seed collision** at iteration 7 that leaked 25% of the held-out grids into training (now seeded from a disjoint string namespace);
- a latent **obs-aliasing** fragility on CPU devices (now `.clone()`d at the storage site).

EOT handling was originally gated off for v1; the upstream reward redesign (per-step penalty) changed that premise, so it's now on by default (see closed issue #181).

🤖 Generated with [Claude Code](https://claude.com/claude-code)