### PR TITLE
ci: 1 agent per pod, CUDA 13.x family, day-long sweep budget

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -17,7 +17,7 @@ assert pr:val/thput > main:val/thput       # optional pass/fail conditions
 assert pr:val/acc >= 0.5                   #   → commit status check
 assert pr:sps == main:sps +- 100           # ~equal within a tolerance
 /ci compare ppo --start-from j0s5y2mc      # PPO compare, same flow
-/ci sweep sft [--pods 2] [--agents-per-pod 5]   # W&B sweep (ci/sweep_sft.yaml)
+/ci sweep sft [--pods 2] [--agents-per-pod 1]   # W&B sweep (ci/sweep_sft.yaml)
 /ci sweep ppo                              # ... from ci/sweep_ppo.yaml
 /ci pods                                   # list CI pods + cost + deadline
 /ci kill --all                             # terminate CI pods (or: /ci kill <pod_id>)

--- a/ci/cli.py
+++ b/ci/cli.py
@@ -75,7 +75,7 @@ def sweep(
     /,
     ref: str = "main",
     pods: int = 1,
-    agents_per_pod: int = 5,
+    agents_per_pod: int = 1,
     gpu_type: str = DEFAULT_GPU,
     dry_run: bool = False,
 ) -> None:

--- a/ci/cli.py
+++ b/ci/cli.py
@@ -11,6 +11,7 @@ import time
 from typing import Optional
 
 from ci.config import (
+    AGENTS_PER_POD_DEFAULT,
     COMPARE_NUM_SAMPLES_DEFAULT,
     COMPARE_SEEDS_DEFAULT,
     GPU_FALLBACKS,
@@ -75,7 +76,7 @@ def sweep(
     /,
     ref: str = "main",
     pods: int = 1,
-    agents_per_pod: int = 1,
+    agents_per_pod: int = AGENTS_PER_POD_DEFAULT,
     gpu_type: str = DEFAULT_GPU,
     dry_run: bool = False,
 ) -> None:

--- a/ci/config.py
+++ b/ci/config.py
@@ -45,8 +45,11 @@ GPU_FALLBACKS = [
 
 # Only schedule on hosts whose driver supports a CUDA version new enough for
 # our torch build. uv.lock pins torch 2.12.x+cu130, which needs a CUDA 13.0
-# runtime (host driver >= 580). Keep in sync with the torch cuXXX build.
-ALLOWED_CUDA_VERSIONS = ["13.0"]
+# runtime (host driver >= 580); any newer 13.x driver is back-compatible, and
+# RunPod's filter is an exact match per entry, so list the whole family — a
+# bare ["13.0"] excludes upgraded hosts and shrinks the eligible pool.
+# Keep in sync with the torch cuXXX build.
+ALLOWED_CUDA_VERSIONS = ["13.0", "13.1", "13.2", "13.3"]
 
 # ── Pod naming ─────────────────────────────────────────────────────
 # Every CI pod encodes its own creation time and kill-by deadline in its name,
@@ -112,7 +115,7 @@ def parse_pod_name(name: str) -> Optional[PodMeta]:
 # clone + rust build — cold hosts have been observed to take ~20 min just to
 # pull the image, so the slack must comfortably exceed that.
 SETUP_SLACK_SECONDS = 2700
-SWEEP_BUDGET_SECONDS = 8 * 3600  # sweeps run until run_cap (from the yaml)
+SWEEP_BUDGET_SECONDS = 24 * 3600  # sweeps run until run_cap (from the yaml)
 
 
 def sft_budget_seconds(num_samples: int, epochs: int) -> int:
@@ -180,7 +183,7 @@ class SweepJob:
     sha: str
     algo: str  # "sft" | "ppo"
     sweep_path: str  # entity/project/sweep_id
-    agents_per_pod: int = 5
+    agents_per_pod: int = 1
     extra_tags: list[str] = field(default_factory=list)  # e.g. pr:<N>, for boot-failure reporting
 
     KIND: ClassVar[str] = "sweep"

--- a/ci/config.py
+++ b/ci/config.py
@@ -117,6 +117,10 @@ def parse_pod_name(name: str) -> Optional[PodMeta]:
 SETUP_SLACK_SECONDS = 2700
 SWEEP_BUDGET_SECONDS = 24 * 3600  # sweeps run until run_cap (from the yaml)
 
+# Single source of truth for the sweep agents-per-pod default; the CLI and the
+# `/ci` comment parser both reference this so their defaults can't drift.
+AGENTS_PER_POD_DEFAULT = 1
+
 
 def sft_budget_seconds(num_samples: int, epochs: int) -> int:
     return int(num_samples * epochs / 1000 * 1.5) + SETUP_SLACK_SECONDS
@@ -183,7 +187,7 @@ class SweepJob:
     sha: str
     algo: str  # "sft" | "ppo"
     sweep_path: str  # entity/project/sweep_id
-    agents_per_pod: int = 1
+    agents_per_pod: int = AGENTS_PER_POD_DEFAULT
     extra_tags: list[str] = field(default_factory=list)  # e.g. pr:<N>, for boot-failure reporting
 
     KIND: ClassVar[str] = "sweep"

--- a/ci/gh_command.py
+++ b/ci/gh_command.py
@@ -91,7 +91,7 @@ metric or unparseable line fails the check.)
 ### Sweeps
 
 - `/ci sweep sft` or `/ci sweep ppo` — W&B sweep from this commit's
-  `ci/sweep_<algo>.yaml`. Options: `--pods 1`, `--agents-per-pod 5`
+  `ci/sweep_<algo>.yaml`. Options: `--pods 1`, `--agents-per-pod 1`
 
 ### Pod management
 
@@ -569,7 +569,7 @@ def build_parser() -> argparse.ArgumentParser:
     sp = sub.add_parser("sweep", add_help=False)
     sp.add_argument("algo", choices=("sft", "ppo"))
     sp.add_argument("--pods", type=int, default=1)
-    sp.add_argument("--agents-per-pod", type=int, default=5)
+    sp.add_argument("--agents-per-pod", type=int, default=1)
     common(sp)
 
     sub.add_parser("pods", add_help=False)

--- a/ci/gh_command.py
+++ b/ci/gh_command.py
@@ -22,6 +22,7 @@ from typing import Optional
 
 from ci import github_api
 from ci.config import (
+    AGENTS_PER_POD_DEFAULT,
     COMPARE_NUM_SAMPLES_DEFAULT,
     COMPARE_SEEDS_DEFAULT,
     GPU_FALLBACKS,
@@ -569,7 +570,7 @@ def build_parser() -> argparse.ArgumentParser:
     sp = sub.add_parser("sweep", add_help=False)
     sp.add_argument("algo", choices=("sft", "ppo"))
     sp.add_argument("--pods", type=int, default=1)
-    sp.add_argument("--agents-per-pod", type=int, default=1)
+    sp.add_argument("--agents-per-pod", type=int, default=AGENTS_PER_POD_DEFAULT)
     common(sp)
 
     sub.add_parser("pods", add_help=False)


### PR DESCRIPTION
## What

- **Agents per pod default → 1.** Hoisted into a single `AGENTS_PER_POD_DEFAULT = 1` constant in `ci/config.py`, referenced by the `SweepJob` dataclass, the `ci` CLI (`sweep`), and the `/ci` comment parser (`gh_command.py`) so the three defaults can no longer drift out of sync. Docs updated to match.
- **`ALLOWED_CUDA_VERSIONS` → full 13.x family** (`["13.0", "13.1", "13.2", "13.3"]`). RunPod's CUDA filter is an exact match per entry, so a bare `["13.0"]` excluded hosts on newer (back-compatible) 13.x drivers and shrank the eligible pool.
- **`SWEEP_BUDGET_SECONDS` → 24h** (was 8h), giving sweeps a full day to reach `run_cap`. Still comfortably under the 48h `MAX_POD_AGE_SECONDS` ceiling.

## Testing

- `uv run ruff check ci/` — clean
- `uv run ty check ci/config.py ci/cli.py ci/gh_command.py` — clean
- `uv run python -m pytest tests/test_ci_infra.py` — 48 passed
- Import check confirms `SweepJob().agents_per_pod == 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GZjtKEVpRcagyBjrn6PjF

---
_Generated by [Claude Code](https://claude.ai/code/session_015GZjtKEVpRcagyBjrn6PjF)_