### PR TITLE
Fix out-of-bounds panic on partial splitter tiles in build_graph

### DIFF
--- a/factorion_rs/src/entities.rs
+++ b/factorion_rs/src/entities.rs
@@ -829,10 +829,17 @@ impl FactoryEntity for Splitter {
         let (x, y) = pos;
         let (dx, dy) = dir.delta();
 
-        let tiles = match entity_tiles(x, y, dir, 2, 1) {
+        // A single-tile delete can leave one tile of a splitter behind; the
+        // graph builder then treats that lone tile as a fresh anchor, and its
+        // 2-wide footprint can extend off-grid. Drop out-of-bounds tiles so the
+        // fan-out below never indexes past the world edge.
+        let tiles: Vec<Pos> = match entity_tiles(x, y, dir, 2, 1) {
             Some(t) => t,
             None => return edges,
-        };
+        }
+        .into_iter()
+        .filter(|t| world.in_bounds(t.x, t.y))
+        .collect();
         let tile_set: std::collections::HashSet<Pos> = tiles.iter().copied().collect();
 
         // Receivers ahead of each tile, collected first: every splitter

--- a/factorion_rs/src/graph.rs
+++ b/factorion_rs/src/graph.rs
@@ -536,6 +536,27 @@ mod tests {
     }
 
     #[test]
+    fn test_partial_splitter_at_edge_does_not_panic() {
+        // A single-tile delete can leave one tile of a splitter behind. The
+        // graph builder then treats that lone tile as a fresh anchor, and its
+        // 2-wide footprint extends off the grid edge. Building the graph (and
+        // the connection fan-out onto the receiver ahead) must not index out
+        // of bounds.
+        let mut w = World::empty(4, 4);
+        // North-facing splitter anchored at (2,2): tiles (2,2) and (3,2).
+        w.place_splitter(2, 2, Direction::North, None);
+        // A receiver ahead of the (3,2) tile, so the fan-out has an edge to emit.
+        w.place(3, 1, Item::TransportBelt, Direction::North, None);
+        // Delete the anchor tile only, leaving a partial splitter at (3,2)
+        // whose recomputed footprint reaches the off-grid column x=4.
+        w.set(2, 2, crate::types::Channel::Entities, 0);
+        w.set(2, 2, crate::types::Channel::Direction, 0);
+
+        // Must not panic.
+        let _ = build_graph(&w);
+    }
+
+    #[test]
     fn test_splitter_four_lane_nodes() {
         // A splitter is two belts side by side, each with two lanes: four
         // nodes, all sharing the anchor for entity-unit grouping.

--- a/factorion_rs/src/graph.rs
+++ b/factorion_rs/src/graph.rs
@@ -249,7 +249,27 @@ fn remap_to_anchor(id: &NodeId, anchor_of: &HashMap<(usize, usize), (usize, usiz
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
-    use crate::types::{Direction, Misc};
+    use crate::rng::Rng;
+    use crate::throughput::calc_throughput;
+    use crate::types::{Channel, Direction, Misc};
+
+    /// Run the full throughput pipeline (the exact path `simulate_throughput`
+    /// takes). Panics — the failure mode these robustness tests exist to catch
+    /// — abort the test.
+    fn sim_no_panic(w: &World) {
+        let g = build_graph(w);
+        let _ = calc_throughput(&g);
+    }
+
+    /// Set a single tile's entity/direction/misc channels directly, bypassing
+    /// the multi-tile placement helpers — the point is to synthesise the
+    /// *partial* entities (a lone tile of a splitter/assembler) that a
+    /// single-tile delete leaves behind.
+    fn set_lone_tile(w: &mut World, x: usize, y: usize, ent: Item, dir: Direction, misc: Misc) {
+        w.set(x, y, Channel::Entities, ent as i64);
+        w.set(x, y, Channel::Direction, dir as i64);
+        w.set(x, y, Channel::Misc, misc as i64);
+    }
 
     /// 1x1 entity configs exercised by the exhaustive connectivity checks.
     /// (Multi-tile assembler/splitter handled separately.)
@@ -532,6 +552,115 @@ mod tests {
                 .get_index(&NodeId::new(Item::TransportBelt, 0, 0, Some(lane)))
                 .unwrap();
             assert!(g.successors[belt0].contains(&ug_down));
+        }
+    }
+
+    #[test]
+    fn build_graph_never_panics_on_lone_entity_tile_anywhere() {
+        // The OOB crash came from a *single* leftover tile of a multi-tile
+        // entity (a splitter whose anchor was deleted) sitting at the grid
+        // edge: build_graph treats it as a fresh anchor and recomputes its
+        // footprint off-grid. Guard the whole class exhaustively — a lone tile
+        // of ANY placeable entity, in ANY direction/misc, at EVERY cell (edges
+        // and corners included), ringed by belts so the feeder/receiver
+        // fan-out actually runs — must never index out of bounds.
+        let placeable = [
+            Item::TransportBelt,
+            Item::Inserter,
+            Item::LongHandedInserter,
+            Item::AssemblingMachine1,
+            Item::UndergroundBelt,
+            Item::Splitter,
+            Item::Sink,
+            Item::Source,
+        ];
+        let dirs = [
+            Direction::North,
+            Direction::East,
+            Direction::South,
+            Direction::West,
+        ];
+        let miscs = [Misc::None, Misc::UndergroundDown, Misc::UndergroundUp];
+        // Small grids maximise edge/corner adjacency, where off-grid reads bite.
+        for size in [1usize, 2, 3, 5] {
+            for &ent in &placeable {
+                for &dir in &dirs {
+                    for &misc in &miscs {
+                        for x in 0..size {
+                            for y in 0..size {
+                                let mut w = World::empty(size, size);
+                                set_lone_tile(&mut w, x, y, ent, dir, misc);
+                                // A belt on each orthogonal neighbour, all
+                                // facing the tile's own direction. The one
+                                // ahead is a receiver the tile drops onto (the
+                                // input to the splitter fan-out that recomputes
+                                // an off-grid footprint tile), the one behind is
+                                // a feeder — so both connection sides run.
+                                for (nx, ny) in [
+                                    (x as i64 - 1, y as i64),
+                                    (x as i64 + 1, y as i64),
+                                    (x as i64, y as i64 - 1),
+                                    (x as i64, y as i64 + 1),
+                                ] {
+                                    if w.in_bounds(nx, ny) {
+                                        let (nx, ny) = (nx as usize, ny as usize);
+                                        if w.entity_at(nx, ny).is_none() {
+                                            set_lone_tile(
+                                                &mut w,
+                                                nx,
+                                                ny,
+                                                Item::TransportBelt,
+                                                dir,
+                                                Misc::None,
+                                            );
+                                        }
+                                    }
+                                }
+                                sim_no_panic(&w);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn build_graph_never_panics_on_random_worlds() {
+        // Broad adversarial coverage: random cells drawn from the value space
+        // the env can actually write (empty or any placeable entity, any
+        // direction/item/misc), across many small grids. Catches OOB / unwrap
+        // panics from partial multi-tile entities, opposing belts, stray items,
+        // and other combinations the structured tests don't enumerate.
+        let entity_choices = [
+            0, // empty
+            Item::TransportBelt as i64,
+            Item::Inserter as i64,
+            Item::LongHandedInserter as i64,
+            Item::AssemblingMachine1 as i64,
+            Item::UndergroundBelt as i64,
+            Item::Splitter as i64,
+            Item::Sink as i64,
+            Item::Source as i64,
+        ];
+        let mut rng = Rng::seeded(0xF00D);
+        for size in [2usize, 3, 4, 5, 11] {
+            for _ in 0..600 {
+                let mut w = World::empty(size, size);
+                for x in 0..size {
+                    for y in 0..size {
+                        let ent = entity_choices[rng.choice_index(entity_choices.len())];
+                        if ent == 0 {
+                            continue;
+                        }
+                        w.set(x, y, Channel::Entities, ent);
+                        w.set(x, y, Channel::Direction, rng.randint(0, 4)); // None..=West
+                        w.set(x, y, Channel::Items, rng.randint(0, 10)); // 0..=raw items
+                        w.set(x, y, Channel::Misc, rng.randint(0, 2)); // None/down/up
+                    }
+                }
+                sim_no_panic(&w);
+            }
         }
     }
 

--- a/tests/test_partial_entity_robustness.py
+++ b/tests/test_partial_entity_robustness.py
@@ -1,0 +1,71 @@
+"""The throughput sim must never panic on partial factories.
+
+During a rollout the agent can place ``empty`` on a *single* tile — including
+one tile of a multi-tile entity (a splitter or an assembler), leaving a partial
+entity behind. ``simulate_throughput`` (the Rust engine) once panicked with an
+index-out-of-bounds on exactly such a world: a splitter with its anchor tile
+deleted, sitting at the grid edge, whose recomputed 2-wide footprint ran
+off-grid.
+
+These end-to-end tests drive the real pipeline — build every lesson's solved
+factory, apply the agent's single-tile delete to each occupied tile, and
+simulate — asserting it never raises. This guards the whole class of
+partial/malformed worlds the policy can produce, not just the one layout in the
+Rust regression test.
+"""
+
+import pytest
+
+from helpers import (
+    Channel,
+    LessonKind,
+    build_factory,
+    items,
+    rs_throughput,
+)
+
+# Channels the env clears when the agent deletes a tile (footprint is left).
+_DELETE_CHANNELS = (Channel.ENTITIES, Channel.DIRECTION, Channel.ITEMS, Channel.MISC)
+
+_SPLITTER_ID = next(v for v, it in items.items() if it.name == "splitter")
+
+
+@pytest.mark.parametrize("kind", list(LessonKind))
+def test_single_tile_delete_never_panics(kind):
+    """Deleting any one tile of any lesson's solved factory must not panic.
+
+    Multi-tile entities (splitters, assemblers) are the interesting case: a
+    single-tile delete leaves a partial entity that the graph builder treats as
+    a fresh anchor.
+    """
+    for seed in range(8):
+        factory = build_factory(size=11, kind=kind, seed=seed)
+        if factory is None:  # rejection sampling can fail for a given seed
+            continue
+        solved_CWH = factory.world_CWH
+        ent_layer = solved_CWH[Channel.ENTITIES.value]
+        for x, y in (ent_layer != 0).nonzero(as_tuple=False).tolist():
+            partial = solved_CWH.clone()
+            for ch in _DELETE_CHANNELS:
+                partial[ch.value, x, y] = 0
+            # Rust panics surface as pyo3_runtime.PanicException; any exception
+            # here is a failure.
+            rs_throughput(partial.permute(1, 2, 0))
+
+
+def test_splitter_partial_at_edge_never_panics():
+    """The exact crash class, reached through the real generator: a
+    SPLITTER_SPLIT / SPLITTER_MERGE factory with a single splitter tile deleted.
+    """
+    for kind in (LessonKind.SPLITTER_SPLIT, LessonKind.SPLITTER_MERGE):
+        for seed in range(16):
+            factory = build_factory(size=11, kind=kind, seed=seed)
+            if factory is None:
+                continue
+            solved_CWH = factory.world_CWH
+            ent_layer = solved_CWH[Channel.ENTITIES.value]
+            for x, y in (ent_layer == _SPLITTER_ID).nonzero(as_tuple=False).tolist():
+                partial = solved_CWH.clone()
+                for ch in _DELETE_CHANNELS:
+                    partial[ch.value, x, y] = 0
+                rs_throughput(partial.permute(1, 2, 0))


### PR DESCRIPTION
## What crashed

The PPO run [`27ib78yp`](https://wandb.ai/beyarkay/factorion/runs/27ib78yp/logs) died ~7.8h in with a Rust panic:

```
pyo3_runtime.PanicException: index out of bounds: the len is 605 but the index is 621
  ... in factorion_rs::entities::calc_lane_aware_edges
  ... in Splitter::connections
  ... in build_graph
  ... in simulate_throughput
```

`605 = 11·11·5` is the world buffer; index `621 = 11·55 + 3·5 + 1` is a read at `x=11, y=3, channel=DIRECTION` — one column **past** the grid's right edge.

## Root cause

A splitter occupies **2 tiles**. The env's delete operation clears a *single* tile, so deleting just the **anchor** tile of a splitter leaves one tile behind. `build_graph` then treats that lone tile as a fresh anchor, and `entity_tiles` extends its 2-wide footprint one cell off-grid. `Splitter::connections`' receiver fan-out passed that off-grid tile into `calc_lane_aware_edges` as a source, whose `direction_at` read past the world buffer and panicked. Once the actor unfroze (iteration 10) and started producing such partial layouts, the sim eventually hit one and crashed the whole run.

> Note: the critic warm-up itself was **not** the problem — it ended at iteration 10 as designed (`Critic warm-up complete; unfreezing actor at iteration 10` in the log). The "~7 hours" is just total elapsed run time shown in the tqdm bar, not warm-up duration.

## Fix

Filter out-of-bounds tiles out of the splitter footprint in `Splitter::connections`, so the throughput sim is robust to malformed/partial multi-tile entities. The assembler path already bounds-checks every neighbor access (`entities.rs:371,376`), so only the splitter was affected.

```rust
let tiles: Vec<Pos> = match entity_tiles(x, y, dir, 2, 1) {
    Some(t) => t,
    None => return edges,
}
.into_iter()
.filter(|t| world.in_bounds(t.x, t.y))
.collect();
```

## Test

`graph::tests::test_partial_splitter_at_edge_does_not_panic` reproduces the exact production scenario (splitter with its anchor tile deleted at the grid edge, plus a receiver ahead to trigger the fan-out). It **panics without the fix and passes with it**. A standalone repro of the original traceback (`simulate_throughput` on the crafted world) was confirmed to reproduce `index out of bounds: len 605, index 621` before the change and return cleanly after.

## Checklist

- ✅ `cargo fmt` / `cargo clippy -- -D warnings`
- ✅ `cargo test` (155 passed, incl. new regression test)
- ✅ `maturin develop --release`
- ✅ `pytest tests/` (3084 passed, 708 skipped)
- ✅ `ruff check .`
- ✅ PPO smoke test (5000 timesteps, exit 0)
- ✅ SFT smoke test (exit 0)
- ⚠️ `ty check .` — 5 diagnostics, all pre-existing on `main` in `sft.py`/`ppo.py` (torch.load / run_rollout_eval), unrelated to this Rust-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQGVe1GHEGXEMcXpWJS2Zp)_