### PR TITLE
CI: always surface W&B run failures on the PR (update the launch comment in place)

### DIFF
--- a/.github/workflows/ci-reporter.yml
+++ b/.github/workflows/ci-reporter.yml
@@ -1,13 +1,23 @@
 name: CI reporter
 
 # Long training runs outlive GitHub's 6h job limit, so the workflow that
-# launched them can't wait for the results. This cron posts a PR summary
-# comment for every finished W&B run tagged pr:<N> that doesn't have one yet
-# (idempotent via an invisible marker in each comment). See ci/report.py.
+# launched them can't wait for the results. This job posts (or edits into the
+# run's launch comment) a PR summary for every terminal W&B run tagged pr:<N>
+# that doesn't have one yet — including crashed/failed runs, so a W&B failure
+# always surfaces on the PR (idempotent via an invisible marker; see
+# ci/report.py).
+#
+# Delivery is deliberately over-triggered: GitHub silently drops scheduled
+# cron ticks under load, and a dropped tick is exactly what once left a failed
+# run unreported. So we also run whenever a /ci command finishes — any PR
+# activity flushes the backlog — on top of a tightened schedule.
 
 on:
   schedule:
-    - cron: "*/30 * * * *"
+    - cron: "*/15 * * * *"
+  workflow_run:
+    workflows: ["CI command"]
+    types: [completed]
   workflow_dispatch:
 
 permissions:

--- a/ci/gh_command.py
+++ b/ci/gh_command.py
@@ -200,6 +200,16 @@ def _post(ctx, body: str) -> int:
     return comment_id
 
 
+def _launch_marker(info: dict) -> str:
+    """Invisible run marker so the reporter cron can find this launch comment
+    and edit the final result into it in place, rather than posting a second
+    comment (or leaving a failed run with no signal but this one)."""
+    from ci.report import RUN_MARKER_TEMPLATE
+
+    run_id = info.get("wandb_run_id")
+    return f"{RUN_MARKER_TEMPLATE.format(run_id=run_id)}\n" if run_id else ""
+
+
 def cmd_sft(args, ctx) -> None:
     job = SftJob(
         sha=ctx["sha"], num_samples=args.num_samples, extra_tags=[f"pr:{ctx['pr']}"]
@@ -207,7 +217,8 @@ def cmd_sft(args, ctx) -> None:
     info = launch(job, args.gpu_type, wait=False)
     _post(
         ctx,
-        _launched_comment(
+        _launch_marker(info)
+        + _launched_comment(
             f"SFT run launched at {_commit_link(ctx['sha'])}",
             [info],
             footer=f"Results land here as a comment when the run finishes. {_project_link(ctx['sha'][:7])}",
@@ -225,7 +236,8 @@ def cmd_ppo(args, ctx) -> None:
     info = launch(job, args.gpu_type, wait=False)
     _post(
         ctx,
-        _launched_comment(
+        _launch_marker(info)
+        + _launched_comment(
             f"PPO run launched at {_commit_link(ctx['sha'])} (from `{args.start_from}`)",
             [info],
             footer=f"Results land here as a comment when the run finishes. {_project_link(ctx['sha'][:7])}",

--- a/ci/github_api.py
+++ b/ci/github_api.py
@@ -51,8 +51,13 @@ def update_pr_comment(comment_id: int, body: str) -> None:
     r.raise_for_status()
 
 
-def list_pr_comment_bodies(pr_number: int, max_pages: int = 10) -> list[str]:
-    bodies: list[str] = []
+def list_pr_comments(pr_number: int, max_pages: int = 10) -> list[dict]:
+    """Each PR comment as {"id": int, "body": str}, oldest first.
+
+    The reporter needs the id (not just the body) so it can UPDATE a run's
+    launch comment in place instead of posting a second one.
+    """
+    comments: list[dict] = []
     for page in range(1, max_pages + 1):
         r = requests.get(
             f"{API}/repos/{_repo()}/issues/{pr_number}/comments",
@@ -62,10 +67,14 @@ def list_pr_comment_bodies(pr_number: int, max_pages: int = 10) -> list[str]:
         )
         r.raise_for_status()
         batch = r.json()
-        bodies.extend(c.get("body", "") for c in batch)
+        comments.extend({"id": int(c["id"]), "body": c.get("body", "")} for c in batch)
         if len(batch) < 100:
             break
-    return bodies
+    return comments
+
+
+def list_pr_comment_bodies(pr_number: int, max_pages: int = 10) -> list[str]:
+    return [c["body"] for c in list_pr_comments(pr_number, max_pages)]
 
 
 def set_commit_status(sha: str, state: str, context: str, description: str) -> None:

--- a/ci/report.py
+++ b/ci/report.py
@@ -582,7 +582,20 @@ def history_csv(out: str, limit: int = 500) -> int:
 # any finished W&B run tagged pr:<N> that has no summary comment yet gets one.
 # An invisible marker in each comment makes the sweep idempotent.
 
+# The launch comment carries the RUN marker so the reporter can find and
+# UPDATE it in place when the run terminates (rather than posting a second
+# comment). The REPORTED marker only ever appears in a final result body, so
+# it — not the run marker — is the idempotency key that stops the cron
+# re-reporting a run it has already reported.
 RUN_MARKER_TEMPLATE = "<!-- factorion-ci-run:{run_id} -->"
+REPORTED_MARKER_TEMPLATE = "<!-- factorion-ci-reported:{run_id} -->"
+
+
+def _result_markers(run_id: str) -> list[str]:
+    return [
+        RUN_MARKER_TEMPLATE.format(run_id=run_id),
+        REPORTED_MARKER_TEMPLATE.format(run_id=run_id),
+    ]
 
 
 def run_summary_markdown(
@@ -603,7 +616,7 @@ def run_summary_markdown(
     repo = os.environ.get("GITHUB_REPOSITORY")
     commit = f"[`{sha7}`](https://github.com/{repo}/commit/{sha7})" if repo else f"`{sha7}`"
     lines = [
-        RUN_MARKER_TEMPLATE.format(run_id=run_id),
+        *_result_markers(run_id),
         f"## {icon} CI {kind} run `{name}` {state}",
         "",
         f"Commit {commit} &middot; [view on W&B]({url})"
@@ -653,7 +666,7 @@ def boot_failure_markdown(
     repo = os.environ.get("GITHUB_REPOSITORY")
     commit = f"[`{sha7}`](https://github.com/{repo}/commit/{sha7})" if repo else f"`{sha7}`"
     lines = [
-        RUN_MARKER_TEMPLATE.format(run_id=run_id),
+        *_result_markers(run_id),
         f"## &#x274C; CI {kind} pod failed to boot",
         "",
         f"The pod for commit {commit} never started the run — it failed while "
@@ -673,13 +686,29 @@ def select_unreported(
     candidates: list[dict], existing_bodies: list[str]
 ) -> list[dict]:
     """Pure core of the reporter: candidates (dicts with a "run_id" key) whose
-    marker doesn't appear in any existing PR comment body."""
+    REPORTED marker doesn't appear in any existing PR comment body.
+
+    Keyed off the reported marker, not the run marker: the launch comment
+    carries the run marker too, so keying off that would make a run look
+    "already reported" the instant it was launched.
+    """
     joined = "\n".join(existing_bodies)
     return [
         c
         for c in candidates
-        if RUN_MARKER_TEMPLATE.format(run_id=c["run_id"]) not in joined
+        if REPORTED_MARKER_TEMPLATE.format(run_id=c["run_id"]) not in joined
     ]
+
+
+def _launch_comment_id(run_id: str, comments: list[dict]) -> Optional[int]:
+    """Id of the run's launch comment (bears its run marker but no reported
+    marker), so the reporter can edit it into the final result in place."""
+    marker = RUN_MARKER_TEMPLATE.format(run_id=run_id)
+    for c in comments:
+        body = c.get("body", "")
+        if marker in body and REPORTED_MARKER_TEMPLATE.format(run_id=run_id) not in body:
+            return c["id"]
+    return None
 
 
 def post_pending_reports(window_days: int = 3, dry_run: bool = False) -> int:
@@ -740,7 +769,8 @@ def post_pending_reports(window_days: int = 3, dry_run: bool = False) -> int:
 
     posted = 0
     for pr_number, candidates in by_pr.items():
-        bodies = github_api.list_pr_comment_bodies(pr_number)
+        comments = github_api.list_pr_comments(pr_number)
+        bodies = [c["body"] for c in comments]
         for c in select_unreported(candidates, bodies):
             if c["boot_failure"]:
                 md = boot_failure_markdown(
@@ -760,8 +790,13 @@ def post_pending_reports(window_days: int = 3, dry_run: bool = False) -> int:
                     sha7=c["sha7"],
                     summary_flat=c["summary_flat"],
                 )
+            launch_id = _launch_comment_id(c["run_id"], comments)
+            where = "update launch comment" if launch_id is not None else "new comment"
             if dry_run:
-                print(f"[dry-run] would comment on PR #{pr_number} for run {c['run_id']}")
+                print(f"[dry-run] would {where} on PR #{pr_number} for run {c['run_id']}")
+            elif launch_id is not None:
+                github_api.update_pr_comment(launch_id, md)
+                print(f"Updated launch comment on PR #{pr_number} for run {c['run_id']}")
             else:
                 github_api.post_pr_comment(pr_number, md)
                 print(f"Commented on PR #{pr_number} for run {c['run_id']}")

--- a/tests/test_ci_gh_command.py
+++ b/tests/test_ci_gh_command.py
@@ -106,6 +106,13 @@ class TestSftDispatch:
         assert len(run_id) == 8
         assert f"https://wandb.ai/testent/factorion/runs/{run_id}" in body
         assert "https://console.runpod.io/pods?id=pod-1" in body
+        # The launch comment carries the run marker so the reporter cron can
+        # edit the final result (including a failure) into it in place instead
+        # of posting a second comment.
+        from ci.report import REPORTED_MARKER_TEMPLATE, RUN_MARKER_TEMPLATE
+
+        assert RUN_MARKER_TEMPLATE.format(run_id=run_id) in body
+        assert REPORTED_MARKER_TEMPLATE.format(run_id=run_id) not in body
         # Every CI comment links back to the /ci comment that triggered it.
         assert "Originally triggered by" in body
         assert "#issuecomment-999" in body

--- a/tests/test_ci_infra.py
+++ b/tests/test_ci_infra.py
@@ -26,7 +26,10 @@ from ci.config import (
 from ci.gh_command import parse_comment
 from ci.jobs import ppo_command, sft_command, sweep_agent_command
 from ci.report import (
+    REPORTED_MARKER_TEMPLATE,
+    RUN_MARKER_TEMPLATE,
     MetricRow,
+    _launch_comment_id,
     boot_failure_markdown,
     compare_metric_rows,
     evaluate_assertion,
@@ -414,10 +417,102 @@ class TestCompareRows:
 
 
 class TestReporter:
-    def test_select_unreported_skips_marked_runs(self):
-        candidates = [{"run_id": "aaa"}, {"run_id": "bbb"}]
-        bodies = ["intro", "report\n<!-- factorion-ci-run:aaa -->"]
-        assert select_unreported(candidates, bodies) == [{"run_id": "bbb"}]
+    def test_select_unreported_skips_already_reported_runs(self):
+        # Idempotency keys off the REPORTED marker, not the run marker: a
+        # launch comment carries the run marker but is not yet a report.
+        candidates = [{"run_id": "aaa"}, {"run_id": "bbb"}, {"run_id": "ccc"}]
+        bodies = [
+            "intro",
+            "report\n" + REPORTED_MARKER_TEMPLATE.format(run_id="aaa"),
+            # bbb's launch comment — run marker present, but no report yet.
+            "launched\n" + RUN_MARKER_TEMPLATE.format(run_id="bbb"),
+        ]
+        assert select_unreported(candidates, bodies) == [
+            {"run_id": "bbb"},
+            {"run_id": "ccc"},
+        ]
+
+    def test_launch_comment_id_targets_the_pending_launch_comment(self):
+        comments = [
+            {"id": 1, "body": "unrelated"},
+            {"id": 2, "body": "launched\n" + RUN_MARKER_TEMPLATE.format(run_id="bbb")},
+        ]
+        # bbb has a launch comment to edit in place; ccc has none → post new.
+        assert _launch_comment_id("bbb", comments) == 2
+        assert _launch_comment_id("ccc", comments) is None
+
+    def test_launch_comment_id_ignores_a_finished_report(self):
+        # A comment that is already a full report (both markers) must not be
+        # re-edited — only a pending launch comment is a valid update target.
+        reported = "\n".join(
+            [
+                RUN_MARKER_TEMPLATE.format(run_id="bbb"),
+                REPORTED_MARKER_TEMPLATE.format(run_id="bbb"),
+                "results...",
+            ]
+        )
+        assert _launch_comment_id("bbb", [{"id": 9, "body": reported}]) is None
+
+    def test_reporter_updates_launch_comment_in_place(self, monkeypatch):
+        # A failed run whose launch comment already exists is edited in place
+        # (no second comment), and a run with no launch comment posts a new
+        # one — so a W&B failure always lands on the PR either way.
+        import wandb
+
+        from ci import github_api, report
+
+        class FakeRun:
+            def __init__(self, rid, state):
+                self.id = rid
+                self.name = f"sft-{rid}"
+                self.state = state
+                self.url = f"https://wandb.ai/x/y/runs/{rid}"
+                self.tags = ["ci", "kind:sft", "pr:42", "sha:abc1234"]
+                self.created_at = "2999-01-01T00:00:00"
+                self.summary = {"_runtime": 12, "val/thput_eot": 0.2}
+
+        class FakeApi:
+            default_entity = "ent"
+
+            def runs(self, *a, **k):
+                return [FakeRun("haslaunch", "failed"), FakeRun("nolaunch", "crashed")]
+
+        monkeypatch.setattr(wandb, "Api", lambda *a, **k: FakeApi())
+        # PR #42 already has haslaunch's launch comment (run marker, no report).
+        comments = [
+            {"id": 111, "body": "launched\n" + RUN_MARKER_TEMPLATE.format(run_id="haslaunch")},
+        ]
+        monkeypatch.setattr(github_api, "list_pr_comments", lambda pr, *a, **k: comments)
+        edits, posts = [], []
+        monkeypatch.setattr(github_api, "update_pr_comment", lambda cid, body: edits.append((cid, body)))
+        monkeypatch.setattr(github_api, "post_pr_comment", lambda pr, body: posts.append((pr, body)) or 1)
+
+        assert report.post_pending_reports() == 2
+        # haslaunch edited its launch comment; nolaunch posted fresh.
+        ((edit_id, edit_body),) = edits
+        assert edit_id == 111
+        assert REPORTED_MARKER_TEMPLATE.format(run_id="haslaunch") in edit_body
+        assert "failed" in edit_body
+        ((post_pr, post_body),) = posts
+        assert post_pr == 42
+        assert REPORTED_MARKER_TEMPLATE.format(run_id="nolaunch") in post_body
+
+    def test_run_summary_is_findable_and_idempotent(self):
+        # A posted result carries BOTH markers: the run marker (so a launch
+        # comment and its eventual report share a discovery key) and the
+        # reported marker (so the cron never reports the same run twice).
+        md = run_summary_markdown(
+            run_id="zzz",
+            name="sft-x",
+            state="failed",
+            url="https://wandb.ai/x/y/runs/zzz",
+            kind="sft",
+            sha7=SHA[:7],
+            summary_flat={},
+        )
+        assert RUN_MARKER_TEMPLATE.format(run_id="zzz") in md
+        assert REPORTED_MARKER_TEMPLATE.format(run_id="zzz") in md
+        assert select_unreported([{"run_id": "zzz"}], [md]) == []
 
     def test_boot_failure_reports_clearly_with_log_tail(self):
         # A pod that dies before the run starts (clone/build/setup) still gets


### PR DESCRIPTION
## Why

On PR #320, [this launch comment](https://github.com/beyarkay/factorion/pull/320#issuecomment-5044941739) announced SFT run [`v5o34ggn`](https://wandb.ai/beyarkay/factorion/runs/v5o34ggn) but the run **failed** (~275 s in) and the comment was never updated — the PR showed no sign of the failure.

Root cause, two parts:

1. **The launch comment is fire-and-forget.** For `sft`/`ppo`, `gh_command.py` posts a launch comment and never touches it again. The only thing that reports a result is the `ci-reporter.yml` cron (`post_pending_reports`), which posts a *separate* comment.
2. **The reporter cron got dropped.** Its logic already handles `failed`/`crashed` runs (verified: `v5o34ggn` is a valid candidate), but its last successful run (10:39) was *before* the failure (~11:01) and GitHub silently dropped the next scheduled tick — a well-known Actions failure mode under load. So no result comment was ever posted.

## What changed

**Update the launch comment in place (`report.py`, `github_api.py`, `gh_command.py`)**
- Each `sft`/`ppo` launch comment now carries an invisible run marker.
- The reporter edits the final result — including failures — into that comment instead of posting a second one.
- Idempotency now keys off a distinct **reported** marker that only a final result body carries, so the run marker in a launch comment no longer makes a just-launched run look already-reported.
- Runs with no launch comment (boot failures, legacy runs) still post a fresh comment, so a failure always lands on the PR either way.

**Over-trigger the reporter (`ci-reporter.yml`)**
- Schedule tightened `*/30` → `*/15`.
- Added a `workflow_run` trigger on the CI command workflow completing, so any `/ci` activity flushes the backlog even when a scheduled tick is dropped.

## Tests

- `select_unreported` re-keyed to the reported marker; new coverage for `_launch_comment_id` (targets the pending launch comment, ignores finished reports).
- End-to-end `post_pending_reports` test with faked W&B + GitHub: a failed run with a launch comment is **edited in place**, one without posts fresh.
- `gh_command` SFT test asserts the launch comment carries the run marker (and not the reported marker).
- Full suite: 3114 passed, 708 skipped; `ruff` + `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GobLtXPPbTrMX5FK3ffova

---
_Generated by [Claude Code](https://claude.ai/code/session_01GobLtXPPbTrMX5FK3ffova)_