### PR TITLE
Unify model sampling into one AgentCNN.sample_action

### DIFF
--- a/factorion-mod/server/server.py
+++ b/factorion-mod/server/server.py
@@ -135,9 +135,7 @@ def request_to_obs(req: dict) -> np.ndarray:
 def _argmax_action(agent: AgentCNN, obs_CWH: np.ndarray, device) -> dict:
     x = torch.from_numpy(obs_CWH).unsqueeze(0).to(device)
     with torch.no_grad():
-        # temperature=0 is the shared sampler's greedy (argmax) mode — the
-        # same code path PPO/SFT and the builder UI use, so an architecture
-        # change never has to be mirrored here.
+        # temperature=0 = the shared sampler's greedy (argmax) mode.
         act = agent.sample_action(x, temperature=0.0, compute_value=False)["action"]
     return {
         "xy": (int(act["xy"][0, 0]), int(act["xy"][0, 1])),

--- a/factorion-mod/server/server.py
+++ b/factorion-mod/server/server.py
@@ -135,23 +135,16 @@ def request_to_obs(req: dict) -> np.ndarray:
 def _argmax_action(agent: AgentCNN, obs_CWH: np.ndarray, device) -> dict:
     x = torch.from_numpy(obs_CWH).unsqueeze(0).to(device)
     with torch.no_grad():
-        encoded, g = agent.encode(x)
-        B = encoded.shape[0]
-        tile_logits = agent.tile_logits(encoded).reshape(B, -1)
-        tile_idx = tile_logits.argmax(dim=-1)
-        x_B = tile_idx // agent.height
-        y_B = tile_idx % agent.height
-        feat = agent.tile_features(encoded, g, torch.arange(B), x_B, y_B)
-        ent = agent.ent_head(feat).argmax(dim=-1)
-        dir_ = agent.dir_head(feat).argmax(dim=-1)
-        item = agent.item_head(feat).argmax(dim=-1)
-        misc = agent.misc_head(feat).argmax(dim=-1)
+        # temperature=0 is the shared sampler's greedy (argmax) mode — the
+        # same code path PPO/SFT and the builder UI use, so an architecture
+        # change never has to be mirrored here.
+        act = agent.sample_action(x, temperature=0.0, compute_value=False)["action"]
     return {
-        "xy": (int(x_B.item()), int(y_B.item())),
-        "entity": int(ent.item()),
-        "direction": int(dir_.item()),
-        "item": int(item.item()),
-        "misc": int(misc.item()),
+        "xy": (int(act["xy"][0, 0]), int(act["xy"][0, 1])),
+        "entity": int(act["entity"].item()),
+        "direction": int(act["direction"].item()),
+        "item": int(act["item"].item()),
+        "misc": int(act["misc"].item()),
     }
 
 

--- a/ppo.py
+++ b/ppo.py
@@ -1172,6 +1172,31 @@ def _categorical_entropy(logp_all_BN):
     return -(logp_all_BN.exp() * logp_all_BN).sum(-1)
 
 
+def _select_action(logp_all_BN, temperature):
+    """Choose one category per row from log-probabilities: argmax when
+    temperature==0 (greedy/deterministic), else sample from the
+    temperature-scaled distribution (temperature==1 reproduces the on-policy
+    Categorical(logits).sample()). log_softmax is invariant to a per-row
+    additive shift, so scaling the stored log-probs by 1/T yields
+    softmax(logits/T) without re-deriving the raw logits."""
+    if temperature == 0.0:
+        return logp_all_BN.argmax(dim=-1)
+    if temperature == 1.0:
+        return _categorical_sample(logp_all_BN)
+    return _categorical_sample(F.log_softmax(logp_all_BN / temperature, dim=-1))
+
+
+def _legal_tile_mask(x_BCWH):
+    """Boolean (B, W*H) mask, True where a tile is a legal placement (empty
+    entity AND buildable footprint). Greedy consumers pass legal_mask=True so
+    an argmax can't re-propose an occupied or walled cell; PPO leaves it off
+    and learns legality from the step penalty."""
+    ent_BWH = x_BCWH[:, _CH_ENT]
+    foot_BWH = x_BCWH[:, _CH_FOOTPRINT]
+    legal_BWH = (ent_BWH == _EMPTY_ENT_ID) & (foot_BWH != _FOOTPRINT_UNAVAILABLE)
+    return legal_BWH.reshape(x_BCWH.shape[0], -1)
+
+
 class _SelfAttnStack(nn.Module):
     """Self-attention over the encoded map so every cell sees every other in
     one hop. Each cell's feature column is a token; the residual out-projection
@@ -1455,20 +1480,54 @@ class AgentCNN(nn.Module):
         lower it if the model rambles, raise it if it stops short."""
         return self.eot_prob(x_BCWH) > threshold
 
-    def get_action_and_value(self, x_BCWH, action=None):
+    def sample_action(
+        self,
+        x_BCWH,
+        *,
+        temperature: float = 1.0,
+        legal_mask: bool = False,
+        eot_threshold: float = 0.5,
+        action=None,
+        compute_value: bool = True,
+    ):
+        """Single source of truth for turning an observation into an action.
+
+        Every consumer routes here, so a change to how the model is sampled —
+        or to the head layout it samples from — lands in exactly one place:
+
+          * PPO on-policy rollout / update — ``temperature=1`` (stochastic),
+            ``legal_mask`` off, value computed, eot ~ Bernoulli(p). Passing
+            ``action`` replays a stored action to recompute its log-prob for
+            the update instead of sampling a fresh one.
+          * greedy consumers (SFT/PPO eval, mod server, builder UI) —
+            ``temperature=0`` (argmax every head), eot fires when
+            ``p > eot_threshold``; eval also passes ``legal_mask=True`` to
+            skip occupied / walled tiles.
+
+        Returns a dict with the sampled ``action`` (a dict of tensors), the
+        summed ``logp`` and joint ``entropy`` of that action, the critic
+        ``value`` (None when ``compute_value=False``), the per-head
+        ``eot_prob``, and the per-head log-prob tensors in ``logp_heads``
+        (tile / entity / direction / item / misc) so callers that visualise
+        the distribution don't re-derive it.
+        """
         # Encode input once and reuse for both action and value heads
         encoded_BCWH, g_BG = self.encode(x_BCWH)  # (B, last_chan, W, H), (B, G)|None
-        value_B = self.critic_value(encoded_BCWH, g_BG)
+        value_B = self.critic_value(encoded_BCWH, g_BG) if compute_value else None
 
         B = encoded_BCWH.shape[0]
 
         # --- Tile selection: joint (x, y) via 1x1 conv ---
         tile_logits_B1WH = self.tile_logits(encoded_BCWH)      # (B, 1, W, H)
         tile_logits_BN = tile_logits_B1WH.reshape(B, -1)       # (B, W*H)
+        if legal_mask:
+            tile_logits_BN = tile_logits_BN.masked_fill(
+                ~_legal_tile_mask(x_BCWH), float("-inf")
+            )
         tile_logp_all_BN = F.log_softmax(tile_logits_BN, dim=-1)
 
         if action is None:
-            tile_idx_B = _categorical_sample(tile_logp_all_BN)  # (B,)
+            tile_idx_B = _select_action(tile_logp_all_BN, temperature)  # (B,)
         else:
             # Reconstruct tile index from stored (x, y)
             tile_idx_B = action[:, 0] * self.height + action[:, 1]
@@ -1496,13 +1555,19 @@ class AgentCNN(nn.Module):
         m_logp_all_BM = F.log_softmax(logits_m_BM, dim=-1)
 
         eot_logit_B = self.eot_logit(encoded_BCWH, g_BG)
+        p_eot_B = torch.sigmoid(eot_logit_B)
 
         if action is None:
-            ent_B = _categorical_sample(e_logp_all_BE)
-            dir_B = _categorical_sample(d_logp_all_BD)
-            item_B = _categorical_sample(i_logp_all_BI)
-            misc_B = _categorical_sample(m_logp_all_BM)
-            eot_B = torch.bernoulli(torch.sigmoid(eot_logit_B))
+            ent_B = _select_action(e_logp_all_BE, temperature)
+            dir_B = _select_action(d_logp_all_BD, temperature)
+            item_B = _select_action(i_logp_all_BI, temperature)
+            misc_B = _select_action(m_logp_all_BM, temperature)
+            # Greedy eot is a threshold on p; stochastic eot is a Bernoulli
+            # draw — the same argmax-vs-sample split the categorical heads use.
+            if temperature == 0.0:
+                eot_B = (p_eot_B > eot_threshold).float()
+            else:
+                eot_B = torch.bernoulli(p_eot_B)
         else:
             ent_B = action[:, 2]
             dir_B = action[:, 3]
@@ -1527,7 +1592,6 @@ class AgentCNN(nn.Module):
         # are still exploring vs collapsed) — the RL analog of SFT's per-head
         # accuracy. Stashed as detached scalars (cheap; mirrors the
         # self.time_for_* attributes already set here, so it stays eager-safe).
-        p_eot_B = torch.sigmoid(eot_logit_B)
         ent_tile = _categorical_entropy(tile_logp_all_BN)
         ent_e = _categorical_entropy(e_logp_all_BE)
         ent_d = _categorical_entropy(d_logp_all_BD)
@@ -1556,7 +1620,27 @@ class AgentCNN(nn.Module):
             "misc": misc_B,
             "eot": eot_B,
         }
-        return action_out, logp_B, entropy_B, value_B
+        return {
+            "action": action_out,
+            "logp": logp_B,
+            "entropy": entropy_B,
+            "value": value_B,
+            "eot_prob": p_eot_B,
+            "logp_heads": {
+                "tile": tile_logp_all_BN,
+                "entity": e_logp_all_BE,
+                "direction": d_logp_all_BD,
+                "item": i_logp_all_BI,
+                "misc": m_logp_all_BM,
+            },
+        }
+
+    def get_action_and_value(self, x_BCWH, action=None):
+        """On-policy PPO sampling: a thin wrapper over :meth:`sample_action`
+        at temperature 1. Kept as a 4-tuple (action, logp, entropy, value) so
+        the ~20 rollout/update/test callsites don't have to change."""
+        out = self.sample_action(x_BCWH, temperature=1.0, action=action)
+        return out["action"], out["logp"], out["entropy"], out["value"]
 
 if __name__ == "__main__":
     print("Starting...")

--- a/ppo.py
+++ b/ppo.py
@@ -1173,12 +1173,10 @@ def _categorical_entropy(logp_all_BN):
 
 
 def _select_action(logp_all_BN, temperature):
-    """Choose one category per row from log-probabilities: argmax when
-    temperature==0 (greedy/deterministic), else sample from the
-    temperature-scaled distribution (temperature==1 reproduces the on-policy
-    Categorical(logits).sample()). log_softmax is invariant to a per-row
-    additive shift, so scaling the stored log-probs by 1/T yields
-    softmax(logits/T) without re-deriving the raw logits."""
+    """Pick one category per row: argmax at temperature==0 (greedy), else
+    sample the temperature-scaled distribution (==1 is the on-policy sample).
+    log_softmax is shift-invariant, so scaling log-probs by 1/T == softmax(
+    logits/T)."""
     if temperature == 0.0:
         return logp_all_BN.argmax(dim=-1)
     if temperature == 1.0:
@@ -1187,10 +1185,9 @@ def _select_action(logp_all_BN, temperature):
 
 
 def _legal_tile_mask(x_BCWH):
-    """Boolean (B, W*H) mask, True where a tile is a legal placement (empty
-    entity AND buildable footprint). Greedy consumers pass legal_mask=True so
-    an argmax can't re-propose an occupied or walled cell; PPO leaves it off
-    and learns legality from the step penalty."""
+    """Boolean (B, W*H), True where a tile is empty AND buildable — the
+    legal-placement mask the greedy eval's argmax needs so it can't re-propose
+    an occupied or walled cell."""
     ent_BWH = x_BCWH[:, _CH_ENT]
     foot_BWH = x_BCWH[:, _CH_FOOTPRINT]
     legal_BWH = (ent_BWH == _EMPTY_ENT_ID) & (foot_BWH != _FOOTPRINT_UNAVAILABLE)
@@ -1490,27 +1487,13 @@ class AgentCNN(nn.Module):
         action=None,
         compute_value: bool = True,
     ):
-        """Single source of truth for turning an observation into an action.
-
-        Every consumer routes here, so a change to how the model is sampled —
-        or to the head layout it samples from — lands in exactly one place:
-
-          * PPO on-policy rollout / update — ``temperature=1`` (stochastic),
-            ``legal_mask`` off, value computed, eot ~ Bernoulli(p). Passing
-            ``action`` replays a stored action to recompute its log-prob for
-            the update instead of sampling a fresh one.
-          * greedy consumers (SFT/PPO eval, mod server, builder UI) —
-            ``temperature=0`` (argmax every head), eot fires when
-            ``p > eot_threshold``; eval also passes ``legal_mask=True`` to
-            skip occupied / walled tiles.
-
-        Returns a dict with the sampled ``action`` (a dict of tensors), the
-        summed ``logp`` and joint ``entropy`` of that action, the critic
-        ``value`` (None when ``compute_value=False``), the per-head
-        ``eot_prob``, and the per-head log-prob tensors in ``logp_heads``
-        (tile / entity / direction / item / misc) so callers that visualise
-        the distribution don't re-derive it.
-        """
+        """The one sampler every consumer routes through. temperature=1 is the
+        stochastic PPO path (eot ~ Bernoulli); temperature=0 is greedy argmax
+        (eot fires at p>eot_threshold) for eval / mod server / builder UI.
+        legal_mask restricts the tile pick to empty+buildable cells; `action`
+        replays a stored action to recompute its log-prob. Returns a dict of
+        action / logp / entropy / value (None if not compute_value) / eot_prob
+        / logp_heads (per-head log-probs, so the UI needn't re-derive them)."""
         # Encode input once and reuse for both action and value heads
         encoded_BCWH, g_BG = self.encode(x_BCWH)  # (B, last_chan, W, H), (B, G)|None
         value_B = self.critic_value(encoded_BCWH, g_BG) if compute_value else None
@@ -1562,12 +1545,11 @@ class AgentCNN(nn.Module):
             dir_B = _select_action(d_logp_all_BD, temperature)
             item_B = _select_action(i_logp_all_BI, temperature)
             misc_B = _select_action(m_logp_all_BM, temperature)
-            # Greedy eot is a threshold on p; stochastic eot is a Bernoulli
-            # draw — the same argmax-vs-sample split the categorical heads use.
-            if temperature == 0.0:
-                eot_B = (p_eot_B > eot_threshold).float()
-            else:
-                eot_B = torch.bernoulli(p_eot_B)
+            eot_B = (
+                (p_eot_B > eot_threshold).float()
+                if temperature == 0.0
+                else torch.bernoulli(p_eot_B)
+            )
         else:
             ent_B = action[:, 2]
             dir_B = action[:, 3]
@@ -1636,9 +1618,8 @@ class AgentCNN(nn.Module):
         }
 
     def get_action_and_value(self, x_BCWH, action=None):
-        """On-policy PPO sampling: a thin wrapper over :meth:`sample_action`
-        at temperature 1. Kept as a 4-tuple (action, logp, entropy, value) so
-        the ~20 rollout/update/test callsites don't have to change."""
+        """sample_action at temperature 1, projected to the (action, logp,
+        entropy, value) 4-tuple the ~20 PPO/test callsites already unpack."""
         out = self.sample_action(x_BCWH, temperature=1.0, action=action)
         return out["action"], out["logp"], out["entropy"], out["value"]
 

--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -538,24 +538,14 @@ def _predict(grid: list[list[dict]]) -> dict:
     H = obs_CWH.shape[3]
 
     with torch.no_grad():
-        # Greedy prediction through the one shared sampler (temperature=0) —
-        # the exact tile / entity / direction / item / misc argmax + eot the
-        # model would act on, identical to PPO/SFT eval and the mod server, so
-        # an architecture change never has to be re-applied here. The critic
-        # is unused in the UI, so skip it. The per-head log-probs come back in
-        # `logp_heads` and drive the side-panel top-p distributions.
+        # Greedy prediction via the shared sampler; the argmax tile is the
+        # "Apply" target, and logp_heads drives the side-panel top-p lists.
         out = agent.sample_action(obs_CWH, temperature=0.0, compute_value=False)
         heads = out["logp_heads"]
-
-        # End-of-turn probability — surfaced in the side panel so the user can
-        # see when the model thinks the factory is finished.
         eot_prob = float(out["eot_prob"][0].item())
 
         tile_probs = heads["tile"].exp()[0]
         tile_top, tile_rest = _tile_top_p(tile_probs, H)
-
-        # The sampler's argmax tile: both the "Apply" target and the tile the
-        # side-panel per-head distributions are conditioned on.
         x = int(out["action"]["xy"][0, 0].item())
         y = int(out["action"]["xy"][0, 1].item())
 
@@ -564,10 +554,8 @@ def _predict(grid: list[list[dict]]) -> dict:
         item_top, item_rest = _top_p_named(heads["item"].exp()[0], _ITEM_NAMES)
         misc_top, misc_rest = _top_p_named(heads["misc"].exp()[0], _MISC_NAMES)
 
-        # Ghost overlays: the greedy per-head pick at EVERY tile (not just the
-        # sampled one) — a whole-grid visualisation layered on the shared
-        # heads, so it re-encodes and runs one batched matmul per head against
-        # the full spatial map, reshaped to (W*H, chan).
+        # Ghost overlays need the greedy per-head pick at EVERY tile, not just
+        # the sampled one — a whole-grid matmul on the shared heads.
         encoded_BCWH, g_1G = agent.encode(obs_CWH)
         feats_all = encoded_BCWH[0].permute(1, 2, 0).reshape(W * H, -1)
         if g_1G is not None:

--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -33,7 +33,6 @@ import gymnasium as gym  # noqa: E402
 import matplotlib.pyplot as plt  # noqa: E402
 import numpy as np  # noqa: E402
 import torch  # noqa: E402
-import torch.nn.functional as F  # noqa: E402
 import tyro  # noqa: E402
 
 os.environ.setdefault("WANDB_MODE", "disabled")
@@ -539,32 +538,40 @@ def _predict(grid: list[list[dict]]) -> dict:
     H = obs_CWH.shape[3]
 
     with torch.no_grad():
-        encoded_BCWH, g_1G = agent.encode(obs_CWH)
-        # End-of-turn probability — sigmoid of the eot head's single
-        # logit. Surfaced in the side panel so the user can see when
-        # the model thinks the factory is finished.
-        eot_prob = float(torch.sigmoid(agent.eot_logit(encoded_BCWH, g_1G)).item())
-        tile_logits = agent.tile_logits(encoded_BCWH).reshape(1, -1)
-        tile_probs = F.softmax(tile_logits, dim=-1)[0]
+        # Greedy prediction through the one shared sampler (temperature=0) —
+        # the exact tile / entity / direction / item / misc argmax + eot the
+        # model would act on, identical to PPO/SFT eval and the mod server, so
+        # an architecture change never has to be re-applied here. The critic
+        # is unused in the UI, so skip it. The per-head log-probs come back in
+        # `logp_heads` and drive the side-panel top-p distributions.
+        out = agent.sample_action(obs_CWH, temperature=0.0, compute_value=False)
+        heads = out["logp_heads"]
+
+        # End-of-turn probability — surfaced in the side panel so the user can
+        # see when the model thinks the factory is finished.
+        eot_prob = float(out["eot_prob"][0].item())
+
+        tile_probs = heads["tile"].exp()[0]
         tile_top, tile_rest = _tile_top_p(tile_probs, H)
 
-        # Argmax — used both as the "Apply" target and to condition the
-        # side-panel per-head distributions on the same tile the top
-        # distribution favours.
-        tile_idx = int(tile_probs.argmax().item())
-        x, y = tile_idx // H, tile_idx % H
+        # The sampler's argmax tile: both the "Apply" target and the tile the
+        # side-panel per-head distributions are conditioned on.
+        x = int(out["action"]["xy"][0, 0].item())
+        y = int(out["action"]["xy"][0, 1].item())
 
-        zero = torch.zeros(1, dtype=torch.long, device=encoded_BCWH.device)
-        feats = agent.tile_features(encoded_BCWH, g_1G, zero, x, y)
-        ent_top, ent_rest = _top_p_named(F.softmax(agent.ent_head(feats), dim=-1)[0], _ENT_NAMES)
-        dir_top, dir_rest = _top_p_named(F.softmax(agent.dir_head(feats), dim=-1)[0], _DIR_NAMES)
-        item_top, item_rest = _top_p_named(F.softmax(agent.item_head(feats), dim=-1)[0], _ITEM_NAMES)
-        misc_top, misc_rest = _top_p_named(F.softmax(agent.misc_head(feats), dim=-1)[0], _MISC_NAMES)
+        ent_top, ent_rest = _top_p_named(heads["entity"].exp()[0], _ENT_NAMES)
+        dir_top, dir_rest = _top_p_named(heads["direction"].exp()[0], _DIR_NAMES)
+        item_top, item_rest = _top_p_named(heads["item"].exp()[0], _ITEM_NAMES)
+        misc_top, misc_rest = _top_p_named(heads["misc"].exp()[0], _MISC_NAMES)
 
-        # Per-tile argmax for ent/dir/item/misc — one matmul per head
-        # against the whole spatial map, reshaped to (W*H, chan3).
+        # Ghost overlays: the greedy per-head pick at EVERY tile (not just the
+        # sampled one) — a whole-grid visualisation layered on the shared
+        # heads, so it re-encodes and runs one batched matmul per head against
+        # the full spatial map, reshaped to (W*H, chan).
+        encoded_BCWH, g_1G = agent.encode(obs_CWH)
         feats_all = encoded_BCWH[0].permute(1, 2, 0).reshape(W * H, -1)
-        feats_all = torch.cat([feats_all, g_1G.expand(W * H, -1)], dim=1)
+        if g_1G is not None:
+            feats_all = torch.cat([feats_all, g_1G.expand(W * H, -1)], dim=1)
         ent_pick = agent.ent_head(feats_all).argmax(dim=-1)
         dir_pick = agent.dir_head(feats_all).argmax(dim=-1)
         item_pick = agent.item_head(feats_all).argmax(dim=-1)

--- a/sft.py
+++ b/sft.py
@@ -46,13 +46,11 @@ from ppo import (  # noqa: E402
     _resolve_start_from,
     _CH_ENT,
     _CH_ITEMS,
-    _CH_FOOTPRINT,
     _EMPTY_ENT_ID,
     _EMPTY_ITEM_VAL,
     _DIR_NONE_VAL,
     _MISC_NONE_VAL,
     _ASM_MACHINE_ENT_ID,
-    _FOOTPRINT_UNAVAILABLE,
 )
 from training_config import SftArgs  # noqa: E402
 
@@ -415,16 +413,6 @@ class RolloutEval(TypedDict):
     per_kind_eot_pos_n: dict[str, int]  # done (should-stop) states seen per LessonKind.name
 
 
-def _apply_legal_tile_mask(tile_logits, obs_batch):
-    """Mask illegal placement tiles to -inf so an argmax skips them."""
-    K = tile_logits.shape[0]
-    ent_ch = obs_batch[:, _CH_ENT]
-    foot_ch = obs_batch[:, _CH_FOOTPRINT]
-    # legal iff no entity & tile is placeable
-    legal = (ent_ch == _EMPTY_ENT_ID) & (foot_ch != _FOOTPRINT_UNAVAILABLE)
-    return tile_logits.masked_fill(~legal.reshape(K, -1), float("-inf"))
-
-
 def _solved_assembler_recipes(solved_CWH) -> set[int]:
     """The set of recipes (item ids) carried by assemblers in a solved factory,
     the ground truth for the rollout's recipe-pick check. Empty for factories
@@ -576,7 +564,6 @@ def run_rollout_eval(
         obs_stack.append(obs)
 
     obs_batch = torch.as_tensor(np.stack(obs_stack), dtype=torch.float32, device=device)
-    batch_idx_K = torch.arange(K, device=device)
 
     with torch.no_grad():
         while any(active):
@@ -584,21 +571,21 @@ def run_rollout_eval(
             # outputs are discarded; the per-eval cost of K-1 stale
             # forwards at the tail is negligible compared to the
             # batching win earlier in the queue.
-            encoded, g_K = agent.encode(obs_batch)
-            eot_probs = torch.sigmoid(agent.eot_logit(encoded, g_K))
-
-            tile_logits = _apply_legal_tile_mask(
-                agent.tile_logits(encoded).reshape(K, -1), obs_batch
+            # Greedy pick through the one shared sampler: temperature=0 is
+            # argmax on every head, legal_mask keeps the tile pick on empty +
+            # buildable cells so it can't livelock on a rejected tile. The
+            # critic is unused here, so skip it.
+            out = agent.sample_action(
+                obs_batch, temperature=0.0, legal_mask=True, compute_value=False
             )
-            tile_idx_K = tile_logits.argmax(dim=1)
-            x_K = tile_idx_K // args.size
-            y_K = tile_idx_K % args.size
-            tile_features = agent.tile_features(encoded, g_K, batch_idx_K, x_K, y_K)
-
-            ent_K = agent.ent_head(tile_features).argmax(dim=1)
-            dir_K = agent.dir_head(tile_features).argmax(dim=1)
-            item_K = agent.item_head(tile_features).argmax(dim=1)
-            misc_K = agent.misc_head(tile_features).argmax(dim=1)
+            act = out["action"]
+            eot_probs = out["eot_prob"]
+            x_K = act["xy"][:, 0]
+            y_K = act["xy"][:, 1]
+            ent_K = act["entity"]
+            dir_K = act["direction"]
+            item_K = act["item"]
+            misc_K = act["misc"]
 
             for i in range(K):
                 if not active[i]:

--- a/sft.py
+++ b/sft.py
@@ -571,10 +571,8 @@ def run_rollout_eval(
             # outputs are discarded; the per-eval cost of K-1 stale
             # forwards at the tail is negligible compared to the
             # batching win earlier in the queue.
-            # Greedy pick through the one shared sampler: temperature=0 is
-            # argmax on every head, legal_mask keeps the tile pick on empty +
-            # buildable cells so it can't livelock on a rejected tile. The
-            # critic is unused here, so skip it.
+            # Greedy pick via the shared sampler; legal_mask keeps argmax off
+            # occupied/walled tiles, and the critic is unused here.
             out = agent.sample_action(
                 obs_batch, temperature=0.0, legal_mask=True, compute_value=False
             )

--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -27,7 +27,6 @@ import sft
 from sft import (
     SftArgs,
     StreamingDemoDataset,
-    _apply_legal_tile_mask,
     _artifact_name,
     _humanize_count,
     _humanize_lr,
@@ -40,7 +39,7 @@ from sft import (
     run_rollout_eval,
     train_sft,
 )
-from ppo import FactorioEnv, AgentCNN, make_env, layers_from_args
+from ppo import FactorioEnv, AgentCNN, make_env, layers_from_args, _legal_tile_mask
 
 
 def _materialise_args(args):
@@ -1365,7 +1364,7 @@ class TestLegalTileMask:
         logits[0, 5] = 5.0
 
         assert logits.argmax(dim=1).item() == 0, "sanity: unmasked picks occupied"
-        masked = _apply_legal_tile_mask(logits, obs)
+        masked = logits.masked_fill(~_legal_tile_mask(obs), float("-inf"))
         assert masked.argmax(dim=1).item() == 5, "masked must skip to legal runner-up"
         assert masked[0, 0] == float("-inf"), "occupied tile must be -inf"
 
@@ -1380,7 +1379,7 @@ class TestLegalTileMask:
         logits[0, 4] = 10.0
         logits[0, 2] = 5.0
 
-        masked = _apply_legal_tile_mask(logits, obs)
+        masked = logits.masked_fill(~_legal_tile_mask(obs), float("-inf"))
         assert masked.argmax(dim=1).item() == 2
         assert masked[0, 4] == float("-inf")
 
@@ -1392,7 +1391,7 @@ class TestLegalTileMask:
         obs[0, Channel.ENTITIES.value] = str2ent("transport_belt").value  # occupy everything
         logits = torch.randn(1, size * size)
 
-        masked = _apply_legal_tile_mask(logits, obs)
+        masked = logits.masked_fill(~_legal_tile_mask(obs), float("-inf"))
         assert torch.isinf(masked).all(), "every tile should be masked to -inf"
         idx = masked.argmax(dim=1).item()
         assert idx == 0, "all-illegal row falls back to tile 0"

--- a/tests/test_spatial_agent.py
+++ b/tests/test_spatial_agent.py
@@ -12,11 +12,22 @@ os.environ["WANDB_DISABLED"] = "true"
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from ppo import AgentCNN, PpoArgs, FactorioEnv, make_env  # noqa: E402
+from ppo import (  # noqa: E402
+    AgentCNN,
+    PpoArgs,
+    FactorioEnv,
+    make_env,
+    _CH_ENT,
+    _CH_FOOTPRINT,
+    _EMPTY_ENT_ID,
+    _FOOTPRINT_UNAVAILABLE,
+)
 from training_config import SharedArgs  # noqa: E402
 from helpers import Channel  # noqa: E402
+from factorion import Footprint  # noqa: E402
 
 NUM_CHANNELS = len(Channel)
+_FOOTPRINT_AVAILABLE = Footprint.AVAILABLE.value
 
 
 ENV_ID = "factorion/FactorioEnv-v0-spatial-test"
@@ -440,3 +451,94 @@ class TestArchVariants:
         agent = AgentCNN(envs, layers=(16, 16, 16), attn_dim=4)
         num_heads = agent.attn.transformer.layers[0].self_attn.num_heads
         assert 4 % num_heads == 0 and num_heads == 4
+
+
+class TestSampleAction:
+    """The unified sampler: temperature is the greedy-vs-stochastic knob and
+    the only piece every consumer (PPO, SFT/PPO eval, mod server, builder UI)
+    goes through, so it must behave identically for all of them."""
+
+    def test_get_action_and_value_delegates(self, agent):
+        """The PPO wrapper is exactly sample_action(temperature=1) projected
+        to a 4-tuple, so a seed-matched pair agrees on every field."""
+        obs = torch.randn(3, NUM_CHANNELS, 5, 5)
+        torch.manual_seed(0)
+        action_a, logp_a, entropy_a, value_a = agent.get_action_and_value(obs)
+        torch.manual_seed(0)
+        out = agent.sample_action(obs, temperature=1.0)
+        torch.testing.assert_close(logp_a, out["logp"])
+        torch.testing.assert_close(entropy_a, out["entropy"])
+        torch.testing.assert_close(value_a, out["value"])
+        for k in ("xy", "entity", "direction", "item", "misc", "eot"):
+            torch.testing.assert_close(action_a[k], out["action"][k])
+
+    def test_greedy_is_deterministic(self, agent):
+        """temperature=0 is argmax on every head, so repeated calls (even
+        without a fixed seed) return byte-identical actions."""
+        obs = torch.randn(4, NUM_CHANNELS, 5, 5)
+        a = agent.sample_action(obs, temperature=0.0)["action"]
+        b = agent.sample_action(obs, temperature=0.0)["action"]
+        for k in ("xy", "entity", "direction", "item", "misc", "eot"):
+            torch.testing.assert_close(a[k], b[k])
+
+    def test_greedy_matches_manual_argmax(self, agent):
+        """The greedy action is the argmax of each head's returned log-probs —
+        the invariant the builder UI relies on to condition its side panel on
+        the same tile the top pick favours."""
+        obs = torch.randn(2, NUM_CHANNELS, 5, 5)
+        out = agent.sample_action(obs, temperature=0.0)
+        heads = out["logp_heads"]
+        tile_idx = heads["tile"].argmax(dim=-1)
+        exp_x = tile_idx // agent.height
+        exp_y = tile_idx % agent.height
+        torch.testing.assert_close(out["action"]["xy"][:, 0], exp_x)
+        torch.testing.assert_close(out["action"]["xy"][:, 1], exp_y)
+        for head_name, act_key in [
+            ("entity", "entity"), ("direction", "direction"),
+            ("item", "item"), ("misc", "misc"),
+        ]:
+            torch.testing.assert_close(
+                out["action"][act_key], heads[head_name].argmax(dim=-1)
+            )
+
+    def test_legal_mask_avoids_occupied_and_walled_tiles(self, agent):
+        """With legal_mask=True the greedy tile pick lands only on empty,
+        buildable cells — the guard the eval rollout needs so argmax can't
+        livelock re-proposing a rejected tile."""
+        obs = torch.zeros(1, NUM_CHANNELS, 5, 5)
+        # Buildable everywhere (footprint AVAILABLE), then occupy every tile
+        # except (2, 3) and wall one of the occupied ones too.
+        obs[0, _CH_FOOTPRINT] = _FOOTPRINT_AVAILABLE
+        obs[0, _CH_ENT] = _EMPTY_ENT_ID + 1
+        obs[0, _CH_ENT, 2, 3] = _EMPTY_ENT_ID
+        obs[0, _CH_FOOTPRINT, 0, 0] = _FOOTPRINT_UNAVAILABLE
+        out = agent.sample_action(obs, temperature=0.0, legal_mask=True)
+        assert int(out["action"]["xy"][0, 0]) == 2
+        assert int(out["action"]["xy"][0, 1]) == 3
+
+    def test_replayed_action_recovers_logp(self, agent):
+        """Passing a stored action recomputes its exact log-prob regardless of
+        temperature — the PPO-update path, unchanged by the refactor."""
+        obs = torch.randn(3, NUM_CHANNELS, 5, 5)
+        out = agent.sample_action(obs, temperature=0.0)
+        act = out["action"]
+        stored = torch.cat(
+            [
+                act["xy"],
+                act["entity"][:, None],
+                act["direction"][:, None],
+                act["item"][:, None],
+                act["misc"][:, None],
+                act["eot"][:, None].long(),
+            ],
+            dim=1,
+        )
+        replay = agent.sample_action(obs, action=stored)
+        torch.testing.assert_close(out["logp"], replay["logp"])
+
+    def test_compute_value_false_skips_critic(self, agent):
+        """Greedy consumers pass compute_value=False (the builder UI even
+        drops the critic head), so value must be None rather than computed."""
+        obs = torch.randn(2, NUM_CHANNELS, 5, 5)
+        out = agent.sample_action(obs, temperature=0.0, compute_value=False)
+        assert out["value"] is None


### PR DESCRIPTION
## Why

The logits→action "sampler" was re-implemented in **four** places, each doing the selection glue differently:

| Location | Selection |
|---|---|
| `ppo.py` `get_action_and_value` (training) | stochastic — `multinomial` per head + `bernoulli` eot |
| `sft.py` `run_rollout_eval` (SFT/PPO eval) | greedy `argmax` + legal-tile mask + eot threshold |
| `factorion-mod/server/server.py` `_argmax_action` | greedy `argmax`, no mask |
| `scripts/factory_builder.py` `_predict` (web UI) | greedy `argmax`, no mask + top-p panels |

The feature-extraction API (`encode`/`tile_features`/`*_head`) was already shared, but the sampling glue was not — so a change to *how an action is selected* (or a new head) meant editing all four sites, and the web UI's greedy path could silently drift from training.

## What

One method is now the single source of truth:

```python
AgentCNN.sample_action(obs, *, temperature=1.0, legal_mask=False,
                       eot_threshold=0.5, action=None, compute_value=True)
```

- **`temperature=0`** → greedy argmax on every head (deterministic) — used by the builder UI, the mod server, and the SFT/PPO greedy eval.
- **`temperature=1`** → the on-policy `Categorical(logits).sample()` PPO uses.
- `legal_mask` restricts the tile head to empty + buildable cells (eval only); `action` replays a stored action to recompute its log-prob (PPO update); `logp_heads` returns the per-head log-probs so distribution-visualising callers don't re-derive them.

Greedy vs. stochastic is now just the temperature knob, and eot follows the same split (threshold at `T=0`, Bernoulli at `T=1`).

## Changes

- **`ppo.py`** — add `sample_action` plus the shared `_select_action` / `_legal_tile_mask` helpers; `get_action_and_value` becomes a thin `temperature=1` wrapper preserving its 4-tuple return, so the ~20 rollout/update/test callsites are untouched and `torch.compile` inlines the call (PPO hot path unchanged).
- **`sft.py`** — `run_rollout_eval` calls `sample_action(temperature=0, legal_mask=True, compute_value=False)`; delete the now-dead `_apply_legal_tile_mask` (its legality logic moved to `ppo._legal_tile_mask`).
- **`factorion-mod/server/server.py`** — `_argmax_action` delegates to `sample_action(temperature=0)`.
- **`scripts/factory_builder.py`** — `_predict` sources the action, per-head top-p distributions, and eot from `sample_action`; the whole-grid ghost overlays stay UI-specific (they argmax every head at every tile, not a single sampled action).
- **Tests** — new `TestSampleAction` suite (greedy determinism, argmax equivalence, legal mask, stored-action logp replay, value skipping); the three tile-mask unit tests move to `_legal_tile_mask`.

## Verification

- Full Python suite: **3116 passed, 708 skipped**.
- `ruff check .` ✅ · `ty check .` ✅
- PPO smoke (`--total-timesteps 5000`, exit 0) — confirms the compiled rollout/update paths still trace and run through the wrapper.
- SFT smoke (exit 0) — exercises `run_rollout_eval` through the unified sampler; `val_thp` computed as before.

No Rust (`.rs`/`.pyi`) changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188BQdJ8SRjV9uY3AWq6LpP

---
_Generated by [Claude Code](https://claude.ai/code/session_0188BQdJ8SRjV9uY3AWq6LpP)_