### PR TITLE
Isolate SFT to MOVE_ONE_ITEM lesson only

### DIFF
--- a/sft.py
+++ b/sft.py
@@ -244,7 +244,7 @@ def _iter_demo_pairs(size, max_level, base_seed, worker_id, num_workers, target=
     until `target` pairs are produced, or forever when `target` is None. Callers
     own their own RNG seeding.
     """
-    kinds = list(LessonKind)
+    kinds = [LessonKind.MOVE_ONE_ITEM]  # HACK: SFT on MOVE_ONE_ITEM only
     kind_samples = {k.name: 0 for k in kinds}
     # Kinds still believed buildable at this size, plus a per-kind counter of
     # consecutive build failures. A kind that can't fit the grid returns None for


### PR DESCRIPTION
Hacky, non-durable change to restrict SFT to a single lesson.

## What

`_generate_pairs`'s sampler now draws only `LessonKind.MOVE_ONE_ITEM` instead of `list(LessonKind)`, so every training pair — and, since the val split derives from the same sampler output, every eval factory — comes from that one lesson.

## Why

To SFT a model on MOVE_ONE_ITEM examples in isolation and see what that policy learns without the other lessons diluting the data.

## Notes

- ~1 LOC diff, marked with a `HACK:` comment — not intended to merge.
- SFT smoke test passes; per-kind val now reports only `MOVE_ONE_ITEM`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJHfjVfWGjiSnHSyD49N8p)_