### PR TITLE
[single-lesson] Isolate SFT to MOVE_VIA_UG_BELT only

### DIFF
--- a/sft.py
+++ b/sft.py
@@ -248,7 +248,7 @@ def _iter_demo_pairs(size, max_level, base_seed, worker_id, num_workers, target=
     until `target` pairs are produced, or forever when `target` is None. Callers
     own their own RNG seeding.
     """
-    kinds = list(LessonKind)
+    kinds = [LessonKind.MOVE_VIA_UG_BELT]  # HACK: SFT on MOVE_VIA_UG_BELT only
     kind_samples = {k.name: 0 for k in kinds}
     # Kinds still believed buildable at this size, plus a per-kind counter of
     # consecutive build failures. A kind that can't fit the grid returns None for


### PR DESCRIPTION
**⚠️ Throwaway experiment PR — one of a batch of 11, all titled `[single-lesson]`. Not for merge; safe to bulk-close.**

## What
One-line change in `sft.py:_iter_demo_pairs`: the sampler now draws only `LessonKind.MOVE_VIA_UG_BELT` instead of `list(LessonKind)`, so every training pair (and every derived eval factory) comes from this one lesson.

```diff
-    kinds = list(LessonKind)
+    kinds = [LessonKind.MOVE_VIA_UG_BELT]  # HACK: SFT on MOVE_VIA_UG_BELT only
```

## Why
To SFT a model on `MOVE_VIA_UG_BELT` in isolation and confirm the lesson's achievable throughput ceiling (goal: verify a single-lesson model can reach ~1.0 throughput). Mirrors the earlier closed PR #284.

## Notes
- +1/−1 diff, marked with a `HACK:` comment — not intended to merge.
- SFT smoke test passes; per-kind val reports only this lesson.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8n62Ty6dMGHbUcTjdKwJn)_