### PR TITLE
Add --start-from to sft.py to resume checkpoint training

### DIFF
--- a/sft.py
+++ b/sft.py
@@ -44,6 +44,7 @@ from ppo import (  # noqa: E402
     make_env,
     layers_from_args,
     assert_device_ok,
+    _resolve_start_from,
     _CH_ENT,
     _CH_ITEMS,
     _CH_FOOTPRINT,
@@ -929,6 +930,17 @@ def train_sft(args: SftArgs):
         else "cpu"
     )
     assert_device_ok(device)
+
+    if args.start_from is not None:
+        print(f"Loading model weights from {args.start_from}")
+        ckpt_path = _resolve_start_from(
+            args.start_from, args.wandb_project_name, args.wandb_entity
+        )
+        # Load to CPU first; the checkpoint may hold CUDA tensors (saved on a
+        # GPU pod) and the agent is moved onto `device` just below, so this
+        # keeps --start-from working on CPU/MPS boxes too.
+        agent.load_state_dict(torch.load(ckpt_path, map_location="cpu"))
+
     agent.to(device)
 
     if cached_train is not None:
@@ -1005,6 +1017,8 @@ def train_sft(args: SftArgs):
         import wandb
 
         sft_tags = ["sft"] + (args.tags or [])
+        if args.start_from is not None:
+            sft_tags.append(f"start_from:{args.start_from}")
         run = wandb.init(
             project=args.wandb_project_name,
             entity=args.wandb_entity,

--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -547,6 +547,63 @@ class TestSFTCheckpointLoading:
 
         envs.close()
 
+    def test_train_sft_start_from_loads_checkpoint_weights(
+        self, registered_env, tmp_path
+    ):
+        """train_sft(--start-from ckpt) resumes a prior run: it loads that
+        checkpoint's full state dict into the agent before training, rather than
+        starting from a fresh init. Marks one head's bias with a sentinel in the
+        checkpoint and asserts it reaches the agent via load_state_dict."""
+        import sft as sft_mod
+
+        envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, 5, "test")])
+        ref = AgentCNN(envs, layers=(16, 16, 16))
+        envs.close()
+        with torch.no_grad():
+            ref.ent_head.bias.fill_(4.2)
+        ckpt = str(tmp_path / "resume_from.pt")
+        torch.save(ref.state_dict(), ckpt)
+
+        # Spy on the constructed agent's load_state_dict so we capture the
+        # tensors actually loaded (training mutates them afterwards, so the
+        # load is the only clean observation point).
+        captured = {}
+        real_cls = sft_mod.AgentCNN
+
+        def spy(*a, **kw):
+            agent = real_cls(*a, **kw)
+            orig_load = agent.load_state_dict
+
+            def load(state_dict, *la, **lkw):
+                captured["ent_bias"] = state_dict["ent_head.bias"].clone()
+                return orig_load(state_dict, *la, **lkw)
+
+            agent.load_state_dict = load
+            return agent
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(sft_mod, "AgentCNN", spy)
+            args = SftArgs(
+                seed=1,
+                size=5,
+                num_samples=100,
+                max_level=2,
+                epochs=1,
+                batch_size=32,
+                layer1=16,
+                layer2=16,
+                layer3=16,
+                start_from=ckpt,
+                checkpoint_path=str(tmp_path / "resumed.pt"),
+                summary_path=str(tmp_path / "resumed.json"),
+            )
+            train_sft(args)
+
+        assert "ent_bias" in captured, "--start-from must trigger a state-dict load"
+        assert torch.allclose(
+            captured["ent_bias"], torch.full_like(captured["ent_bias"], 4.2)
+        ), "the resumed checkpoint's weights must be the ones loaded"
+
 
 class TestSFTLossConvergence:
     def test_loss_decreases_on_small_dataset(self, registered_env):

--- a/training_config.py
+++ b/training_config.py
@@ -191,6 +191,13 @@ class PpoArgs(SharedArgs):
 
 @dataclass
 class SftArgs(SharedArgs):
+    start_from: Optional[str] = None
+    """Checkpoint to resume training from instead of a fresh model: either a
+    local .pt path OR a W&B run id (e.g. a prior SFT run like 'qv4uei74', whose
+    model artifact is downloaded automatically). Loads the full AgentCNN state
+    dict so a long run can be continued rather than restarted. Pair with
+    --wandb-run-id to also log into the same W&B run."""
+
     # One epoch over fresh data; architecture matches checkpoint kkcv6xe3.
     num_samples: int = 45_000_000
     """(state, action) pairs streamed per epoch. Generated on the fly by


### PR DESCRIPTION
## What

Adds a `--start-from` flag to `sft.py`, mirroring the one `ppo.py` already has, so an SFT run can **resume from a checkpoint** instead of starting from a fresh init. This lets a long (~8hr) training run be continued and pushed further rather than restarted from zero.

`--start-from` accepts either:
- a local `.pt` checkpoint path, or
- a W&B run id (e.g. a prior SFT run like `qv4uei74`), whose `model`-type artifact is downloaded automatically.

Both branches route through the existing shared `_resolve_start_from` / `_resolve_wandb_checkpoint` in `ppo.py` — the exact same resolution logic PPO uses — so behaviour and error messages match.

## How it works

- `SftArgs.start_from: Optional[str]` added in `training_config.py`.
- In `train_sft`, after the agent is constructed and before it's moved to the training device, the resolved checkpoint's full `AgentCNN` state dict is loaded (`map_location="cpu"` so a GPU-pod checkpoint still loads on CPU/MPS boxes).
- The W&B run is tagged `start_from:<value>` for provenance, mirroring PPO's `_append_run_tags`.

To also continue logging into the *same* W&B run, pair it with the existing `--wandb-run-id` flag:

```bash
uv run python sft.py --start-from qv4uei74 --wandb-run-id qv4uei74 --track ...
```

## Testing

- New end-to-end test `test_train_sft_start_from_loads_checkpoint_weights`: marks a head bias with a sentinel in a saved checkpoint, runs `train_sft(--start-from ckpt)`, and asserts the sentinel weights reach the agent via `load_state_dict` (the load is the only clean observation point since training then mutates them).
- Verified the resume path manually: a fresh run saved `sft_smoke.pt`, then a second run with `--start-from sft_smoke.pt` logged `Loading model weights from ...` and continued training from the loaded prior (higher starting `val/thput`).
- `ruff`, `ty`, the SFT smoke test, and the affected test files all pass.

The checkpoint resolver itself was already covered by `tests/test_resolve_start_from.py`; this PR only adds the *loading* into the SFT loop and its test.


---
_Generated by [Claude Code](https://claude.ai/code/session_017RQSPD8UyTiontYTYKDP6V)_