### PR TITLE
[base] Train SFT on MEMORISE_2 only

### DIFF
--- a/sft.py
+++ b/sft.py
@@ -245,7 +245,7 @@ def _iter_demo_pairs(size, max_level, base_seed, worker_id, num_workers, target=
     until `target` pairs are produced, or forever when `target` is None. Callers
     own their own RNG seeding.
     """
-    kinds = list(LessonKind)
+    kinds = [LessonKind.MEMORISE_2_INGREDIENT_RECIPES]  # HACK: SFT on MEMORISE_2 only
     kind_samples = {k.name: 0 for k in kinds}
     # Kinds still believed buildable at this size, plus a per-kind counter of
     # consecutive build failures. A kind that can't fit the grid returns None for


### PR DESCRIPTION
**Base of a two-PR stack.** This PR does exactly one thing; the global-context architecture change lands in a follow-up PR stacked on top of this branch, so a compare between the two isolates the architecture effect on identical data.

## Change

`sft.py`, 1 line (`HACK:`): restrict the training-pair sampler to `MEMORISE_2_INGREDIENT_RECIPES`, so the whole run trains and evals on that single lesson (the val split derives from the same sampler output).

## Purpose

The controlled baseline for the receptive-field-starvation experiment: windowed per-tile heads, MEMORISE_2 data only. The stacked PR adds the global-context heads and nothing else, so `this-branch-vs-stacked` is an apples-to-apples measure of the architecture change (same lesson, same val split).

## Notes

- CI `python-tests` will be **red by design**: the 4 `TestGenerateDataset` tests assert the sampler spans ≥2 lessons, which single-lesson isolation intentionally breaks. Everything else passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJHfjVfWGjiSnHSyD49N8p)_