### PR TITLE
ci: make /ci help instant and terse

### DIFF
--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -22,10 +22,31 @@ permissions:
   statuses: write
 
 jobs:
+  # `/ci help` is just static text — skip checkout/python/uv entirely and post
+  # ci/HELP.md straight from the GitHub API so it lands in seconds, not minutes.
+  help:
+    if: >-
+      github.event.issue.pull_request
+      && startsWith(github.event.comment.body, '/ci help')
+      && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                  github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post the cheatsheet
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BODY="$(gh api "repos/${{ github.repository }}/contents/ci/HELP.md" \
+            --jq '.content' | base64 -d)"
+          gh api --method POST \
+            "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
+            -f body="$BODY"
+
   ci-command:
     if: >-
       github.event.issue.pull_request
       && startsWith(github.event.comment.body, '/ci')
+      && !startsWith(github.event.comment.body, '/ci help')
       && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
                   github.event.comment.author_association)
     runs-on: ubuntu-latest

--- a/ci/HELP.md
+++ b/ci/HELP.md
@@ -1,0 +1,31 @@
+## `/ci` — copy-paste cheatsheet
+
+Each job runs **this PR's head commit** on a self-terminating pod and reports
+back here as a comment. Only the flags shown are overridable; everything else
+comes from `training_config.py`. Full grammar: `ci/README.md`.
+
+```text
+# sweeps                            (also: --agents-per-pod N)
+/ci sweep sft --pods 4
+/ci sweep ppo --pods 4
+
+# single runs
+/ci sft --num-samples 5000000
+/ci ppo --start-from abc123 --total-timesteps 40000000
+
+# comparisons — N seeds/side; add `assert` lines for a pass/fail status
+/ci compare sft --seeds 3
+assert pr:val/thput > main:val/thput
+assert pr:val/acc >= 0.5
+
+/ci compare ppo --start-from abc123 --total-timesteps 40000000 --seeds 3
+assert pr:val/thput > main:val/thput
+
+# pods
+/ci pods
+/ci kill abc123                    # or: /ci kill --all
+/ci watchdog --dry-run
+```
+
+`assert` sides: `pr:`/`test:` = this branch, `main:`/`base:` = baseline; ops
+`< > <= >= == ~=` (`~=` ≈ equal, append `+- tol`). Bare numbers are thresholds.

--- a/ci/gh_command.py
+++ b/ci/gh_command.py
@@ -3,7 +3,7 @@
 The workflow hands over the comment body plus PR context via env vars; this
 module parses the command, launches pods with the repo's secrets, and posts
 the outcome back to the PR — comments are the backbone of CI reporting.
-`/ci help` posts HELP below, which doubles as the grammar reference.
+`/ci help` posts `ci/HELP.md`, which doubles as the grammar reference.
 
 Env: COMMENT_BODY, COMMENT_URL, PR_NUMBER, HEAD_SHA, GITHUB_TOKEN,
 GITHUB_REPOSITORY, RUNPOD_API_KEY, WANDB_API_KEY.
@@ -50,57 +50,8 @@ COMPARE_STATUS_CONTEXT = "factorion-ci/compare"
 # under the workflow's own timeout.
 MAX_WAIT_SECONDS = 320 * 60
 
-HELP = """\
-## `/ci` — GPU training jobs from PR comments
-
-Every job runs **this PR's head commit** on a self-terminating RunPod pod and
-reports back here as a comment. Hyperparameters come from `training_config.py`;
-the flags below are the entire override surface (see `ci/README.md`).
-
-### Train
-
-- `/ci sft` — SFT from scratch (production-sized: `SftArgs.num_samples`)
-- `/ci sft --num-samples 200000` — quick smoke run (~minutes)
-- `/ci ppo --start-from j0s5y2mc` — PPO from an SFT checkpoint (W&B run id);
-  optional `--total-timesteps N`
-
-The result comment (headline metrics + all metrics) lands when the run
-finishes, however long it takes.
-
-### Compare this branch to main
-
-- `/ci compare sft` — N seeds each of this branch and main (one pod per run),
-  then a seed-paired diff of every logged metric. Options: `--seeds 3`,
-  `--num-samples 5000000`, `--base-ref main`
-- `/ci compare ppo --start-from j0s5y2mc` — same, comparing PPO finetuning
-  from that checkpoint on both commits; optional `--total-timesteps N`
-
-Add `assert` lines to turn the comparison into a pass/fail commit status:
-
-```
-/ci compare sft --seeds 3
-assert pr:val/thput > main:val/thput
-assert pr:val/acc >= 0.5
-```
-
-(`pr:`/`test:` = this branch, `main:`/`base:` = the baseline; bare numbers
-are thresholds. Comparators on group means: `<` `>` `<=` `>=`, plus `==` /
-`~=` meaning approximately equal — |lhs − rhs| <= 1e-3 by default, or append
-a tolerance like `assert pr:val/acc == main:val/acc +- 0.01`. A missing
-metric or unparseable line fails the check.)
-
-### Sweeps
-
-- `/ci sweep sft` or `/ci sweep ppo` — W&B sweep from this commit's
-  `ci/sweep_<algo>.yaml`. Options: `--pods 1`, `--agents-per-pod 1`
-
-### Pod management
-
-- `/ci pods` — list CI pods (status, cost, deadline)
-- `/ci kill <pod_id>` or `/ci kill --all` — terminate CI pods
-- `/ci watchdog --dry-run` — show what the leaked-pod reaper would do
-- `/ci help` — this message
-"""
+with open(os.path.join(os.path.dirname(__file__), "HELP.md")) as _help_file:
+    HELP = _help_file.read()
 
 
 def parse_comment(body: str) -> tuple[list[str], list[str]]:

--- a/tests/test_ci_gh_command.py
+++ b/tests/test_ci_gh_command.py
@@ -265,7 +265,7 @@ class TestBadInput:
         gh_command.main()
         ((_, body),) = gh_ctx["comments"]
         for snippet in (
-            "/ci sft --num-samples 200000",  # concrete example, not just grammar
+            "/ci sft --num-samples 5000000",  # concrete example, not just grammar
             "/ci ppo --start-from",
             "/ci compare sft",
             "/ci compare ppo --start-from",


### PR DESCRIPTION
## What

`/ci help` was slow (full checkout + setup-python + uv + dep install before it could post anything) and wordy (a long multi-section grammar dump). This makes it near-instant and turns it into a copy-paste cheatsheet.

## Changes

- **`ci/HELP.md`** (new) — concise, copy-paste-first help: a single fenced block with the exact flag phrasing for sweeps, single runs, comparisons (+`assert` lines), and pod management, plus a one-line note on `assert` sides/operators. This is now the single source of truth for the help text.
- **`.github/workflows/ci-command.yml`** — new `help` job that fires on `/ci help` and posts `ci/HELP.md` straight from the GitHub Contents API (no checkout, no Python, no uv), so it lands in seconds instead of minutes. The main `ci-command` job now excludes `/ci help`.
- **`ci/gh_command.py`** — `HELP` is loaded from `ci/HELP.md` instead of an inline string, so the parse-error fallback and the (slow-path) bare `/ci` still show the same text.

## Notes

- The fast help job reads `ci/HELP.md` from the default branch via the API, so help is generic/stable rather than reflecting a PR's in-flight edits — intended.
- Bare `/ci` (no subcommand) still goes through the normal job and posts the same help; only `/ci help` gets the fast path.

## Testing

- `HELP` loads from the new file; `uv run ruff check ci/gh_command.py` and `uv run ty check ci/gh_command.py` pass.
- Workflow YAML validated with `yaml.safe_load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jQtRUchp5C1ABX9KDe5tb

---
_Generated by [Claude Code](https://claude.ai/code/session_015jQtRUchp5C1ABX9KDe5tb)_