### PR TITLE
Add per-lesson eot_acc/eot_pos_recall to the greedy rollout eval

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -165,6 +165,21 @@ def _run_greedy_eval(agent, args, eval_seeds_to_kind, device) -> dict:
     for kn, acc in roll["per_kind_asm_item_acc"].items():
         if asm_n.get(kn, 0) > 0:
             metrics[f"eval/{kn}/asm_item_acc"] = acc
+
+    # EOT-head accuracy/recall from the same rollout. PPO has no expert-labelled
+    # val set, so this on-rollout score is the only per-lesson EOT-head signal it
+    # gets (mirrors SFT's val/{kind}/eot_acc + eot_pos_recall). Per-lesson
+    # positive recall only surfaces once a lesson actually reaches a done state.
+    metrics["eval/eot_acc"] = roll["eot_acc"]
+    metrics["eval/eot_pos_recall"] = roll["eot_pos_recall"]
+    eot_step_n = roll["per_kind_eot_step_n"]
+    eot_pos_n = roll["per_kind_eot_pos_n"]
+    for kn, acc in roll["per_kind_eot_acc"].items():
+        if eot_step_n.get(kn, 0) > 0:
+            metrics[f"eval/{kn}/eot_acc"] = acc
+    for kn, rec in roll["per_kind_eot_pos_recall"].items():
+        if eot_pos_n.get(kn, 0) > 0:
+            metrics[f"eval/{kn}/eot_pos_recall"] = rec
     return metrics
 
 
@@ -1467,11 +1482,15 @@ if __name__ == "__main__":
         wandb.define_metric("eval/thput", summary="max")
         wandb.define_metric("eval/thput_eot", summary="max")
         wandb.define_metric("eval/asm_item_acc", summary="max")
+        wandb.define_metric("eval/eot_acc", summary="max")
+        wandb.define_metric("eval/eot_pos_recall", summary="max")
         wandb.define_metric("eval/seconds", summary="last")
         for ln in _LESSONS:
             wandb.define_metric(f"eval/{ln}/thput", summary="max")
             wandb.define_metric(f"eval/{ln}/thput_eot", summary="max")
             wandb.define_metric(f"eval/{ln}/asm_item_acc", summary="max")
+            wandb.define_metric(f"eval/{ln}/eot_acc", summary="max")
+            wandb.define_metric(f"eval/{ln}/eot_pos_recall", summary="max")
         for m in ["thput", "thput_raw", "reward", "length", "eot_rate",
                   "invalid_frac", "num_entities", "entity_efficiency",
                   "frac_reachable"]:

--- a/sft.py
+++ b/sft.py
@@ -408,6 +408,12 @@ class RolloutEval(TypedDict):
     asm_item_acc: float  # frac of placed assemblers given the correct recipe
     per_kind_asm_item_acc: dict[str, float]  # asm_item_acc, keyed by LessonKind.name
     per_kind_asm_n: dict[str, int]  # assembler placements scored per LessonKind.name
+    eot_acc: float  # frac of rollout steps whose EOT prediction matches "is the factory done?"
+    eot_pos_recall: float  # frac of done states where the EOT head actually fired
+    per_kind_eot_acc: dict[str, float]  # eot_acc, keyed by LessonKind.name
+    per_kind_eot_pos_recall: dict[str, float]  # eot_pos_recall, keyed by LessonKind.name
+    per_kind_eot_step_n: dict[str, int]  # rollout steps scored per LessonKind.name
+    per_kind_eot_pos_n: dict[str, int]  # done (should-stop) states seen per LessonKind.name
 
 
 def _apply_legal_tile_mask(tile_logits, obs_batch):
@@ -470,10 +476,23 @@ def run_rollout_eval(
     tiles, so it can't livelock re-proposing an occupied tile the env
     keeps rejecting. Eval-only; training is untouched.
 
+    In the same rollout we also score the EOT *head* against ground truth,
+    mirroring SFT's teacher-forced val/eot_acc but measured on-rollout so PPO
+    (which has no expert-labelled val set) can track it. Ground truth per step
+    is the SFT terminal-sample idea: a state is a should-stop positive iff the
+    factory is already complete (`thput_normed >= 1.0`). Because `eot_prob` and
+    `cur_thp` are both read off the *same* pre-action state, they line up: a
+    build step (throughput < 1.0) should have the head silent, and a finished
+    factory should have it firing. `eot_acc` is the fraction of steps whose
+    prediction (`prob > eot_threshold`) matches that label; `eot_pos_recall` is
+    the fraction of done states the head correctly fired on.
+
     Returns a dict with:
         overall, overall_eot — mean throughput ignoring / respecting EOT;
         per_kind, per_kind_eot — same, keyed by LessonKind.name;
-        per_kind_n — sample count per kind in the eval.
+        per_kind_n — sample count per kind in the eval;
+        eot_acc, eot_pos_recall — EOT-head accuracy / positive-class recall;
+        per_kind_eot_acc, per_kind_eot_pos_recall — same, keyed by kind.
     """
     was_training = agent.training
     agent.eval()
@@ -499,6 +518,12 @@ def run_rollout_eval(
     all_eot_throughputs: list[float] = []
     per_kind_asm_correct: dict[str, int] = {k.name: 0 for k in LessonKind}
     per_kind_asm_total: dict[str, int] = {k.name: 0 for k in LessonKind}
+    # EOT-head scoring: every scored step counts toward *_step; done states
+    # (should-stop positives) also count toward *_pos.
+    per_kind_eot_correct: dict[str, int] = {k.name: 0 for k in LessonKind}
+    per_kind_eot_step_total: dict[str, int] = {k.name: 0 for k in LessonKind}
+    per_kind_eot_pos_correct: dict[str, int] = {k.name: 0 for k in LessonKind}
+    per_kind_eot_pos_total: dict[str, int] = {k.name: 0 for k in LessonKind}
 
     if not seeds_sorted:
         if was_training:
@@ -514,6 +539,12 @@ def run_rollout_eval(
             "asm_item_acc": 0.0,
             "per_kind_asm_item_acc": dict(zero),
             "per_kind_asm_n": dict(per_kind_n),
+            "eot_acc": 0.0,
+            "eot_pos_recall": 0.0,
+            "per_kind_eot_acc": dict(zero),
+            "per_kind_eot_pos_recall": dict(zero),
+            "per_kind_eot_step_n": dict(per_kind_n),
+            "per_kind_eot_pos_n": dict(per_kind_n),
         }
 
     # Cap K at the number of seeds — spinning up more envs than work
@@ -592,9 +623,20 @@ def run_rollout_eval(
                 # Snapshot the EOT-respecting throughput the first time the
                 # head crosses threshold — but keep stepping regardless, so
                 # `overall` reflects true build skill (EOT ignored).
-                if not eot_fired[i] and float(eot_probs[i]) > eot_threshold:
+                pred_stop = float(eot_probs[i]) > eot_threshold
+                if not eot_fired[i] and pred_stop:
                     eot_fired[i] = True
                     eot_thp[i] = cur_thp
+
+                # Score the head against ground truth on this pre-action state:
+                # it should fire iff the factory is already complete. `cur_thp`
+                # and `eot_probs[i]` are both this same state, so they align.
+                is_done = cur_thp >= 1.0
+                per_kind_eot_step_total[k.name] += 1
+                per_kind_eot_correct[k.name] += int(pred_stop == is_done)
+                if is_done:
+                    per_kind_eot_pos_total[k.name] += 1
+                    per_kind_eot_pos_correct[k.name] += int(pred_stop)
 
                 action = {
                     "xy": np.array([int(x_K[i]), int(y_K[i])], dtype=int),
@@ -680,6 +722,21 @@ def run_rollout_eval(
         for kn, n in per_kind_asm_total.items()
     }
 
+    eot_step_all = sum(per_kind_eot_step_total.values())
+    eot_pos_all = sum(per_kind_eot_pos_total.values())
+    eot_acc = sum(per_kind_eot_correct.values()) / eot_step_all if eot_step_all else 0.0
+    eot_pos_recall = (
+        sum(per_kind_eot_pos_correct.values()) / eot_pos_all if eot_pos_all else 0.0
+    )
+    per_kind_eot_acc = {
+        kn: (per_kind_eot_correct[kn] / n if n else 0.0)
+        for kn, n in per_kind_eot_step_total.items()
+    }
+    per_kind_eot_pos_recall = {
+        kn: (per_kind_eot_pos_correct[kn] / n if n else 0.0)
+        for kn, n in per_kind_eot_pos_total.items()
+    }
+
     if was_training:
         agent.train()
     return {
@@ -691,6 +748,12 @@ def run_rollout_eval(
         "asm_item_acc": asm_item_acc,
         "per_kind_asm_item_acc": per_kind_asm_item_acc,
         "per_kind_asm_n": dict(per_kind_asm_total),
+        "eot_acc": eot_acc,
+        "eot_pos_recall": eot_pos_recall,
+        "per_kind_eot_acc": per_kind_eot_acc,
+        "per_kind_eot_pos_recall": per_kind_eot_pos_recall,
+        "per_kind_eot_step_n": dict(per_kind_eot_step_total),
+        "per_kind_eot_pos_n": dict(per_kind_eot_pos_total),
     }
 
 

--- a/sft.py
+++ b/sft.py
@@ -476,17 +476,6 @@ def run_rollout_eval(
     tiles, so it can't livelock re-proposing an occupied tile the env
     keeps rejecting. Eval-only; training is untouched.
 
-    In the same rollout we also score the EOT *head* against ground truth,
-    mirroring SFT's teacher-forced val/eot_acc but measured on-rollout so PPO
-    (which has no expert-labelled val set) can track it. Ground truth per step
-    is the SFT terminal-sample idea: a state is a should-stop positive iff the
-    factory is already complete (`thput_normed >= 1.0`). Because `eot_prob` and
-    `cur_thp` are both read off the *same* pre-action state, they line up: a
-    build step (throughput < 1.0) should have the head silent, and a finished
-    factory should have it firing. `eot_acc` is the fraction of steps whose
-    prediction (`prob > eot_threshold`) matches that label; `eot_pos_recall` is
-    the fraction of done states the head correctly fired on.
-
     Returns a dict with:
         overall, overall_eot — mean throughput ignoring / respecting EOT;
         per_kind, per_kind_eot — same, keyed by LessonKind.name;

--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -1060,6 +1060,12 @@ class TestRunRolloutEval:
             "asm_item_acc",
             "per_kind_asm_item_acc",
             "per_kind_asm_n",
+            "eot_acc",
+            "eot_pos_recall",
+            "per_kind_eot_acc",
+            "per_kind_eot_pos_recall",
+            "per_kind_eot_step_n",
+            "per_kind_eot_pos_n",
         }
         overall, per_kind, per_kind_n = (
             roll["overall"],
@@ -1216,6 +1222,62 @@ class TestRunRolloutEval:
             "EOT firing before the first step must snapshot reset throughput (0)"
         )
         assert 0.0 <= always["overall"] <= 1.5
+
+    def test_rollout_eot_head_scoring(self, registered_env):
+        """The rollout scores the EOT head per step against ground truth: a
+        pre-action state is a should-stop positive iff the factory is already
+        complete (thput_normed >= 1.0). Forcing the head to never / always fire
+        (via the threshold) exposes the invariant: the greedy trajectory is
+        independent of the threshold, so both runs see the same steps and the
+        same done/not-done labels. Never-fire is correct exactly on the not-done
+        steps, always-fire exactly on the done steps — every step is one or the
+        other, so the two accuracies partition to 1.0. Never firing recalls no
+        positive; always firing recalls them all (1.0) when any exist."""
+        size = 5
+        envs = gym.vector.SyncVectorEnv([make_env(ENV_ID, 0, False, size, "test")])
+        agent = AgentCNN(envs, layers=(16, 16, 16))
+        envs.close()
+
+        args = SftArgs(
+            seed=1,
+            size=size,
+            num_samples=50,
+            max_level=2 * size,
+            layer1=16,
+            layer2=16,
+            layer3=16,
+        )
+        val_seeds_to_kind = self._build_val_seeds_to_kind(size=size, num_kinds=4)
+        common = dict(
+            device=torch.device("cpu"), max_seeds=len(val_seeds_to_kind)
+        )
+
+        never = run_rollout_eval(
+            agent, args, val_seeds_to_kind, eot_threshold=10.0, **common
+        )
+        always = run_rollout_eval(
+            agent, args, val_seeds_to_kind, eot_threshold=-1.0, **common
+        )
+
+        for roll in (never, always):
+            assert 0.0 <= roll["eot_acc"] <= 1.0
+            assert 0.0 <= roll["eot_pos_recall"] <= 1.0
+            for kn, acc in roll["per_kind_eot_acc"].items():
+                assert 0.0 <= acc <= 1.0
+                if roll["per_kind_eot_step_n"][kn] == 0:
+                    assert acc == 0.0, f"{kn}: no steps but acc {acc}"
+
+        # Trajectory (and thus per-step labels) is threshold-independent.
+        assert never["per_kind_eot_step_n"] == always["per_kind_eot_step_n"]
+        assert never["per_kind_eot_pos_n"] == always["per_kind_eot_pos_n"]
+
+        assert never["eot_acc"] + always["eot_acc"] == pytest.approx(1.0), (
+            "never-fire scores not-done steps, always-fire scores done steps"
+        )
+
+        assert never["eot_pos_recall"] == 0.0, "silent head recalls no positive"
+        total_pos = sum(always["per_kind_eot_pos_n"].values())
+        assert always["eot_pos_recall"] == (1.0 if total_pos > 0 else 0.0)
 
     def _run_with_recorded_proposals(self, monkeypatch):
         """Run a greedy rollout eval with a FactorioEnv that records, for every


### PR DESCRIPTION
## What

Adds per-lesson `eot_acc` and `eot_pos_recall` metrics, scored on the greedy held-out rollout, and surfaces them in PPO's `eval/` section.

SFT already logs per-lesson EOT-head accuracy/recall via its teacher-forced val set (`val/{LESSON}/eot_acc`, `val/{LESSON}/eot_pos_recall`). **PPO had neither** — it has no expert-labelled val set, so its only per-lesson stop-signal visibility was throughput-based (`eval/{LESSON}/thput_eot`). This closes that gap.

## How

`run_rollout_eval` (shared by SFT's rollout eval and PPO's `eval/`) now scores the EOT head against ground truth on every rollout step:

- **Ground truth** mirrors SFT's terminal-sample idea: a *pre-action* state is a should-stop positive iff the factory is already complete (`thput_normed >= 1.0`), a negative otherwise.
- `eot_prob` and `cur_thp` are read off the **same** pre-action state, so they line up — a build step (throughput < 1.0) should have the head silent, a finished factory should have it firing.
- **`eot_acc`** = fraction of steps whose prediction (`prob > eot_threshold`) matches that label. **`eot_pos_recall`** = fraction of done states the head correctly fired on.

The function returns overall `eot_acc`/`eot_pos_recall` plus per-`LessonKind` breakdowns and their step / positive-state counts.

PPO's `_run_greedy_eval` logs `eval/eot_acc`, `eval/eot_pos_recall`, and `eval/{LESSON}/{eot_acc,eot_pos_recall}` (per-lesson recall gated to lessons that actually reach a done state), with `define_metric` summaries set to `max`. These sit in the `eval/` tail (no change to the CI headline report).

## Tests

- Extended the rollout-eval return-shape test with the six new keys.
- New `test_rollout_eot_head_scoring`: forces the head to never/always fire via the threshold and asserts the invariant that the two accuracies partition to 1.0 (never-fire is right on not-done steps, always-fire on done steps), a silent head recalls no positive, and an always-firing head recalls all positives when any exist.
- Full Python suite (3083 passed), ruff, ty, and PPO/SFT smoke tests all green. Rust untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRfdsGDVjJybm2ZAAsjLAc)_