### PR TITLE
Add per-entity frugality penalty to PPO terminal reward

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -365,12 +365,13 @@ def _resolve_start_from(
     return path
 
 
-def make_env(env_id, idx, capture_video, size, run_name, throughput_reward_scale=PpoArgs.throughput_reward_scale, step_penalty=PpoArgs.step_penalty):
+def make_env(env_id, idx, capture_video, size, run_name, throughput_reward_scale=PpoArgs.throughput_reward_scale, step_penalty=PpoArgs.step_penalty, entity_penalty_scale=PpoArgs.entity_penalty_scale):
     def thunk():
         kwargs: dict[str, Any] = {"render_mode": "rgb_array"} if capture_video else {}
         kwargs.update({'size': size, 'max_steps': size*size, 'idx': idx,
                        'throughput_reward_scale': throughput_reward_scale,
-                       'step_penalty': step_penalty})
+                       'step_penalty': step_penalty,
+                       'entity_penalty_scale': entity_penalty_scale})
         env = gym.make(env_id, **kwargs)
         if capture_video:
             env = gym.wrappers.RecordVideo(env, f"videos/{run_name}/env_{idx}", episode_trigger=lambda e: (e+1) % 10 == 0)
@@ -437,10 +438,12 @@ class FactorioEnv(gym.Env):
         options: Optional[dict] = None,
         throughput_reward_scale: float = PpoArgs.throughput_reward_scale,
         step_penalty: float = PpoArgs.step_penalty,
+        entity_penalty_scale: float = PpoArgs.entity_penalty_scale,
     ):
         super().__init__()
         self.throughput_reward_scale = throughput_reward_scale
         self.step_penalty = step_penalty
+        self.entity_penalty_scale = entity_penalty_scale
         if render_mode is not None:
             self.metadata = {"render_modes": [render_mode], "render_fps": 2}
             self.render_mode = render_mode
@@ -880,6 +883,9 @@ class FactorioEnv(gym.Env):
         reward = -self.step_penalty
         if terminated or truncated:
             reward += self.throughput_reward_scale * thput_normed
+            # Frugality penalty: discourage wasteful factories (too many belts,
+            # inserters, etc.) by subtracting a small cost per non-empty entity.
+            reward -= self.entity_penalty_scale * num_entities
 
         self._thput_raw = thput_raw
         self._thput_normed = thput_normed
@@ -1559,7 +1565,7 @@ if __name__ == "__main__":
         print("AMP: bf16 autocast enabled for forward passes")
 
     print(f"Setting up envs with {args}")
-    env_thunks = [make_env(args.env_id, i, args.capture_video, args.size, run_name, args.throughput_reward_scale, args.step_penalty) for i in range(args.num_envs)]
+    env_thunks = [make_env(args.env_id, i, args.capture_video, args.size, run_name, args.throughput_reward_scale, args.step_penalty, args.entity_penalty_scale) for i in range(args.num_envs)]
     # Per-env attributes (see comments below). Set in-process for SyncVectorEnv,
     # via set_attr (which marshals to the workers) for AsyncVectorEnv.
     # _train_seed: fresh factory every episode — env i sweeps args.seed+i,
@@ -2123,7 +2129,7 @@ if __name__ == "__main__":
         if args.capture_video and ((iteration-1) % 50 == 0 or iteration + 1 == args.num_iterations):
             print(f"Recording agent progress at {iteration}")
             num_render_envs = 5
-            render_envs = gym.vector.SyncVectorEnv([make_env(args.env_id, i, False, args.size, run_name, args.throughput_reward_scale, args.step_penalty) for i in range(num_render_envs)])
+            render_envs = gym.vector.SyncVectorEnv([make_env(args.env_id, i, False, args.size, run_name, args.throughput_reward_scale, args.step_penalty, args.entity_penalty_scale) for i in range(num_render_envs)])
             next_obs_ECWH_render, _ = render_envs.reset(seed=args.seed, options={'num_missing_entities': float('inf')})
 
             temp_dirs = [tempfile.mkdtemp() for _ in range(num_render_envs)]

--- a/tests/test_early_termination.py
+++ b/tests/test_early_termination.py
@@ -94,8 +94,9 @@ class TestEarlyTermination:
 
 
 class TestReward:
-    """Reward = throughput_reward_scale * throughput - step_penalty * num_steps:
-    a per-step penalty plus the terminal throughput reward when the episode
+    """Reward = throughput_reward_scale * throughput - step_penalty * num_steps
+    - entity_penalty_scale * num_entities: a per-step penalty plus the terminal
+    throughput reward (less the per-entity frugality penalty) when the episode
     ends (solve / eot / max_steps)."""
 
     def test_solved_factory_with_eot_pays_full_reward(self):
@@ -110,7 +111,9 @@ class TestReward:
 
         assert terminated is True
         assert info["thput_normed"] >= 1.0
-        expected = env.throughput_reward_scale * info["thput_normed"] - env.step_penalty
+        expected = (env.throughput_reward_scale * info["thput_normed"]
+                    - env.step_penalty
+                    - env.entity_penalty_scale * info["num_entities"])
         assert reward == pytest.approx(expected)
 
     def test_step_penalty_only_mid_episode(self):
@@ -136,7 +139,9 @@ class TestReward:
 
         assert truncated is True
         assert terminated is False
-        expected = env.throughput_reward_scale * info["thput_normed"] - env.step_penalty
+        expected = (env.throughput_reward_scale * info["thput_normed"]
+                    - env.step_penalty
+                    - env.entity_penalty_scale * info["num_entities"])
         assert reward == pytest.approx(expected)
 
     def test_eot_action_terminates_episode(self):
@@ -152,8 +157,30 @@ class TestReward:
         assert terminated is True, "eot=1 should terminate the episode"
         assert truncated is False
         assert info["thput_normed"] < 1.0  # ended early, not a full solve
-        expected = env.throughput_reward_scale * info["thput_normed"] - env.step_penalty
+        expected = (env.throughput_reward_scale * info["thput_normed"]
+                    - env.step_penalty
+                    - env.entity_penalty_scale * info["num_entities"])
         assert reward == pytest.approx(expected)
+
+    def test_entity_penalty_scales_with_entity_count(self):
+        """The terminal reward drops by entity_penalty_scale per non-empty
+        entity, so a wasteful factory is penalised more than a frugal one."""
+        env = _make_env(size=5, max_steps=10)
+        env.entity_penalty_scale = 0.01
+        env.reset(seed=42, options={"num_missing_entities": 0})
+
+        action = _noop_action()
+        action["eot"] = 1
+        _, reward, terminated, _, info = env.step(action)
+
+        assert terminated is True
+        expected = (env.throughput_reward_scale * info["thput_normed"]
+                    - env.step_penalty
+                    - env.entity_penalty_scale * info["num_entities"])
+        assert reward == pytest.approx(expected)
+        # A non-zero penalty must actually pull the reward below the penalty-free value.
+        assert info["num_entities"] > 0
+        assert reward < env.throughput_reward_scale * info["thput_normed"] - env.step_penalty
 
 
 class TestStepsTaken:

--- a/training_config.py
+++ b/training_config.py
@@ -126,6 +126,8 @@ class PpoArgs(SharedArgs):
     """scales the terminal throughput reward (paid once when the episode ends, on eot or max_steps); throughput is in [0, 1] so this sets the max terminal reward."""
     step_penalty: float = 0.0
     """penalty subtracted every step, so dragging the build out costs reward and the eot head learns to fire once the factory can't improve. Small relative to throughput_reward_scale. Set to 0 so the reward is purely the terminal throughput (thput_eot)."""
+    entity_penalty_scale: float = 0.001
+    """per-entity penalty subtracted from the terminal reward: (# non-empty entities) * this. Nudges the policy toward frugal factories (fewer belts/inserters/etc.) rather than wasteful ones. A crude proxy for material cost; a future version may sum per-entity recipe costs instead."""
     max_grad_norm: float = 1.221
     """the maximum norm for the gradient clipping"""
     target_kl: Optional[float] = 0.02


### PR DESCRIPTION
## What

Adds a frugality penalty to the PPO terminal reward so the policy is nudged toward factories that use *fewer* entities (belts, inserters, assemblers, …) rather than wasteful ones.

At episode end the reward now subtracts `entity_penalty_scale * num_entities`, where `num_entities` is the count of non-empty entity tiles (already computed in the terminal-step diagnostics). More entities → less reward.

## Why

Nothing currently discourages the policy from spamming redundant entities to hit a target throughput. This is a crude first cut at a material-cost signal. As noted in the task and the code comment, a future version may sum per-entity recipe costs (from the recipes slice) instead of a flat per-entity count.

## Changes

- **`training_config.py`** — new `PpoArgs.entity_penalty_scale: float = 0.001` hyperparameter.
- **`ppo.py`** — threaded the knob through `make_env` and `FactorioEnv.__init__`; applied `reward -= entity_penalty_scale * num_entities` in the terminal-reward branch of `step()` (only when `terminated or truncated`, where `num_entities` is the real count). Updated the two internal `make_env` call sites.
- **`tests/test_early_termination.py`** — updated the three terminal-reward assertions to include the new term and added `test_entity_penalty_scales_with_entity_count` verifying a non-zero penalty pulls the reward below the penalty-free value.

## Testing

- `pytest tests/test_early_termination.py` — 11 passed (incl. new test)
- `ruff check .` — clean
- `ty check .` — no new diagnostics (the 5 remaining are pre-existing in `sft.py`/`test_sft.py`, untouched here)
- PPO smoke test (`--total-timesteps 5000`) — runs cleanly; `entity_penalty_scale=0.001` visible in the args

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAjJ8x6wqdDfZGfBSScjZ7)_