### PR TITLE
Lower SFT lr default to the attention-arch sweep's band (3.242e-3 → 1e-3)

### DIFF
--- a/training_config.py
+++ b/training_config.py
@@ -233,8 +233,7 @@ class SftArgs(SharedArgs):
     lr: float = 1e-3
     """peak learning rate (after warmup, before cosine decay). ~1e-3 is the
     centre of the 91w8vyea attention-arch sweep's top-cluster (8.6e-4–1.5e-3,
-    best 8.95e-4); the old 3.242e-3 predated attention (a #244-era conv-only
-    sweep) and sat above the [8e-4, 3e-3] band this architecture was swept in."""
+    best 8.95e-4), within its [8e-4, 3e-3] search band."""
     warmup_frac: float = 0.0
     """fraction of total steps for linear warmup from lr*1e-3 up to lr. 0 disables warmup."""
     min_lr_ratio: float = 0.02869

--- a/training_config.py
+++ b/training_config.py
@@ -231,9 +231,7 @@ class SftArgs(SharedArgs):
     batch_size: int = 512
     """training batch size"""
     lr: float = 1e-3
-    """peak learning rate (after warmup, before cosine decay). ~1e-3 is the
-    centre of the 91w8vyea attention-arch sweep's top-cluster (8.6e-4–1.5e-3,
-    best 8.95e-4), within its [8e-4, 3e-3] search band."""
+    """peak learning rate (after warmup, before cosine decay)"""
     warmup_frac: float = 0.0
     """fraction of total steps for linear warmup from lr*1e-3 up to lr. 0 disables warmup."""
     min_lr_ratio: float = 0.02869

--- a/training_config.py
+++ b/training_config.py
@@ -230,8 +230,11 @@ class SftArgs(SharedArgs):
     """number of training epochs"""
     batch_size: int = 512
     """training batch size"""
-    lr: float = 3.242e-3
-    """peak learning rate (after warmup, before cosine decay)"""
+    lr: float = 1e-3
+    """peak learning rate (after warmup, before cosine decay). ~1e-3 is the
+    centre of the 91w8vyea attention-arch sweep's top-cluster (8.6e-4–1.5e-3,
+    best 8.95e-4); the old 3.242e-3 predated attention (a #244-era conv-only
+    sweep) and sat above the [8e-4, 3e-3] band this architecture was swept in."""
     warmup_frac: float = 0.0
     """fraction of total steps for linear warmup from lr*1e-3 up to lr. 0 disables warmup."""
     min_lr_ratio: float = 0.02869


### PR DESCRIPTION
## What

Sets the `SftArgs.lr` default from **`3.242e-3` → `1e-3`**. One-line value change plus a why-note in the docstring.

## Why

While investigating why a fresh 200M-sample SFT run (`jcbap929`) was underperforming both the arch sweep *and* an ancient 250M conv-only run, I traced it to a stale learning rate that rode through the transformer merge.

- The self-attention PR (**#314**) promoted its conv/attention defaults onto the winning region of sweep **`91w8vyea`**, but **left `lr` untouched** at `3.242e-3`.
- That value comes from **#244** — a pre-attention, conv-only full-hparam sweep — and it sits **above** the `[8e-4, 3e-3]` band the attention architecture was actually swept in.
- The `91w8vyea` top runs clustered at **`8.6e-4–1.5e-3` (best `8.95e-4`)**; the nearest tested run to the shipped arch (`attn_dim 192 / 12 heads / 4 layers`, run `8b51h40i`) used `lr 1.15e-3`. So the shipped default was **~3× too high** and never validated for this architecture.
- The `/ci compare sft` that *was* run on #314 (commit `a093322`) held `lr` fixed at `3.242e-3` on **both** sides at only 5M samples, so it validated the architecture delta but could never surface the lr problem.

The cosine LR schedule spans the full `num_samples` (`T_max = num_samples/batch_size`), so the mismatch compounds on long runs: at a `3.242e-3` peak, a 200M-sample run trains its **entire first half above the swept band** and only reaches the sweep-optimal ~1e-3 around 60% through. That's why `jcbap929` plateaus near the old conv-only baseline (`val/thput_eot ≈ 0.815`) despite a far better architecture, instead of reaching the sweep's `~0.88` — the optimisation is lr-limited, so the architecture's capacity can't express itself. (Raw `val/thput` *does* improve, 0.33 → 0.51, confirming the arch helps where lr isn't the bottleneck.)

`1e-3` is the centre of the sweep's top-cluster and inside the swept band.

## Testing

- `ruff check .` — clean
- `ty check .` — clean
- SFT smoke (`--size 5 --num-samples 200 --epochs 2 …`) — exit 0; summary confirms `lr: 0.001`
- `pytest tests/test_sft.py` — 110 passed, 2 skipped

No Rust changes; no test pins the lr default.

## Suggested follow-up (not in this PR)

- Confirm with `/ci compare sft --seeds 3` (PR vs main) — ideally at a longer `--num-samples` than 5M so the schedule-stretch effect is in scope.
- Optional: the shipped architecture (`attn_dim 192 / h12 / L4 / gfd 64`, conv `128/128/128`) is a hand-pick of the winning *region*, not an exact sweep run — the closest tested point was `attn_dim 128 / gfd 16`, conv `96/0/128/128`. Worth a look if squeezing the last bit of `val/thput_eot`, but it's within the validated region so I left it alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZ6bSB8LsEeSbknxtWHP3D)_