### PR TITLE
Fix multi-tile prediction placement in factory builder

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -93,6 +93,107 @@ _CH_FOOTPRINT = Channel.FOOTPRINT.value
 # "buildable" is exactly "not UNAVAILABLE" — only the one sentinel is named.
 _FOOTPRINT_UNAVAILABLE = Footprint.UNAVAILABLE.value
 
+
+def apply_placement_action(
+    world_CWH: torch.Tensor,
+    action,
+    *,
+    source_id: int,
+    sink_id: int,
+) -> tuple[bool, Optional[str], Optional[dict]]:
+    """Validate and apply one placement action to ``world_CWH``.
+
+    This is the single source of truth for turning a model prediction into a
+    world mutation. ``FactorioEnv.step`` and the factory-builder UI both call
+    it, so multi-tile footprints, rejection rules, and mirrored channels cannot
+    drift between rollout/training and interactive inference.
+
+    Returns ``(is_invalid, invalid_reason_key, placed_action)``. The final item
+    is the human-readable action record used by the environment, or ``None``
+    when validation rejected the placement.
+    """
+    x, y = action["xy"]
+    entity_id = action["entity"]
+    direc = action["direction"]
+    item_id = action["item"]
+    misc = action["misc"]
+    size_x, size_y = world_CWH.shape[1:3]
+
+    assert 0 <= x < size_x, f"x={x} out of bounds [0, {size_x})"
+    assert 0 <= y < size_y, f"y={y} out of bounds [0, {size_y})"
+
+    invalid_reason_key: Optional[str] = None
+    if not (0 <= entity_id < _N_ENTITIES):
+        return True, None, None
+    if not (0 <= direc < _N_DIRECTIONS):
+        return True, None, None
+    if entity_id in (source_id, sink_id):
+        return True, "placed_source_or_sink", None
+    if entity_id == _ASM_MACHINE_ENT_ID and item_id == _EMPTY_ITEM_VAL:
+        return True, "place_asm_mach_wo_recipe", None
+    if (
+        entity_id not in (_EMPTY_ENT_ID, _ASM_MACHINE_ENT_ID)
+        and direc == _DIR_NONE_VAL
+    ):
+        return True, "placement_wo_direction", None
+    if entity_id == _EMPTY_ENT_ID and direc != _DIR_NONE_VAL:
+        return True, "direction_wo_entity", None
+    if misc == _MISC_NONE_VAL and entity_id == _UG_BELT_ENT_ID:
+        return True, "ug_belt_wo_up_or_down", None
+    if misc != _MISC_NONE_VAL and entity_id != _UG_BELT_ENT_ID:
+        return True, "placement_with_unneeded_misc", None
+
+    # Compute the entity's full footprint (anchor for 1x1, all occupied tiles
+    # for multi-tile). The Rust helper is canonical and handles rotation.
+    proto = entities[entity_id]
+    tiles_list = factorion_rs.py_entity_tiles(
+        x, y, direc, proto.width, proto.height
+    )
+    if tiles_list is None:
+        tiles_list = [(x, y)]
+    tiles_list = [tuple(t) for t in tiles_list]
+
+    # Read and write through a zero-copy numpy view. Besides keeping this hot
+    # rollout path cheap, this makes the all-tiles validation + mutation atomic:
+    # a rejected multi-tile placement never leaves a partial entity behind.
+    world_np = world_CWH.numpy()
+    if any(
+        not (0 <= tx < size_x and 0 <= ty < size_y)
+        for tx, ty in tiles_list
+    ):
+        return True, "too_wide", None
+    if any(
+        world_np[_CH_FOOTPRINT, tx, ty] == _FOOTPRINT_UNAVAILABLE
+        for tx, ty in tiles_list
+    ):
+        return True, "placed_on_masked_tile", None
+    if any(
+        int(world_np[_CH_ENT, tx, ty]) in (source_id, sink_id)
+        for tx, ty in tiles_list
+    ):
+        return True, "replaced_source_or_sink", None
+    if entity_id != _EMPTY_ENT_ID and any(
+        int(world_np[_CH_ENT, tx, ty]) != _EMPTY_ENT_ID
+        for tx, ty in tiles_list
+    ):
+        return True, "placed_on_existing_entity", None
+
+    for tx, ty in tiles_list:
+        world_np[_CH_ENT, tx, ty] = entity_id
+        world_np[_CH_DIR, tx, ty] = direc
+        world_np[_CH_ITEMS, tx, ty] = item_id
+        world_np[_CH_MISC, tx, ty] = misc
+
+    placed_action = {
+        "entity": entities[entity_id].name,
+        "xy": (x, y),
+        "direction": Direction(direc),
+        "item": items[item_id].name,
+        "misc": Misc(misc),
+    }
+    return False, invalid_reason_key, placed_action
+
+
 moving_average_length = 500
 end_of_episode_thputs = deque(maxlen=moving_average_length)
 for _ in range(moving_average_length):
@@ -684,129 +785,28 @@ class FactorioEnv(gym.Env):
         return self._world_CWH.cpu().numpy(), self._get_info()
 
     def step(self, action):
-        x, y = action["xy"]
-        entity_id = action["entity"]
-        direc = action["direction"]
-        item_id = action["item"]
-        misc = action["misc"]
-
-
-        assert 0 <= x < self._world_CWH.shape[1], f"x={x} out of bounds [0, {self._world_CWH.shape[1]})"
-        assert 0 <= y < self._world_CWH.shape[2], f"y={y} out of bounds [0, {self._world_CWH.shape[2]})"
-        source_id = self._source_id
-        sink_id = self._sink_id
-
         self.actions.append(None)
-        action_is_invalid = False
         eot_declared = int(action.get("eot", 0)) == 1
         # Track only which invalid_reason fired (None = valid). The full 10-key
         # dict is built lazily at info time — it's logged-only and read just for
         # finished envs, so building it every step was wasted work.
-        invalid_reason_key = None
-
-        # Check that the action is actually valid
         if eot_declared:
             action_is_invalid = False  # EOT carries no placement to validate.
-        elif not (0 <= entity_id < _N_ENTITIES):
-            action_is_invalid = True
-        elif not (0 <= direc < _N_DIRECTIONS):
-            action_is_invalid = True
-        elif entity_id in (source_id, sink_id):
-            # agent tried to place a source or sink
-            invalid_reason_key = 'placed_source_or_sink'
-            action_is_invalid = True
-        elif entity_id == _ASM_MACHINE_ENT_ID and item_id == _EMPTY_ITEM_VAL:
-            # Model is trying to place an assembling machine without a recipe
-            invalid_reason_key = 'place_asm_mach_wo_recipe'
-            action_is_invalid = True
-        elif entity_id not in (_EMPTY_ENT_ID, _ASM_MACHINE_ENT_ID) and direc == _DIR_NONE_VAL:
-            # Model is trying to put a thing without giving a direction
-            invalid_reason_key = 'placement_wo_direction'
-            action_is_invalid = True
-        elif entity_id == _EMPTY_ENT_ID and direc != _DIR_NONE_VAL:
-            # Model is trying to put a thing without giving a direction
-            invalid_reason_key = 'direction_wo_entity'
-            action_is_invalid = True
-        elif (misc == _MISC_NONE_VAL) and (entity_id == _UG_BELT_ENT_ID):
-            # model is trying to place an underground belt without giving a down/up
-            invalid_reason_key = 'ug_belt_wo_up_or_down'
-            action_is_invalid = True
-        elif (misc != _MISC_NONE_VAL) and (entity_id != _UG_BELT_ENT_ID):
-            # model is trying to place a thing that doesn't need a Misc but
-            # still giving it a Misc
-            invalid_reason_key = 'placement_with_unneeded_misc'
-            action_is_invalid = True
+            invalid_reason_key = None
         else:
-            # Compute the entity's full footprint (anchor for 1x1, all
-            # occupied tiles for multi-tile). py_entity_tiles handles
-            # rotation correctly; the previous x+width/y+height bounds
-            # checks were direction-agnostic and wrong for rotated splitters.
-            proto = entities[entity_id]
-            tiles_list = factorion_rs.py_entity_tiles(x, y, direc, proto.width, proto.height)
-            if tiles_list is None:
-                tiles_list = [(x, y)]
-            tiles_list = [tuple(t) for t in tiles_list]
-
-            # Validate every tile of the footprint. Multi-tile placements
-            # were previously only validated at the anchor, so a splitter
-            # could overlap an existing belt at its secondary tile or
-            # extend off-grid undetected.
-            # Read the FOOTPRINT/ENTITIES channels through a zero-copy numpy view
-            # of the (CPU) world: per-tile torch scalar indexing carries heavy
-            # per-op dispatch overhead in this hot validity path; numpy scalar
-            # reads are far cheaper and give identical values (the world is not
-            # mutated until below, so the view is the pre-placement state).
-            world_np = self._world_CWH.numpy()
-            out_of_bounds = any(
-                not (0 <= tx < self.size and 0 <= ty < self.size)
-                for tx, ty in tiles_list
+            (
+                action_is_invalid,
+                invalid_reason_key,
+                placed_action,
+            ) = apply_placement_action(
+                self._world_CWH,
+                action,
+                source_id=self._source_id,
+                sink_id=self._sink_id,
             )
-            if out_of_bounds:
-                invalid_reason_key = 'too_wide'
-                action_is_invalid = True
-            elif any(
-                world_np[_CH_FOOTPRINT, tx, ty] == _FOOTPRINT_UNAVAILABLE
-                for tx, ty in tiles_list
-            ):
-                invalid_reason_key = 'placed_on_masked_tile'
-                action_is_invalid = True
-            elif any(
-                int(world_np[_CH_ENT, tx, ty]) in (source_id, sink_id)
-                for tx, ty in tiles_list
-            ):
-                invalid_reason_key = 'replaced_source_or_sink'
-                action_is_invalid = True
-            elif entity_id != _EMPTY_ENT_ID and any(
-                int(world_np[_CH_ENT, tx, ty]) != _EMPTY_ENT_ID
-                for tx, ty in tiles_list
-            ):
-                # A real (non-empty) placement may not clobber an existing
-                # entity on any of its footprint tiles. Placing `empty` is
-                # exempt — that is the delete operation. Source/sink overlaps
-                # are caught above with their own, more specific reason.
-                invalid_reason_key = 'placed_on_existing_entity'
-                action_is_invalid = True
-            else:
-                action_is_invalid = False
-                # entity/direction/items/misc at every footprint tile. For a
-                # multi-tile entity (asm, splitter) the recipe/filter and misc
-                # are mirrored across the whole footprint, not just the anchor,
-                # so every tile of the entity carries identical channels.
-                # Written through world_np (aliases _world_CWH).
-                for tx, ty in tiles_list:
-                    world_np[_CH_ENT, tx, ty] = entity_id
-                    world_np[_CH_DIR, tx, ty] = direc
-                    world_np[_CH_ITEMS, tx, ty] = item_id
-                    world_np[_CH_MISC, tx, ty] = misc
-                placed_name = entities[entity_id].name
-                self.actions[-1] = {
-                    'entity': placed_name,
-                    'xy': (x, y),
-                    'direction': Direction(direc),
-                    'item': items[item_id].name,
-                    'misc': Misc(misc),
-                }
-                if placed_name != 'empty':
+            if placed_action is not None:
+                self.actions[-1] = placed_action
+                if placed_action["entity"] != "empty":
                     self._num_placed_entities += 1
 
         self.invalid_actions += 1 if action_is_invalid else 0
@@ -2513,5 +2513,3 @@ if __name__ == "__main__":
     with open(summary_path, "w") as f:
         json.dump(summary, f, indent=2)
     print(f"Summary written to {summary_path}")
-
-

--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -60,6 +60,7 @@ from ppo import (  # noqa: E402
     AgentCNN,
     FactorioEnv,
     _resolve_wandb_checkpoint,
+    apply_placement_action,
     make_env,
 )
 
@@ -133,11 +134,11 @@ class Args:
     checkpoint: Optional[str] = None
     """path to a trained SFT/PPO checkpoint (.pt). If set, the UI shows
     the model's predicted next placement and exposes an Apply button."""
-    wandb_run: Optional[str] = "j0s5y2mc"
+    wandb_run: Optional[str] = "h76h80yb"
     """W&B run id (or full path 'entity/project/run_id'). The run's most
     recent model-type artifact is downloaded to /tmp/factorion-checkpoints
-    and loaded. Mutually exclusive with --checkpoint. Defaults to the
-    canonical SFT run j0s5y2mc (sft-11x11, best_val_throughput 0.335)."""
+    and loaded. Mutually exclusive with --checkpoint. Defaults to run
+    h76h80yb."""
     wandb_project: str = "factorion"
     """W&B project to look in when --wandb-run is a bare id."""
     wandb_entity: Optional[str] = None
@@ -199,6 +200,38 @@ def world_CWH_to_grid(world_CWH: torch.Tensor) -> list[list[dict]]:
             })
         rows.append(row)
     return rows
+
+
+def _apply_prediction(grid: list[list[dict]], prediction: dict) -> dict:
+    """Apply a model prediction through the rollout environment's placement path.
+
+    The browser intentionally does not know entity dimensions or footprint
+    rules. It sends the current grid and predicted action here; this function
+    converts their names to action IDs and delegates the actual validation and
+    mutation to :func:`ppo.apply_placement_action`, the same function used by
+    :meth:`ppo.FactorioEnv.step`.
+    """
+    world_CWH = build_world(grid).permute(2, 0, 1).contiguous()
+    name_to_value = {it.name: it.value for it in items.values()}
+    action = {
+        "xy": (int(prediction["x"]), int(prediction["y"])),
+        "entity": name_to_value[prediction["entity"]],
+        "direction": Direction[prediction["direction"]].value,
+        "item": name_to_value[prediction["item"]],
+        "misc": Misc[prediction["misc"]].value,
+        "eot": 0,
+    }
+    is_invalid, invalid_reason, _placed_action = apply_placement_action(
+        world_CWH,
+        action,
+        source_id=name_to_value["stack_inserter"],
+        sink_id=name_to_value["bulk_inserter"],
+    )
+    return {
+        "applied": not is_invalid,
+        "invalid_reason": invalid_reason,
+        "grid": world_CWH_to_grid(world_CWH),
+    }
 
 
 # Cap retries so a misconfigured (size, kind) pair fails fast with a
@@ -984,6 +1017,7 @@ let autoApplying = false;
 let autoApplyGeneration = 0;
 let autoApplyFrame = null;
 let autoApplyHoldTimer = null;
+let applyKeyHeld = false;
 
 function emptyCell() {{
   return {{
@@ -1355,21 +1389,43 @@ async function requestFastPrediction() {{
   return data;
 }}
 
-// Apply a single predicted placement to the grid, exactly as if the
-// user had placed it by hand. `cand` is either a ghost candidate or the
-// argmax `prediction` itself — both carry {{x, y, entity, direction,
-// item, misc}}, so the same code applies either. footprint is preserved
-// (the model never predicts it).
-function applyCandidate(cand, interactive = true) {{
+// Apply through the server-side placement function shared with
+// FactorioEnv.step. The browser deliberately has no copy of multi-tile
+// geometry or action-validity rules.
+async function applyCandidate(cand, interactive = true) {{
   const {{ x, y, entity, direction, item, misc }} = cand;
-  grid[y][x] = {{
-    entity, direction, item, misc, footprint: grid[y][x].footprint,
-  }};
-  selected = {{ x, y }};
-  prediction = null;
-  if (interactive) {{
-    renderGrid(); syncEditor();
-    scheduleCompute();
+  const info = document.getElementById('model-info');
+  try {{
+    const resp = await fetch('/apply_prediction', {{
+      method: 'POST',
+      headers: {{ 'Content-Type': 'application/json' }},
+      body: JSON.stringify({{ grid, prediction: {{
+        x, y, entity, direction, item, misc,
+      }} }}),
+    }});
+    const data = await resp.json();
+    if (data.error) {{
+      if (info) info.textContent = 'apply failed: ' + data.error;
+      return false;
+    }}
+    if (!data.applied) {{
+      if (info) {{
+        info.textContent =
+          'prediction rejected: ' + (data.invalid_reason || 'invalid action');
+      }}
+      return false;
+    }}
+    grid = data.grid;
+    selected = {{ x, y }};
+    prediction = null;
+    if (interactive) {{
+      renderGrid(); syncEditor();
+      scheduleCompute();
+    }}
+    return true;
+  }} catch (e) {{
+    if (info) info.textContent = 'apply failed: ' + e;
+    return false;
   }}
 }}
 
@@ -1395,7 +1451,11 @@ async function runAutoApply(generation) {{
     while (autoApplying && generation === autoApplyGeneration) {{
       const action = await requestFastPrediction();
       if (!autoApplying || generation !== autoApplyGeneration) break;
-      applyCandidate(action, false);
+      const applied = await applyCandidate(action, false);
+      if (!applied) {{
+        autoApplying = false;
+        break;
+      }}
       count += 1;
       renderAutoApplyFrame();
       if (info) {{
@@ -1437,22 +1497,28 @@ function stopAutoApply() {{
 
 function beginApplyKey() {{
   if (!modelLoaded) return;
+  applyKeyHeld = true;
   clearTimeout(_predictionTimer);
   clearTimeout(_graphTimer);
   // Preserve tap-to-apply: consume the visible prediction once, then only
   // enter the continuous request pump if the key remains down.
+  let firstApply = Promise.resolve(true);
   if (prediction) {{
-    applyCandidate(prediction, false);
-    renderAutoApplyFrame();
+    firstApply = applyCandidate(prediction, false);
+    firstApply.then((applied) => {{
+      if (applied) renderAutoApplyFrame();
+    }});
   }}
   clearTimeout(autoApplyHoldTimer);
-  autoApplyHoldTimer = setTimeout(() => {{
+  autoApplyHoldTimer = setTimeout(async () => {{
     autoApplyHoldTimer = null;
-    startAutoApply();
+    const applied = await firstApply;
+    if (applyKeyHeld && applied) startAutoApply();
   }}, 120);
 }}
 
 function endApplyKey() {{
+  applyKeyHeld = false;
   clearTimeout(autoApplyHoldTimer);
   autoApplyHoldTimer = null;
   if (autoApplying) {{
@@ -1681,7 +1747,7 @@ document.addEventListener('keyup', (ev) => {{
 }});
 
 function cancelApplyKeyIfActive() {{
-  if (autoApplying || autoApplyHoldTimer !== null) endApplyKey();
+  if (applyKeyHeld || autoApplying || autoApplyHoldTimer !== null) endApplyKey();
 }}
 // A lost keyup (for example, switching windows while holding a) must not
 // leave the request pump running in the background.
@@ -1767,7 +1833,13 @@ class Handler(BaseHTTPRequestHandler):
         self.send_error(404)
 
     def do_POST(self):  # noqa: N802
-        if self.path not in ("/graph", "/predict", "/load_model", "/load_lesson"):
+        if self.path not in (
+            "/graph",
+            "/predict",
+            "/apply_prediction",
+            "/load_model",
+            "/load_lesson",
+        ):
             self.send_error(404)
             return
         length = int(self.headers.get("Content-Length", "0"))
@@ -1781,6 +1853,10 @@ class Handler(BaseHTTPRequestHandler):
                     result = _predict_action(payload["grid"])
                 else:
                     result = _predict(payload["grid"])
+            elif self.path == "/apply_prediction":
+                result = _apply_prediction(
+                    payload["grid"], payload["prediction"]
+                )
             elif self.path == "/load_lesson":
                 result = _load_lesson(
                     kind_name=payload["kind"],

--- a/tests/test_factory_builder.py
+++ b/tests/test_factory_builder.py
@@ -91,6 +91,10 @@ def _empty_grid(size: int) -> list[list[dict]]:
     ]
 
 
+def test_default_wandb_run():
+    assert fb.Args().wandb_run == "h76h80yb"
+
+
 # ── Pure helpers ────────────────────────────────────────────────────────────
 
 class TestTopP:
@@ -163,6 +167,117 @@ class TestBuildWorld:
         world = fb.build_world(grid)
         assert int(world[0, 0, fb.Channel.FOOTPRINT.value]) == \
             fb.Footprint.UNAVAILABLE.value
+
+
+class TestApplyPrediction:
+    """The web UI delegates placement to the rollout's shared mutation path."""
+
+    @staticmethod
+    def _prediction(
+        *,
+        x: int,
+        y: int,
+        entity: str,
+        direction: str,
+        item: str = "empty",
+        misc: str = "NONE",
+    ) -> dict:
+        return {
+            "x": x,
+            "y": y,
+            "entity": entity,
+            "direction": direction,
+            "item": item,
+            "misc": misc,
+        }
+
+    def test_assembler_prediction_fills_same_3x3_world_footprint_as_rollout(
+        self,
+    ):
+        out = fb._apply_prediction(
+            _empty_grid(5),
+            self._prediction(
+                x=0,
+                y=1,
+                entity="assembling_machine_1",
+                direction="NONE",
+                item="electronic_circuit",
+            ),
+        )
+
+        assert out["applied"] is True
+        placed = {
+            (x, y)
+            for y, row in enumerate(out["grid"])
+            for x, cell in enumerate(row)
+            if cell["entity"] == "assembling_machine_1"
+        }
+        assert placed == {(x, y) for x in range(3) for y in range(1, 4)}
+        for x, y in placed:
+            assert out["grid"][y][x]["item"] == "electronic_circuit"
+
+    @pytest.mark.parametrize(
+        ("direction", "expected"),
+        [
+            ("EAST", {(2, 2), (2, 3)}),
+            ("WEST", {(2, 2), (2, 3)}),
+            ("NORTH", {(2, 2), (3, 2)}),
+            ("SOUTH", {(2, 2), (3, 2)}),
+        ],
+    )
+    def test_splitter_prediction_fills_rotated_two_tile_footprint(
+        self, direction, expected
+    ):
+        out = fb._apply_prediction(
+            _empty_grid(5),
+            self._prediction(
+                x=2, y=2, entity="splitter", direction=direction
+            ),
+        )
+        placed = {
+            (x, y)
+            for y, row in enumerate(out["grid"])
+            for x, cell in enumerate(row)
+            if cell["entity"] == "splitter"
+        }
+        assert out["applied"] is True
+        assert placed == expected
+
+    def test_prediction_calls_shared_rollout_placement_function(
+        self, monkeypatch
+    ):
+        called = 0
+        shared_apply = fb.apply_placement_action
+
+        def recording_apply(*args, **kwargs):
+            nonlocal called
+            called += 1
+            return shared_apply(*args, **kwargs)
+
+        monkeypatch.setattr(fb, "apply_placement_action", recording_apply)
+        fb._apply_prediction(
+            _empty_grid(3),
+            self._prediction(
+                x=1, y=1, entity="transport_belt", direction="EAST"
+            ),
+        )
+        assert called == 1
+
+    def test_invalid_multitile_prediction_is_rejected_atomically(self):
+        grid = _empty_grid(5)
+        grid[3][2]["entity"] = "transport_belt"
+        grid[3][2]["direction"] = "EAST"
+
+        out = fb._apply_prediction(
+            grid,
+            self._prediction(
+                x=2, y=2, entity="splitter", direction="EAST"
+            ),
+        )
+
+        assert out["applied"] is False
+        assert out["invalid_reason"] == "placed_on_existing_entity"
+        assert out["grid"] == grid
 
 
 # ── Graph rendering (Rust-backed) ───────────────────────────────────────────
@@ -497,9 +612,7 @@ class TestPredictSchema:
 
 class TestRenderIndexApplyWiring:
     """The served HTML must wire clicking a ghosted tile to applying that
-    candidate. This is JS embedded in a Python string, so we assert on the
-    rendered markup rather than driving a browser — enough to catch the
-    wiring being dropped or the candidate field contract drifting."""
+    candidate through the server-side rollout placement path."""
 
     def test_click_applies_visible_candidate(self):
         html = fb.render_index(default_size=11)
@@ -516,6 +629,9 @@ class TestRenderIndexApplyWiring:
         _predict emits per candidate — keep the two in lockstep."""
         html = fb.render_index(default_size=11)
         assert "const { x, y, entity, direction, item, misc } = cand;" in html
+        assert "fetch('/apply_prediction'" in html
+        assert "body: JSON.stringify({ grid, prediction:" in html
+        assert "grid = data.grid;" in html
         # The same fields _predict guarantees on each candidate (see
         # TestPredictSchema.test_predict_returns_full_schema).
         path = _make_tiny_checkpoint(size=4, chan=8)


### PR DESCRIPTION
## What changed

- Extract the model placement mutation into `apply_placement_action`, shared by `FactorioEnv.step` and the factory builder.
- Route interactive and fast autoregressive UI applications through a server endpoint that uses the shared placement path.
- Expand assembler and splitter predictions to their complete canonical footprints, including rotated splitters.
- Reject invalid multi-tile placements atomically instead of partially updating the browser grid.
- Change the factory builder's default W&B run to `h76h80yb`.
- Add regression coverage for assembler footprints, splitter orientations, atomic rejection, shared-function delegation, and the default run.

## Why

The policy predicts one anchor tile for a multi-tile entity. Rollout/PPO placement expands that anchor into the full entity footprint, but the browser previously wrote only the anchor cell. Applying a prediction in the UI therefore produced a different next world from the one seen during training and evaluation.

Keeping placement logic in one shared function prevents the UI and rollout environment from drifting again.

## User impact

Applying assembler and splitter predictions in the factory builder now produces the same world state the model receives in rollout. The incoming fast held-key prediction workflow remains supported and also uses the shared placement rules.

## Validation

- Full pre-push hook: `3174 passed, 708 skipped`
- Focused UI/placement/spatial tests: `116 passed`
- `ruff check`: passed
- `ty check`: passed
- Live local `/apply_prediction` endpoint verified with a 3x3 assembler placement
