### PR TITLE
ci: drop consumer GeForce cards from the GPU fallback chain

### DIFF
--- a/ci/config.py
+++ b/ci/config.py
@@ -31,14 +31,14 @@ WANDB_PROJECT = SftArgs().wandb_project_name
 # Preferred first, then availability fallbacks (each pricier/bigger). The
 # default is the RTX 2000 Ada — the GPU the speed benchmarks were tuned on;
 # these models are tiny and the workload is single-core-CPU-bound, so a bigger
-# GPU is overkill (see tests/benchmarks/EXPERIMENT_LOG.md).
+# GPU is overkill (see tests/benchmarks/EXPERIMENT_LOG.md). GeForce cards
+# (3090/4090) omitted: their community hosts hand out busy GPUs → the job
+# crashes at its first .to(device) with cudaErrorDevicesUnavailable (PR #290).
 GPU_FALLBACKS = [
     "NVIDIA RTX 2000 Ada Generation",
     "NVIDIA RTX A4000",
     "NVIDIA RTX 4000 Ada Generation",
     "NVIDIA RTX A5000",
-    "NVIDIA GeForce RTX 3090",
-    "NVIDIA GeForce RTX 4090",
     "NVIDIA RTX 6000 Ada Generation",
     "NVIDIA RTX A6000",
 ]


### PR DESCRIPTION
## What

Removes `NVIDIA GeForce RTX 3090` and `NVIDIA GeForce RTX 4090` from `GPU_FALLBACKS` in `ci/config.py`, so CI pods only schedule onto datacenter cards.

## Why

On [PR #290](https://github.com/beyarkay/factorion/pull/290), compare pods kept terminating before their W&B runs registered. Pulling the `boot-failure` runs' logs showed every one crashed at the job's **first GPU op**:

```
File "sft.py", line 944, in train_sft
    agent.to(device)
torch.AcceleratorError: CUDA error: CUDA-capable device(s) is/are busy or unavailable
  → cudaErrorDevicesUnavailable
```

Setup (clone, Rust build, model construction) succeeded every time — it died the instant it touched the GPU. The discriminator was the **card**, not the code:

| GPU | Outcome |
|---|---|
| RTX 3090 (3 pods, across 2 launches) | ❌ `cudaErrorDevicesUnavailable` |
| RTX A4000 (3 pods) | ✅ trained fine |

The consumer GeForce cards live on RunPod community hosts that routinely hand out an already-busy GPU. Restricting the lineup to datacenter cards keeps pods off those hosts.

## Notes

Minimal fix for the observed failure (+3/-3). A larger "GPU preflight + auto-relaunch onto a fresh host" was considered but deliberately left out of scope — it's insurance against a *datacenter* card ever being busy, not the bug diagnosed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)