### PR TITLE
Fix ty check diagnostics in test_sft.py

### DIFF
--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -578,7 +578,7 @@ class TestSFTCheckpointLoading:
                 captured["ent_bias"] = state_dict["ent_head.bias"].clone()
                 return orig_load(state_dict, *la, **lkw)
 
-            agent.load_state_dict = load
+            agent.load_state_dict = load  # ty: ignore[invalid-assignment]
             return agent
 
         with pytest.MonkeyPatch.context() as mp:
@@ -1248,15 +1248,24 @@ class TestRunRolloutEval:
             layer3=16,
         )
         val_seeds_to_kind = self._build_val_seeds_to_kind(size=size, num_kinds=4)
-        common = dict(
-            device=torch.device("cpu"), max_seeds=len(val_seeds_to_kind)
-        )
+        device = torch.device("cpu")
+        max_seeds = len(val_seeds_to_kind)
 
         never = run_rollout_eval(
-            agent, args, val_seeds_to_kind, eot_threshold=10.0, **common
+            agent,
+            args,
+            val_seeds_to_kind,
+            device,
+            max_seeds=max_seeds,
+            eot_threshold=10.0,
         )
         always = run_rollout_eval(
-            agent, args, val_seeds_to_kind, eot_threshold=-1.0, **common
+            agent,
+            args,
+            val_seeds_to_kind,
+            device,
+            max_seeds=max_seeds,
+            eot_threshold=-1.0,
         )
 
         for roll in (never, always):


### PR DESCRIPTION
## Summary
- `run_rollout_eval` was called via a `**common` dict spread whose inferred value type (`device | int`) didn't narrow to the `max_seeds: int` parameter, tripping `invalid-argument-type` in `ty check` (4 occurrences). Replaced with direct positional/keyword args.
- `agent.load_state_dict = load` triggered `invalid-assignment` (implicit method shadowing). Annotated as an intentional shadow with `# ty: ignore[invalid-assignment]`, matching the existing suppression convention in `ppo.py`/`tests/test_factory_builder.py`.

No production code changed — `tests/test_sft.py` only.

## Test plan
- [x] `uv run ty check .` — all checks passed (was 5 diagnostics)
- [x] `WANDB_MODE=disabled WANDB_DISABLED=true uv run python -m pytest tests/test_sft.py -k "test_rollout_eot_head_scoring or test_train_sft_start_from_loads_checkpoint_weights" -v` — both pass
- [x] `uv run ruff check tests/test_sft.py` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01DCgTT5D9S4SC5ng9B3ZCvR)_