### PR TITLE
MEMORISE_2 isolation + global-context feature (H1 kill-test)

### DIFF
--- a/factorion-mod/server/server.py
+++ b/factorion-mod/server/server.py
@@ -142,6 +142,8 @@ def _argmax_action(agent: AgentCNN, obs_CWH: np.ndarray, device) -> dict:
         x_B = tile_idx // agent.height
         y_B = tile_idx % agent.height
         feat = encoded[torch.arange(B), :, x_B, y_B]
+        if agent.global_feat_dim > 0:
+            feat = torch.cat([feat, agent._global_feat(encoded)], dim=1)
         ent = agent.ent_head(feat).argmax(dim=-1)
         dir_ = agent.dir_head(feat).argmax(dim=-1)
         item = agent.item_head(feat).argmax(dim=-1)

--- a/ppo.py
+++ b/ppo.py
@@ -1131,7 +1131,7 @@ def _categorical_entropy(logp_all_BN):
 
 
 class AgentCNN(nn.Module):
-    def __init__(self, envs, layers=(48, 48, 64), kernel_size=3, tile_head_std=0.01, critic_head_std=1.0, dropout=0.0, cat_embed_dim=8):
+    def __init__(self, envs, layers=(48, 48, 64), kernel_size=3, tile_head_std=0.01, critic_head_std=1.0, dropout=0.0, cat_embed_dim=8, global_feat_dim=32):
         super().__init__()
         # Grid size from the vector env's single observation space (shape
         # (C, W, H)) so this works for both SyncVectorEnv and AsyncVectorEnv
@@ -1221,15 +1221,30 @@ class AgentCNN(nn.Module):
         # Tile selection: 1x1 conv producing one logit per spatial position
         self.tile_logits = layer_init(nn.Conv2d(last_chan, 1, kernel_size=1), std=tile_head_std)
 
+        # The per-tile heads read a single feature column encoded[:, :, x, y],
+        # so their receptive field is capped at the conv stack's window. Recipe
+        # choice, UG-span, and "which way is the sink" are grid-global questions
+        # that window can't answer. Concatenate a pooled summary of the whole
+        # encoded map (mean+max over space, projected to global_feat_dim) onto
+        # the tile features so every head sees global context. global_feat_dim=0
+        # disables it, recovering the window-only heads.
+        self.global_feat_dim = global_feat_dim
+        if global_feat_dim > 0:
+            self.global_proj = nn.Sequential(
+                layer_init(nn.Linear(2 * last_chan, global_feat_dim)),
+                nn.ReLU(),
+            )
+        head_in = last_chan + global_feat_dim
+
         # Per-tile entity/direction/item/misc heads (conditioned on selected
         # tile features). The env's step() requires all four to be set
         # consistently — e.g. an underground_belt placement must carry
         # misc=UNDERGROUND_DOWN/UP, and an assembling_machine_1 placement
         # must carry a recipe in `item`.
-        self.ent_head = layer_init(nn.Linear(last_chan, self.num_entities))
-        self.dir_head = layer_init(nn.Linear(last_chan, self.num_directions))
-        self.item_head = layer_init(nn.Linear(last_chan, self.num_items))
-        self.misc_head = layer_init(nn.Linear(last_chan, self.num_misc))
+        self.ent_head = layer_init(nn.Linear(head_in, self.num_entities))
+        self.dir_head = layer_init(nn.Linear(head_in, self.num_directions))
+        self.item_head = layer_init(nn.Linear(head_in, self.num_items))
+        self.misc_head = layer_init(nn.Linear(head_in, self.num_misc))
 
         # Bias every head toward its "empty / NONE" slot (value 0) so a
         # freshly-initialised policy mostly proposes no-ops, matching the
@@ -1264,6 +1279,14 @@ class AgentCNN(nn.Module):
         footprint = x_BCWH[:, _CH_FOOTPRINT:_CH_FOOTPRINT + 1]  # (B, 1, W, H), scalar
 
         return torch.cat([ent_e, item_e, dir_oh, misc_oh, footprint], dim=1)
+
+    def _global_feat(self, encoded_BCWH):
+        """Pool the whole encoded map into a per-batch global-context vector
+        (mean+max over the W,H axes, projected to global_feat_dim). Feeds the
+        per-tile heads the grid-wide information their windowed features lack."""
+        mean_BC = encoded_BCWH.mean(dim=(2, 3))
+        max_BC = encoded_BCWH.amax(dim=(2, 3))
+        return self.global_proj(torch.cat([mean_BC, max_BC], dim=1))
 
     def get_value(self, x_BCWH):
         encoded = self.encoder(self._encode_input(x_BCWH))
@@ -1315,6 +1338,9 @@ class AgentCNN(nn.Module):
         # torch.compile folds it into the graph.
         batch_idx = torch.arange(B, device=encoded_BCWH.device)
         tile_features_BC = encoded_BCWH[batch_idx, :, x_B, y_B]  # (B, chan3)
+        if self.global_feat_dim > 0:
+            global_BG = self._global_feat(encoded_BCWH)          # (B, global_feat_dim)
+            tile_features_BC = torch.cat([tile_features_BC, global_BG], dim=1)
 
         # --- Entity / direction / item / misc heads (conditioned on tile features) ---
         logits_e_BE = self.ent_head(tile_features_BC)

--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -547,6 +547,8 @@ def _predict(grid: list[list[dict]]) -> dict:
         x, y = tile_idx // H, tile_idx % H
 
         feats = encoded_BCWH[0, :, x, y].unsqueeze(0)
+        if agent.global_feat_dim > 0:
+            feats = torch.cat([feats, agent._global_feat(encoded_BCWH)], dim=1)
         ent_top, ent_rest = _top_p_named(F.softmax(agent.ent_head(feats), dim=-1)[0], _ENT_NAMES)
         dir_top, dir_rest = _top_p_named(F.softmax(agent.dir_head(feats), dim=-1)[0], _DIR_NAMES)
         item_top, item_rest = _top_p_named(F.softmax(agent.item_head(feats), dim=-1)[0], _ITEM_NAMES)
@@ -555,6 +557,8 @@ def _predict(grid: list[list[dict]]) -> dict:
         # Per-tile argmax for ent/dir/item/misc — one matmul per head
         # against the whole spatial map, reshaped to (W*H, chan3).
         feats_all = encoded_BCWH[0].permute(1, 2, 0).reshape(W * H, -1)
+        if agent.global_feat_dim > 0:
+            feats_all = torch.cat([feats_all, agent._global_feat(encoded_BCWH).expand(W * H, -1)], dim=1)
         ent_pick = agent.ent_head(feats_all).argmax(dim=-1)
         dir_pick = agent.dir_head(feats_all).argmax(dim=-1)
         item_pick = agent.item_head(feats_all).argmax(dim=-1)

--- a/sft.py
+++ b/sft.py
@@ -571,6 +571,8 @@ def run_rollout_eval(
             x_K = tile_idx_K // args.size
             y_K = tile_idx_K % args.size
             tile_features = encoded[batch_idx_K, :, x_K, y_K]
+            if agent.global_feat_dim > 0:
+                tile_features = torch.cat([tile_features, agent._global_feat(encoded)], dim=1)
 
             ent_K = agent.ent_head(tile_features).argmax(dim=1)
             dir_K = agent.dir_head(tile_features).argmax(dim=1)
@@ -1126,6 +1128,8 @@ def train_sft(args: SftArgs):
             y_B = batch_tile % agent.height
             batch_idx = torch.arange(B, device=device)
             tile_features = encoded[batch_idx, :, x_B, y_B]
+            if agent.global_feat_dim > 0:
+                tile_features = torch.cat([tile_features, agent._global_feat(encoded)], dim=1)
 
             ent_logits = agent.ent_head(tile_features)
             dir_logits = agent.dir_head(tile_features)
@@ -1315,6 +1319,8 @@ def train_sft(args: SftArgs):
                 y_B = batch_tile % agent.height
                 batch_idx = torch.arange(B, device=device)
                 tile_features = encoded[batch_idx, :, x_B, y_B]
+                if agent.global_feat_dim > 0:
+                    tile_features = torch.cat([tile_features, agent._global_feat(encoded)], dim=1)
 
                 ent_logits = agent.ent_head(tile_features)
                 dir_logits = agent.dir_head(tile_features)

--- a/sft.py
+++ b/sft.py
@@ -244,7 +244,7 @@ def _iter_demo_pairs(size, max_level, base_seed, worker_id, num_workers, target=
     until `target` pairs are produced, or forever when `target` is None. Callers
     own their own RNG seeding.
     """
-    kinds = list(LessonKind)
+    kinds = [LessonKind.MEMORISE_2_INGREDIENT_RECIPES]  # HACK: SFT on MEMORISE_2 only
     kind_samples = {k.name: 0 for k in kinds}
     # Kinds still believed buildable at this size, plus a per-kind counter of
     # consecutive build failures. A kind that can't fit the grid returns None for

--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -578,6 +578,8 @@ class TestSFTLossConvergence:
             y_B = tiles % agent.height
             batch_idx = torch.arange(B)
             tile_features = encoded[batch_idx, :, x_B, y_B]
+            if agent.global_feat_dim > 0:
+                tile_features = torch.cat([tile_features, agent._global_feat(encoded)], dim=1)
 
             ent_logits = agent.ent_head(tile_features)
             dir_logits = agent.dir_head(tile_features)


### PR DESCRIPTION
Kill-test for **H1 — receptive-field starvation**: the per-tile heads decide what to place at (x,y) from a conv-window's worth of features, but recipe choice / UG-span / "which way is the sink" are grid-global questions that window can't answer.

## Changes

Two commits:

1. **Global-context feature** (`ppo.py`, SFT forward paths, test). Pool the whole encoded map (mean+max over the spatial axes) and project to `global_feat_dim=32`, then concatenate onto the per-tile features before the ent/dir/item/misc heads. `global_feat_dim=0` recovers the window-only heads. Wired at every direct head callsite: PPO `get_action_and_value` plus the SFT train/val/greedy-rollout forward paths.
2. **Isolate SFT to MEMORISE_2** (`sft.py`, 1 line, `HACK:`). Restrict the training-pair sampler to `MEMORISE_2_INGREDIENT_RECIPES` so the whole run trains and evals on that one lesson.

## Kill-test protocol

- Train 10M samples on MEMORISE_2 only, with the global-context heads.
- **Success criterion**: `val/MEMORISE_2_INGREDIENT_RECIPES/asm_item_acc` climbs from ~0.1 → >0.8. If it works, the next step is the 11-lesson version.

## Notes

- CI `python-tests` will be **red by design**: the 4 `TestGenerateDataset` multi-kind tests assert the sampler spans ≥2 lessons, which the isolation hack intentionally breaks. All other tests (incl. checkpoint round-trips and the SFT convergence test, updated for the new head input dim) pass.
- SFT + PPO smoke tests pass; `ruff` + `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJHfjVfWGjiSnHSyD49N8p)_