### PR TITLE
Extract AgentCNN.tile_features_at() shared by PPO/SFT/rollout

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -1303,6 +1303,24 @@ class AgentCNN(nn.Module):
         max_BC = encoded_BCWH.amax(dim=(2, 3))
         return self.global_proj(torch.cat([mean_BC, max_BC], dim=1))
 
+    def tile_features_at(self, encoded_BCWH, x_B, y_B):
+        """Gather the per-tile feature column at each row's (x, y), appended
+        with the global-context vector when global_feat_dim>0. This is the
+        exact input the entity/direction/item/misc heads consume, shared by the
+        policy forward, the SFT train/val loops, and the greedy rollout eval so
+        those paths stay in lockstep (they run literally the same network).
+
+        The batch index is rebuilt fresh each call on purpose: a cached arange
+        would be captured into the CUDA-graph memory pool under reduce-overhead
+        and overwritten on the next replay; recreating it is trivially cheap and
+        torch.compile folds it into the graph."""
+        B = encoded_BCWH.shape[0]
+        batch_idx = torch.arange(B, device=encoded_BCWH.device)
+        tile_features = encoded_BCWH[batch_idx, :, x_B, y_B]
+        if self.global_feat_dim > 0:
+            tile_features = torch.cat([tile_features, self._global_feat(encoded_BCWH)], dim=1)
+        return tile_features
+
     def get_value(self, x_BCWH):
         encoded = self.encoder(self._encode_input(x_BCWH))
         value_B = self.critic_head(encoded).squeeze(-1)
@@ -1347,15 +1365,7 @@ class AgentCNN(nn.Module):
         y_B = tile_idx_B % self.height
 
         # --- Extract per-tile features at selected (x, y) ---
-        # Build the batch index fresh each call. A cached arange would be
-        # captured into the CUDA-graph memory pool under reduce-overhead and get
-        # overwritten on the next replay; recreating it is trivially cheap and
-        # torch.compile folds it into the graph.
-        batch_idx = torch.arange(B, device=encoded_BCWH.device)
-        tile_features_BC = encoded_BCWH[batch_idx, :, x_B, y_B]  # (B, chan3)
-        if self.global_feat_dim > 0:
-            global_BG = self._global_feat(encoded_BCWH)          # (B, global_feat_dim)
-            tile_features_BC = torch.cat([tile_features_BC, global_BG], dim=1)
+        tile_features_BC = self.tile_features_at(encoded_BCWH, x_B, y_B)
 
         # --- Entity / direction / item / misc heads (conditioned on tile features) ---
         logits_e_BE = self.ent_head(tile_features_BC)

--- a/sft.py
+++ b/sft.py
@@ -577,7 +577,6 @@ def run_rollout_eval(
         obs_stack.append(obs)
 
     obs_batch = torch.as_tensor(np.stack(obs_stack), dtype=torch.float32, device=device)
-    batch_idx_K = torch.arange(K, device=device)
 
     with torch.no_grad():
         while any(active):
@@ -594,9 +593,7 @@ def run_rollout_eval(
             tile_idx_K = tile_logits.argmax(dim=1)
             x_K = tile_idx_K // args.size
             y_K = tile_idx_K % args.size
-            tile_features = encoded[batch_idx_K, :, x_K, y_K]
-            if agent.global_feat_dim > 0:
-                tile_features = torch.cat([tile_features, agent._global_feat(encoded)], dim=1)
+            tile_features = agent.tile_features_at(encoded, x_K, y_K)
 
             ent_K = agent.ent_head(tile_features).argmax(dim=1)
             dir_K = agent.dir_head(tile_features).argmax(dim=1)
@@ -1197,10 +1194,8 @@ def train_sft(args: SftArgs):
             # Extract features at target tile for entity/direction/item/misc heads
             x_B = batch_tile // agent.height
             y_B = batch_tile % agent.height
-            batch_idx = torch.arange(B, device=device)
-            tile_features = encoded[batch_idx, :, x_B, y_B]
-            if agent.global_feat_dim > 0:
-                tile_features = torch.cat([tile_features, agent._global_feat(encoded)], dim=1)
+            batch_idx = torch.arange(B, device=device)  # reused by tile_hit below
+            tile_features = agent.tile_features_at(encoded, x_B, y_B)
 
             ent_logits = agent.ent_head(tile_features)
             dir_logits = agent.dir_head(tile_features)
@@ -1392,10 +1387,8 @@ def train_sft(args: SftArgs):
 
                 x_B = batch_tile // agent.height
                 y_B = batch_tile % agent.height
-                batch_idx = torch.arange(B, device=device)
-                tile_features = encoded[batch_idx, :, x_B, y_B]
-                if agent.global_feat_dim > 0:
-                    tile_features = torch.cat([tile_features, agent._global_feat(encoded)], dim=1)
+                batch_idx = torch.arange(B, device=device)  # reused by tile_hit below
+                tile_features = agent.tile_features_at(encoded, x_B, y_B)
 
                 ent_logits = agent.ent_head(tile_features)
                 dir_logits = agent.dir_head(tile_features)


### PR DESCRIPTION
## What

Deduplicates the "gather the per-tile feature column at `(x, y)`, then append the pooled global-context vector" block, which was reimplemented **four times**:

- `AgentCNN.get_action_and_value` (ppo.py) — the policy forward
- `run_rollout_eval` (sft.py) — greedy held-out throughput eval
- the SFT **train** loop (sft.py)
- the SFT **val** loop (sft.py)

All four ran identical logic:

```python
batch_idx = torch.arange(B, device=...)
tile_features = encoded[batch_idx, :, x_B, y_B]
if global_feat_dim > 0:
    tile_features = torch.cat([tile_features, self._global_feat(encoded)], dim=1)
```

## Why

CLAUDE.md stresses that SFT and PPO run **literally the same network** (an SFT checkpoint loads straight into the PPO policy). Four copies of the exact input the entity/direction/item/misc heads consume is a drift risk — adding a head, or changing how global context is fused, means editing four places. This folds it into a single `AgentCNN.tile_features_at(encoded, x_B, y_B)` method so there is one definition. The fresh-`arange` / CUDA-graph rationale moves into the method docstring.

Pure refactor — no behaviour change. The method rebuilds `batch_idx` fresh each call (as the compiled PPO path already did), so the `torch.compile(reduce-overhead)` graph is unaffected.

## Verification

- `ruff check` clean; `ty check` unchanged (same 5 pre-existing diagnostics)
- `pytest tests/test_spatial_agent.py test_torch_compile.py test_sft.py test_rl_from_checkpoint.py` — 162 passed, 2 skipped
- PPO smoke (`--total-timesteps 5000`) and SFT smoke both run to completion

## Follow-up candidates (not in this PR)

Other duplication I noticed but left alone to keep the diff focused — happy to do any on request:
- The `RolloutEval` → metrics unpacking (`eval/*` in ppo `_run_greedy_eval` vs `val/*` in sft) shares its per-kind guard structure.
- `{k.name: 0 for k in LessonKind}` accumulator dicts appear ~25× in sft.py.
- The `random/np/torch` seed triple and the GPU-resident `.to(device)` tuple-unpack each repeat a few times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017fu8sM6caiv74DvmsrCyVL)_