### PR TITLE
Add per-head not-none accuracy metrics to SFT val

### DIFF
--- a/sft.py
+++ b/sft.py
@@ -1046,9 +1046,6 @@ def train_sft(args: SftArgs):
     val_misc_acc = 0.0
     val_eot_acc = 0.0
     val_eot_pos_recall = 0.0
-    # Placement heads whose plain accuracy is inflated by a dominant NONE class,
-    # so not-none accuracy scores only their real-target samples (EOT: its rare
-    # positive class, so it reuses the positive-class recall under "eot").
     nn_heads = ("ent", "dir", "item", "misc")
     val_not_none_acc = {h: 0.0 for h in (*nn_heads, "eot")}
     # Cumulative optimisation pressure, used as the wandb x-axis (see the

--- a/sft.py
+++ b/sft.py
@@ -49,6 +49,9 @@ from ppo import (  # noqa: E402
     _CH_ITEMS,
     _CH_FOOTPRINT,
     _EMPTY_ENT_ID,
+    _EMPTY_ITEM_VAL,
+    _DIR_NONE_VAL,
+    _MISC_NONE_VAL,
     _ASM_MACHINE_ENT_ID,
     _FOOTPRINT_UNAVAILABLE,
 )
@@ -1043,6 +1046,11 @@ def train_sft(args: SftArgs):
     val_misc_acc = 0.0
     val_eot_acc = 0.0
     val_eot_pos_recall = 0.0
+    # Placement heads whose plain accuracy is inflated by a dominant NONE class,
+    # so not-none accuracy scores only their real-target samples (EOT: its rare
+    # positive class, so it reuses the positive-class recall under "eot").
+    nn_heads = ("ent", "dir", "item", "misc")
+    val_not_none_acc = {h: 0.0 for h in (*nn_heads, "eot")}
     # Cumulative optimisation pressure, used as the wandb x-axis (see the
     # define_metric calls above). global_step counts optimiser updates;
     # samples_seen counts training pairs the model has been updated on.
@@ -1267,6 +1275,8 @@ def train_sft(args: SftArgs):
         val_eot_correct = 0
         val_eot_pos_correct = 0
         val_eot_pos_total = 0
+        val_nn_correct = {h: 0 for h in nn_heads}
+        val_nn_total = {h: 0 for h in nn_heads}
         val_total = 0
         val_place_total = 0
         # Direction (target, pred) over placement samples, for the confusion
@@ -1296,6 +1306,8 @@ def train_sft(args: SftArgs):
         per_kind_eot_total = {k.name: 0 for k in LessonKind}
         per_kind_eot_pos_correct = {k.name: 0 for k in LessonKind}
         per_kind_eot_pos_total = {k.name: 0 for k in LessonKind}
+        per_kind_nn_correct = {h: {k.name: 0 for k in LessonKind} for h in nn_heads}
+        per_kind_nn_total = {h: {k.name: 0 for k in LessonKind} for h in nn_heads}
 
         with torch.no_grad():
             for (idx_cpu,) in val_index_loader:
@@ -1413,6 +1425,17 @@ def train_sft(args: SftArgs):
                 val_total += B
                 val_place_total += int(is_place.sum().item())
 
+                # Per head: (correctness, "target is a real non-NONE option" mask).
+                nn_masks = {
+                    "ent": (ent_correct_per, is_place & (batch_ent != _EMPTY_ENT_ID)),
+                    "dir": (dir_correct_per, is_place & (batch_dir != _DIR_NONE_VAL)),
+                    "item": (item_correct_per, is_place & (batch_item != _EMPTY_ITEM_VAL)),
+                    "misc": (misc_correct_per, is_place & (batch_misc != _MISC_NONE_VAL)),
+                }
+                for h, (correct, m) in nn_masks.items():
+                    val_nn_correct[h] += int((correct & m).sum().item())
+                    val_nn_total[h] += int(m.sum().item())
+
                 val_eot_correct += int(eot_correct_per.sum().item())
                 is_pos = batch_eot > 0.5
                 val_eot_pos_correct += int(eot_correct_per[is_pos].sum().item())
@@ -1442,6 +1465,10 @@ def train_sft(args: SftArgs):
                     per_kind_misc_correct[k_name] += int(
                         misc_correct_per[mask_k].sum().item()
                     )
+                    for h, (correct, m) in nn_masks.items():
+                        mk = m & mask_k
+                        per_kind_nn_correct[h][k_name] += int((correct & mk).sum().item())
+                        per_kind_nn_total[h][k_name] += int(mk.sum().item())
                     per_kind_loss_sum[k_name] += loss_per_sample[mask_k].sum().item()
                     # EOT spans the whole kind (placement + terminal), so use
                     # the full kind mask here, not the placement-only mask_k.
@@ -1478,6 +1505,13 @@ def train_sft(args: SftArgs):
         val_eot_pos_recall = (
             val_eot_pos_correct / val_eot_pos_total if val_eot_pos_total > 0 else 0.0
         )
+        # 0.0 when a head saw no non-NONE target this window (e.g. no recipe
+        # placements → no item targets); EOT reuses its positive-class recall.
+        val_not_none_acc = {
+            h: (val_nn_correct[h] / val_nn_total[h] if val_nn_total[h] > 0 else 0.0)
+            for h in nn_heads
+        }
+        val_not_none_acc["eot"] = val_eot_pos_recall
 
         # Build per-kind metric dict for both stdout and wandb. Skip kinds
         # absent from the val split (e.g. small datasets where some kinds
@@ -1512,6 +1546,19 @@ def train_sft(args: SftArgs):
             per_kind_metrics[f"val/{k.name}/eot_pos_recall"] = (
                 per_kind_eot_pos_correct[k.name] / eot_pos_n if eot_pos_n > 0 else 0.0
             )
+
+            # Guarded per head so a metric only surfaces for kinds that actually
+            # exercise a non-NONE target for it (else the ratio is meaningless).
+            for h in nn_heads:
+                nn_n = per_kind_nn_total[h][k.name]
+                if nn_n > 0:
+                    per_kind_metrics[f"val/{k.name}/not_none_{h}_acc"] = (
+                        per_kind_nn_correct[h][k.name] / nn_n
+                    )
+            if eot_pos_n > 0:
+                per_kind_metrics[f"val/{k.name}/not_none_eot_acc"] = (
+                    per_kind_eot_pos_correct[k.name] / eot_pos_n
+                )
 
         val_seconds = time.time() - t_val
 
@@ -1630,6 +1677,10 @@ def train_sft(args: SftArgs):
                     "val/misc_acc": val_misc_acc,
                     "val/eot_acc": val_eot_acc,
                     "val/eot_pos_recall": val_eot_pos_recall,
+                    **{
+                        f"val/not_none_{h}_acc": acc
+                        for h, acc in val_not_none_acc.items()
+                    },
                     "train/epoch": epoch,
                     "train/samples_seen": samples_seen,
                     "train/global_step": global_step,
@@ -1685,6 +1736,10 @@ def train_sft(args: SftArgs):
         "val_misc_acc": round(val_misc_acc, 4),
         "val_eot_acc": round(val_eot_acc, 4),
         "val_eot_pos_recall": round(val_eot_pos_recall, 4),
+        **{
+            f"val_not_none_{h}_acc": round(acc, 4)
+            for h, acc in val_not_none_acc.items()
+        },
         "val_loss": round(val_loss, 4),
         "num_samples": args.num_samples,
         "epochs": args.epochs,

--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -1479,6 +1479,107 @@ class TestPerKindEotMetrics:
         assert {k.split("/")[1] for k in acc_keys} == place_kinds
 
 
+class TestNotNoneHeadAccuracy:
+    """val/not_none_<HEAD>_acc and val/<LESSON>/not_none_<HEAD>_acc — per-head
+    accuracy restricted to samples whose target is a real (non-NONE) option, so
+    the dominant NONE class stops inflating the plain *_acc metrics."""
+
+    _HEADS = ["ent", "dir", "item", "misc", "eot"]
+
+    def test_not_none_metrics_logged(self, monkeypatch, tmp_path):
+        """train_sft must log the global val/not_none_<HEAD>_acc for every head
+        and the per-kind val/<LESSON>/not_none_<HEAD>_acc for kinds that
+        exercise a non-NONE target, each in [0, 1]."""
+        import wandb
+        from unittest.mock import MagicMock
+
+        logged: dict = {}
+        fake_run = MagicMock()
+        fake_run.url = "http://test/run"
+        fake_run.summary = {}
+        fake_run.log.side_effect = lambda d, *a, **k: logged.update(d)
+        monkeypatch.setattr(wandb, "init", lambda *a, **k: fake_run)
+        monkeypatch.setattr(wandb, "Artifact", lambda *a, **k: MagicMock())
+
+        args = SftArgs(
+            seed=1,
+            size=5,
+            num_samples=400,
+            max_level=2,
+            epochs=1,
+            batch_size=32,
+            layer1=16,
+            layer2=16,
+            layer3=16,
+            track=True,
+            eval_rollouts=False,  # skip the slow greedy rollout
+            checkpoint_path=str(tmp_path / "k.pt"),
+            summary_path=str(tmp_path / "k.json"),
+        )
+        train_sft(args)
+
+        # Every head gets a global not-none metric, always in [0, 1].
+        for head in self._HEADS:
+            key = f"val/not_none_{head}_acc"
+            assert key in logged, f"expected global {key} to be logged"
+            assert 0.0 <= logged[key] <= 1.0, f"{key}={logged[key]} out of [0, 1]"
+
+        # Entity/direction have a non-NONE target on essentially every
+        # placement, so their per-kind not-none metric must appear for the
+        # kinds that get a placement /acc.
+        place_kinds = {
+            k.split("/")[1]
+            for k in logged
+            if k.startswith("val/") and k.endswith("/acc") and k.count("/") == 2
+        }
+        for head in ("ent", "dir"):
+            kinds = {
+                k.split("/")[1]
+                for k in logged
+                if k.endswith(f"/not_none_{head}_acc") and k.count("/") == 2
+            }
+            assert kinds, f"expected per-kind val/<LESSON>/not_none_{head}_acc"
+            assert kinds <= place_kinds
+
+        # Any per-kind not-none metric that surfaced must be a valid fraction.
+        for k, v in logged.items():
+            if "/not_none_" in k and k.endswith("_acc") and k.count("/") == 2:
+                assert 0.0 <= v <= 1.0, f"{k}={v} out of [0, 1]"
+
+    def test_not_none_eot_acc_equals_pos_recall(self, monkeypatch, tmp_path):
+        """EOT's not-none option is the positive (stop) class, so its not-none
+        accuracy is exactly the positive-class recall already logged."""
+        import wandb
+        from unittest.mock import MagicMock
+
+        logged: dict = {}
+        fake_run = MagicMock()
+        fake_run.url = "http://test/run"
+        fake_run.summary = {}
+        fake_run.log.side_effect = lambda d, *a, **k: logged.update(d)
+        monkeypatch.setattr(wandb, "init", lambda *a, **k: fake_run)
+        monkeypatch.setattr(wandb, "Artifact", lambda *a, **k: MagicMock())
+
+        args = SftArgs(
+            seed=1,
+            size=5,
+            num_samples=400,
+            max_level=2,
+            epochs=1,
+            batch_size=32,
+            layer1=16,
+            layer2=16,
+            layer3=16,
+            track=True,
+            eval_rollouts=False,
+            checkpoint_path=str(tmp_path / "k.pt"),
+            summary_path=str(tmp_path / "k.json"),
+        )
+        train_sft(args)
+
+        assert logged["val/not_none_eot_acc"] == logged["val/eot_pos_recall"]
+
+
 class TestDirectionConfusion:
     """Direction confusion matrix diagnostic. Direction values:
     NONE=0, NORTH=1, EAST=2, SOUTH=3, WEST=4."""


### PR DESCRIPTION
## What & why

The plain per-head val accuracies (`val/ent_acc`, `val/dir_acc`, `val/item_acc`, `val/misc_acc`, `val/eot_acc`) are noisy/optimistic because each head has a dominant **NONE** option that dominates the sample mix:

- **ent** → empty entity
- **dir** → `Direction.NONE`
- **item** → empty item (no recipe/filter)
- **misc** → `Misc.NONE` (not an underground belt)
- **eot** → `EOT=0` (not the end of the turn)

So a model that never places a real recipe still scores ~0.95 on `item_acc`. The assembler-only `asm_item_acc` captured the right idea for one head; this generalises it to every head.

## Change

Adds, in `sft.py`'s validation loop:

- **Global** `val/not_none_<HEAD>_acc` for `HEAD ∈ {ent, dir, item, misc, eot}`
- **Per-lesson** `val/<LESSON>/not_none_<HEAD>_acc`

Each equals `(count correct & target != NONE) / (count target != NONE)` over placement samples. `tile` is excluded (no NONE class). EOT's not-none option is the positive stop class, so `not_none_eot_acc` is exactly the existing positive-class recall (`val/eot_pos_recall`) — now surfaced under the uniform name too. The five globals also land in the summary JSON.

The plain `*_acc`, `asm_item_acc`, and `eot_pos_recall` metrics are left untouched.

## Verification

Smoke run (untrained model) shows the metric doing its job — plain `item=0.949` / `misc=0.926` collapse to `not_none_item_acc=0.0` / `not_none_misc_acc=0.0`, exposing that no real recipe/underground pick is correct, while `dir`/`ent` (almost always non-NONE) stay in line with their plain versions.

- `uv run ruff check` — clean
- `uv run ty check sft.py` — clean
- New tests in `tests/test_sft.py::TestNotNoneHeadAccuracy` (global + per-kind logging in [0,1]; `not_none_eot_acc == eot_pos_recall`) — pass
- SFT smoke test — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016osEYPizdMGkVZgstKiiib)_