### PR TITLE
Log-compress the terminal reward across lesson scales

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -1,4 +1,5 @@
 import json
+import math
 import os
 import contextlib
 import typing
@@ -236,6 +237,8 @@ def _run_signature(args) -> str:
         sig += f"-kl{args.target_kl:g}"
     if args.critic_warmup:
         sig += f"-cw{args.critic_warmup}"
+    if args.reward_symlog_r0:
+        sig += f"-r0{args.reward_symlog_r0:g}"
     if args.start_from:
         sig += f"-from{args.start_from}"
     sig += f"-c{layers}-seed{args.seed}"
@@ -507,11 +510,13 @@ def make_env(
     size,
     run_name,
     entity_cost_scale=PpoArgs.entity_cost_scale,
+    reward_symlog_r0=PpoArgs.reward_symlog_r0,
 ):
     def thunk():
         kwargs: dict[str, Any] = {"render_mode": "rgb_array"} if capture_video else {}
         kwargs.update({'size': size, 'max_steps': size*size, 'idx': idx,
-                       'entity_cost_scale': entity_cost_scale})
+                       'entity_cost_scale': entity_cost_scale,
+                       'reward_symlog_r0': reward_symlog_r0})
         env = gym.make(env_id, **kwargs)
         if capture_video:
             env = gym.wrappers.RecordVideo(env, f"videos/{run_name}/env_{idx}", episode_trigger=lambda e: (e+1) % 10 == 0)
@@ -577,11 +582,15 @@ class FactorioEnv(gym.Env):
         idx: Optional[int] = None,
         options: Optional[dict] = None,
         entity_cost_scale: float = PpoArgs.entity_cost_scale,
+        reward_symlog_r0: float = PpoArgs.reward_symlog_r0,
     ):
         super().__init__()
         if entity_cost_scale < 0:
             raise ValueError("entity_cost_scale must be non-negative")
+        if reward_symlog_r0 < 0:
+            raise ValueError("reward_symlog_r0 must be non-negative")
         self.entity_cost_scale = entity_cost_scale
+        self.reward_symlog_r0 = reward_symlog_r0
         if render_mode is not None:
             self.metadata = {"render_modes": [render_mode], "render_fps": 2}
             self.render_mode = render_mode
@@ -928,10 +937,19 @@ class FactorioEnv(gym.Env):
 
         reward = 0.0
         if terminated or truncated:
-            # Multiplication makes cost a secondary modifier of achieved
-            # throughput: a no-output factory always earns zero terminal
-            # throughput reward, however many entities it contains.
-            reward = thput_raw * cost_efficiency
+            if self.reward_symlog_r0 > 0:
+                # Log-compressed throughput so lessons whose ceilings differ by
+                # ~360x contribute comparable gradient; cost then rides along as
+                # an additive penalty whose bite no longer depends on which
+                # lesson (i.e. which reward scale) the episode came from.
+                reward = math.log1p(
+                    thput_raw / self.reward_symlog_r0
+                ) - math.log1p(self.entity_cost_scale * entity_cost)
+            else:
+                # Multiplication makes cost a secondary modifier of achieved
+                # throughput: a no-output factory always earns zero terminal
+                # throughput reward, however many entities it contains.
+                reward = thput_raw * cost_efficiency
 
         self._thput_raw = thput_raw
         self._thput_normed = thput_normed
@@ -1864,6 +1882,7 @@ if __name__ == "__main__":
             args.size,
             run_name,
             args.entity_cost_scale,
+            args.reward_symlog_r0,
         )
         for i in range(args.num_envs)
     ]
@@ -2445,6 +2464,7 @@ if __name__ == "__main__":
                     args.size,
                     run_name,
                     args.entity_cost_scale,
+                    args.reward_symlog_r0,
                 )
                 for i in range(num_render_envs)
             ])

--- a/ppo.py
+++ b/ppo.py
@@ -237,8 +237,6 @@ def _run_signature(args) -> str:
         sig += f"-kl{args.target_kl:g}"
     if args.critic_warmup:
         sig += f"-cw{args.critic_warmup}"
-    if args.reward_symlog_r0:
-        sig += f"-r0{args.reward_symlog_r0:g}"
     if args.start_from:
         sig += f"-from{args.start_from}"
     sig += f"-c{layers}-seed{args.seed}"
@@ -937,19 +935,17 @@ class FactorioEnv(gym.Env):
 
         reward = 0.0
         if terminated or truncated:
+            # Multiplication makes cost a secondary modifier of achieved
+            # throughput: a no-output factory always earns zero terminal
+            # throughput reward, however many entities it contains.
+            reward = thput_raw * cost_efficiency
             if self.reward_symlog_r0 > 0:
-                # Log-compressed throughput so lessons whose ceilings differ by
-                # ~360x contribute comparable gradient; cost then rides along as
-                # an additive penalty whose bite no longer depends on which
-                # lesson (i.e. which reward scale) the episode came from.
-                reward = math.log1p(
-                    thput_raw / self.reward_symlog_r0
-                ) - math.log1p(self.entity_cost_scale * entity_cost)
-            else:
-                # Multiplication makes cost a secondary modifier of achieved
-                # throughput: a no-output factory always earns zero terminal
-                # throughput reward, however many entities it contains.
-                reward = thput_raw * cost_efficiency
+                # Compress so lessons whose ceilings differ by ~360x contribute
+                # comparable gradient. Compressing the cost-adjusted reward
+                # rather than subtracting a log-space cost term keeps zero
+                # throughput at exactly zero; above the knee the two agree to
+                # <0.005 anyway, since log1p(x*ce/r0) -> ln(x/r0) - ln(1/ce).
+                reward = math.log1p(reward / self.reward_symlog_r0)
 
         self._thput_raw = thput_raw
         self._thput_normed = thput_normed

--- a/tests/test_early_termination.py
+++ b/tests/test_early_termination.py
@@ -24,11 +24,10 @@ def _make_env(size=5, max_steps=10, **kwargs):
 
 def _expected_reward(env, info):
     """The terminal reward the env's configured scheme should have paid."""
+    reward = info["thput_raw"] * info["cost_efficiency"]
     if env.reward_symlog_r0 > 0:
-        return math.log1p(
-            info["thput_raw"] / env.reward_symlog_r0
-        ) - math.log1p(env.entity_cost_scale * info["entity_cost"])
-    return info["thput_raw"] * info["cost_efficiency"]
+        return math.log1p(reward / env.reward_symlog_r0)
+    return reward
 
 
 def _noop_action():
@@ -105,8 +104,10 @@ class TestEarlyTermination:
 
 
 class TestReward:
-    """Reward = log1p(raw_throughput / r0) - log1p(scale * entity_cost),
-    or raw_throughput * cost_efficiency when the log transform is disabled."""
+    """Reward = raw_throughput * cost_efficiency, log-compressed at r0 unless
+    the compression is disabled. The cost multiplier is bounded in (0, 1] and
+    log1p is non-negative on it, so cost can reduce reward but never make it
+    negative under either scheme."""
 
     def test_solved_factory_with_eot_pays_raw_throughput_reward(self):
         """Declaring eot on a solved factory pays cost-adjusted raw throughput."""
@@ -195,13 +196,18 @@ class TestReward:
         assert 0 < info["cost_efficiency"] < 1
         assert reward < info["thput_raw"]
 
-    def test_zero_throughput_cost_penalty_is_never_negative_without_log(self):
+    @pytest.mark.parametrize("reward_symlog_r0", [0.0, 0.01])
+    def test_zero_throughput_cost_penalty_is_never_negative(self, reward_symlog_r0):
+        """Entities that deliver nothing must score exactly zero, not negative:
+        else an empty grid beats a nearly-complete factory and the policy is
+        rewarded for building nothing. Holds under either scheme because the
+        cost multiplier is bounded in (0, 1] and log1p(0) == 0."""
         env = FactorioEnv(
             size=5,
             max_steps=10,
             idx=0,
             entity_cost_scale=1_000_000.0,
-            reward_symlog_r0=0.0,
+            reward_symlog_r0=reward_symlog_r0,
         )
         env.reset(seed=42, options={"num_missing_entities": 99})
 
@@ -228,36 +234,6 @@ class TestReward:
         assert info["thput_raw"] == 0
         assert info["entity_cost"] == pytest.approx(2.0)
         assert reward == 0
-
-    def test_log_reward_pays_negative_for_zero_throughput_with_cost(self):
-        """The log-space cost term is subtracted, so entities that deliver
-        nothing are worse than an empty grid rather than merely equal to it."""
-        env = _make_env(size=5, max_steps=10)
-        env.reset(seed=42, options={"num_missing_entities": 99})
-
-        entity_grid = env._world_CWH[Channel.ENTITIES.value]
-        markers = np.argwhere(
-            (entity_grid.numpy() == env._source_id)
-            | (entity_grid.numpy() == env._sink_id)
-        )
-        x, y = next(
-            (int(x), int(y))
-            for x, y in np.argwhere(entity_grid.numpy() == 0)
-            if all(abs(x - mx) + abs(y - my) > 1 for mx, my in markers)
-        )
-        entity_grid[x, y] = str2ent("transport_belt").value
-        env._world_CWH[Channel.DIRECTION.value, x, y] = Direction.NORTH.value
-
-        action = _noop_action()
-        action["eot"] = 1
-        _, reward, terminated, _, info = env.step(action)
-
-        assert terminated is True
-        assert info["thput_raw"] == 0
-        assert reward == pytest.approx(
-            -math.log1p(env.entity_cost_scale * info["entity_cost"])
-        )
-        assert reward < 0
 
 
 class TestLogRewardScaleCompression:

--- a/tests/test_early_termination.py
+++ b/tests/test_early_termination.py
@@ -1,5 +1,6 @@
 """Tests for early termination when the agent solves the puzzle."""
 
+import math
 import os
 import sys
 
@@ -12,13 +13,22 @@ os.environ["WANDB_DISABLED"] = "true"
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from factorion import Channel, Direction, str2ent  # noqa: E402
+from factorion import Channel, Direction, LessonKind, str2ent  # noqa: E402
 from ppo import FactorioEnv  # noqa: E402
 
 
-def _make_env(size=5, max_steps=10):
+def _make_env(size=5, max_steps=10, **kwargs):
     """Create a FactorioEnv for testing."""
-    return FactorioEnv(size=size, max_steps=max_steps, idx=0)
+    return FactorioEnv(size=size, max_steps=max_steps, idx=0, **kwargs)
+
+
+def _expected_reward(env, info):
+    """The terminal reward the env's configured scheme should have paid."""
+    if env.reward_symlog_r0 > 0:
+        return math.log1p(
+            info["thput_raw"] / env.reward_symlog_r0
+        ) - math.log1p(env.entity_cost_scale * info["entity_cost"])
+    return info["thput_raw"] * info["cost_efficiency"]
 
 
 def _noop_action():
@@ -95,8 +105,8 @@ class TestEarlyTermination:
 
 
 class TestReward:
-    """Reward = raw_throughput * cost_efficiency. The multiplier is bounded
-    in (0, 1], so cost can reduce reward but never make it negative."""
+    """Reward = log1p(raw_throughput / r0) - log1p(scale * entity_cost),
+    or raw_throughput * cost_efficiency when the log transform is disabled."""
 
     def test_solved_factory_with_eot_pays_raw_throughput_reward(self):
         """Declaring eot on a solved factory pays cost-adjusted raw throughput."""
@@ -109,8 +119,7 @@ class TestReward:
 
         assert terminated is True
         assert info["thput_normed"] >= 1.0
-        expected = info["thput_raw"] * info["cost_efficiency"]
-        assert reward == pytest.approx(expected)
+        assert reward == pytest.approx(_expected_reward(env, info))
 
     def test_mid_episode_reward_is_zero(self):
         env = _make_env(size=5, max_steps=20)
@@ -134,8 +143,7 @@ class TestReward:
 
         assert truncated is True
         assert terminated is False
-        expected = info["thput_raw"] * info["cost_efficiency"]
-        assert reward == pytest.approx(expected)
+        assert reward == pytest.approx(_expected_reward(env, info))
 
     def test_eot_action_terminates_episode(self):
         """A non-solved factory ends immediately when the agent declares eot=1,
@@ -152,13 +160,27 @@ class TestReward:
         assert truncated is False
         assert info["frac_invalid_actions"] == 0
         assert info["thput_normed"] < 1.0  # ended early, not a full solve
-        expected = info["thput_raw"] * info["cost_efficiency"]
-        assert reward == pytest.approx(expected)
+        assert reward == pytest.approx(_expected_reward(env, info))
 
-    def test_entity_cost_reduces_reward_multiplicatively(self):
-        """A non-zero entity cost reduces throughput reward without an
-        additive subtraction."""
+    def test_entity_cost_reduces_reward(self):
+        """A non-zero entity cost lowers the reward below the pure
+        throughput term."""
         env = _make_env(size=5, max_steps=10)
+        env.entity_cost_scale = 0.01
+        env.reset(seed=42, options={"num_missing_entities": 0})
+
+        action = _noop_action()
+        action["eot"] = 1
+        _, reward, terminated, _, info = env.step(action)
+
+        assert terminated is True
+        assert reward == pytest.approx(_expected_reward(env, info))
+        assert info["entity_cost"] > 0
+        assert reward < math.log1p(info["thput_raw"] / env.reward_symlog_r0)
+
+    def test_entity_cost_reduces_reward_multiplicatively_without_log(self):
+        """With the log transform off, cost is a multiplier bounded in (0, 1]."""
+        env = _make_env(size=5, max_steps=10, reward_symlog_r0=0.0)
         env.entity_cost_scale = 0.01
         env.reset(seed=42, options={"num_missing_entities": 0})
 
@@ -173,12 +195,13 @@ class TestReward:
         assert 0 < info["cost_efficiency"] < 1
         assert reward < info["thput_raw"]
 
-    def test_zero_throughput_cost_penalty_is_never_negative(self):
+    def test_zero_throughput_cost_penalty_is_never_negative_without_log(self):
         env = FactorioEnv(
             size=5,
             max_steps=10,
             idx=0,
             entity_cost_scale=1_000_000.0,
+            reward_symlog_r0=0.0,
         )
         env.reset(seed=42, options={"num_missing_entities": 99})
 
@@ -205,6 +228,65 @@ class TestReward:
         assert info["thput_raw"] == 0
         assert info["entity_cost"] == pytest.approx(2.0)
         assert reward == 0
+
+    def test_log_reward_pays_negative_for_zero_throughput_with_cost(self):
+        """The log-space cost term is subtracted, so entities that deliver
+        nothing are worse than an empty grid rather than merely equal to it."""
+        env = _make_env(size=5, max_steps=10)
+        env.reset(seed=42, options={"num_missing_entities": 99})
+
+        entity_grid = env._world_CWH[Channel.ENTITIES.value]
+        markers = np.argwhere(
+            (entity_grid.numpy() == env._source_id)
+            | (entity_grid.numpy() == env._sink_id)
+        )
+        x, y = next(
+            (int(x), int(y))
+            for x, y in np.argwhere(entity_grid.numpy() == 0)
+            if all(abs(x - mx) + abs(y - my) > 1 for mx, my in markers)
+        )
+        entity_grid[x, y] = str2ent("transport_belt").value
+        env._world_CWH[Channel.DIRECTION.value, x, y] = Direction.NORTH.value
+
+        action = _noop_action()
+        action["eot"] = 1
+        _, reward, terminated, _, info = env.step(action)
+
+        assert terminated is True
+        assert info["thput_raw"] == 0
+        assert reward == pytest.approx(
+            -math.log1p(env.entity_cost_scale * info["entity_cost"])
+        )
+        assert reward < 0
+
+
+class TestLogRewardScaleCompression:
+    """The point of the log transform: lessons whose achievable items/s differ
+    by orders of magnitude must not differ by orders of magnitude in reward."""
+
+    def _solved_reward(self, kind, size=11):
+        """Terminal reward for eot on an already-solved factory of `kind`."""
+        env = _make_env(size=size, max_steps=10)
+        env.reset(seed=7, options={"num_missing_entities": 0, "kind": kind})
+        action = _noop_action()
+        action["eot"] = 1
+        _, reward, _, _, info = env.step(action)
+        return reward, info["thput_raw"]
+
+    def test_belt_and_assembler_rewards_are_within_one_order_of_magnitude(self):
+        belt_r, belt_thput = self._solved_reward(LessonKind.MOVE_ONE_ITEM)
+        asm_r, asm_thput = self._solved_reward(
+            LessonKind.MEMORISE_4_INGREDIENT_RECIPES
+        )
+
+        raw_ratio = belt_thput / asm_thput
+        reward_ratio = belt_r / asm_r
+
+        assert raw_ratio > 50, "expected a large raw items/s gap between lessons"
+        assert reward_ratio < 10, (
+            f"log reward still spreads lessons {reward_ratio:.1f}x "
+            f"(raw gap {raw_ratio:.1f}x)"
+        )
 
 
 class TestStepsTaken:

--- a/tests/test_rl_from_checkpoint.py
+++ b/tests/test_rl_from_checkpoint.py
@@ -143,6 +143,10 @@ class TestEotTerminationAndMetrics:
         a = PpoArgs()
         assert a.entity_cost_scale == 0.001
 
+    def test_reward_symlog_r0_default(self):
+        a = PpoArgs()
+        assert a.reward_symlog_r0 == 0.01
+
 
 class TestCriticWarmupParamSplit:
     def _split(self, agent):

--- a/training_config.py
+++ b/training_config.py
@@ -143,27 +143,27 @@ class PpoArgs(SharedArgs):
     vf_coef: float = 0.794
     """coefficient of the value function"""
     entity_cost_scale: float = 0.001
-    """strength of the terminal entity-cost penalty. Each entity costs its
-    per-output recursively-expanded raw-item count plus cumulative craft time.
-    With reward_symlog_r0 > 0 the penalty is additive in log space
-    (- log1p(entity_cost_scale * cost)); otherwise the reward is raw
-    items/second divided by (1 + entity_cost_scale * cost). 0 disables the
-    penalty."""
+    """strength of the multiplicative terminal entity-cost penalty. Each
+    entity costs its per-output recursively-expanded raw-item count plus
+    cumulative craft time; terminal reward is raw items/second divided by
+    (1 + entity_cost_scale * cost). This keeps zero-throughput reward at zero
+    and never makes the throughput component negative. 0 disables the penalty."""
     reward_symlog_r0: float = 0.01
-    """reference flow (items/s) for the log-compressed terminal reward
-    `log1p(thput_raw / r0) - log1p(entity_cost_scale * cost)`.
+    """reference flow (items/s) at which the terminal reward is log-compressed:
+    `log1p(thput_raw * cost_efficiency / r0)`.
     Solved lessons differ ~360x in achievable items/s (belts 15, MEMORISE_2
-    0.043), so raw reward hands belt lessons two orders of magnitude more
-    gradient than assembler lessons and leaves the small end under a shared
-    critic's error floor. log1p turns those multiplicative scale gaps into
-    additive offsets, which baselines subtract off for free; r0 puts the
-    smallest flow we care about at the knee of the log (r0=1 would be plain
+    0.043), so an uncompressed reward hands belt lessons two orders of
+    magnitude more gradient than assembler lessons and leaves the small end
+    under a shared critic's error floor. log1p turns those multiplicative scale
+    gaps into additive offsets, which baselines subtract off for free; r0 puts
+    the smallest flow we care about at the knee of the log (r0=1 would be plain
     symlog, which only compresses the top and still leaves ~66x, while r0=0.01
-    brings the spread to ~4.5x). Being a monotone transform of
-    a terminal-only reward it cannot change which factory is optimal per
-    lesson, only how gradient is shared across them. Note the cost term is now
-    a subtraction, so a zero-throughput factory scores slightly negative rather
-    than zero. 0 restores the multiplicative raw-throughput reward."""
+    brings the spread to ~4.5x). Being a monotone transform of a terminal-only
+    reward it cannot change which factory is optimal per lesson, only how
+    gradient is shared across them; compressing the cost-adjusted reward (as
+    opposed to subtracting a log-space cost term) also keeps zero throughput at
+    exactly zero, so a factory that delivers nothing is never worse than an
+    empty grid. 0 disables the compression."""
     max_grad_norm: float = 1.221
     """the maximum norm for the gradient clipping"""
     target_kl: Optional[float] = 0.02

--- a/training_config.py
+++ b/training_config.py
@@ -143,11 +143,27 @@ class PpoArgs(SharedArgs):
     vf_coef: float = 0.794
     """coefficient of the value function"""
     entity_cost_scale: float = 0.001
-    """strength of the multiplicative terminal entity-cost penalty. Each
-    entity costs its per-output recursively-expanded raw-item count plus
-    cumulative craft time; terminal reward is raw items/second divided by
-    (1 + entity_cost_scale * cost). This keeps zero-throughput reward at zero
-    and never makes the throughput component negative. 0 disables the penalty."""
+    """strength of the terminal entity-cost penalty. Each entity costs its
+    per-output recursively-expanded raw-item count plus cumulative craft time.
+    With reward_symlog_r0 > 0 the penalty is additive in log space
+    (- log1p(entity_cost_scale * cost)); otherwise the reward is raw
+    items/second divided by (1 + entity_cost_scale * cost). 0 disables the
+    penalty."""
+    reward_symlog_r0: float = 0.01
+    """reference flow (items/s) for the log-compressed terminal reward
+    `log1p(thput_raw / r0) - log1p(entity_cost_scale * cost)`.
+    Solved lessons differ ~360x in achievable items/s (belts 15, MEMORISE_2
+    0.043), so raw reward hands belt lessons two orders of magnitude more
+    gradient than assembler lessons and leaves the small end under a shared
+    critic's error floor. log1p turns those multiplicative scale gaps into
+    additive offsets, which baselines subtract off for free; r0 puts the
+    smallest flow we care about at the knee of the log (r0=1 would be plain
+    symlog, which only compresses the top and still leaves ~66x, while r0=0.01
+    brings the spread to ~4.5x). Being a monotone transform of
+    a terminal-only reward it cannot change which factory is optimal per
+    lesson, only how gradient is shared across them. Note the cost term is now
+    a subtraction, so a zero-throughput factory scores slightly negative rather
+    than zero. 0 restores the multiplicative raw-throughput reward."""
     max_grad_norm: float = 1.221
     """the maximum norm for the gradient clipping"""
     target_kl: Optional[float] = 0.02


### PR DESCRIPTION
## Why

Lesson ceilings differ by orders of magnitude in items/s, so an uncompressed terminal reward gives belt lessons ~100x more gradient than assembler lessons, and leaves the small end below a shared critic's error floor. Measured on solved factories (`num_missing_entities=0`, eot immediately, seed 7, size 11) — "share" is each lesson's reward as a fraction of the largest, i.e. roughly its slice of the gradient budget:

| lesson | thput (i/s) | cost | reward (main) | share | reward (PR) | share |
|---|---:|---:|---:|---:|---:|---:|
| MOVE_ONE_ITEM | 15.000 | 20.0 | 14.706 | 100.0% | 7.294 | 100.0% |
| SPLITTER_MERGE_SIDELOADED | 15.000 | 70.8 | 14.009 | 95.3% | 7.246 | 99.3% |
| MOVE_VIA_UG_BELT | 15.000 | 45.0 | 14.354 | 97.6% | 7.270 | 99.7% |
| MOVE_ONE_ITEM_CHAOS | 15.000 | 32.0 | 14.535 | 98.8% | 7.282 | 99.8% |
| CROSS_UNDER_BELT | 15.000 | 67.0 | 14.058 | 95.6% | 7.249 | 99.4% |
| SPLITTER_SPLIT | 7.500 | 66.8 | 7.031 | 47.8% | 6.557 | 89.9% |
| FACTORY_1_INGREDIENT | 4.378 | 242.5 | 3.523 | 24.0% | 5.867 | 80.4% |
| MEMORISE_1_INGREDIENT_RECIPES | 0.860 | 52.8 | 0.817 | 5.6% | 4.415 | 60.5% |
| MEMORISE_4_INGREDIENT_RECIPES | 0.172 | 82.0 | 0.159 | 1.1% | 2.827 | 38.8% |
| MEMORISE_3_INGREDIENT_RECIPES | 0.086 | 72.2 | 0.080 | 0.5% | 2.200 | 30.2% |
| MEMORISE_2_INGREDIENT_RECIPES | 0.043 | 62.5 | 0.040 | 0.3% | 1.619 | 22.2% |
| **spread (max/min)** | | | **363x** | | **4.5x** | |

The gap is a cliff, not a gradient: the five 15 i/s belt lessons already sit within 5% of each other, then SPLITTER_SPLIT halves and the MEMORISE lessons fall to 0.3–5.6%. Note MEMORISE ordering is non-monotonic in ingredient count (1 → 0.860, 2 → 0.043, 3 → 0.086, 4 → 0.172) — that's recipe crafting-time structure, not difficulty, and those four lessons span 20x among themselves before compression.

## What changed

One line in `FactorioEnv.step`'s terminal reward:

```python
reward = thput_raw * cost_efficiency          # unchanged
if self.reward_symlog_r0 > 0:
    reward = math.log1p(reward / self.reward_symlog_r0)
```

with `r0 = PpoArgs.reward_symlog_r0 = 0.01` items/s. Everything downstream — GAE, returns, critic, advantages — then lives consistently in compressed space.

- **Why `log1p` and not plain symlog.** Symlog (`sign(x)·ln(1+|x|)`) is ~identity below 1, so it compresses the top and leaves the bottom untouched: it would take the spread to ~66x, not 4.5x. `r0` moves the knee down to the smallest flow worth caring about; symlog is the `r0 = 1` special case, and rewards here are non-negative so the symmetric branch never applies.
- **`r0` is a units choice, not task knowledge.** One global constant meaning "one item per 100 seconds is the smallest flow we care about". Task-independent, never consults a lesson ceiling or a recipe value, and works unchanged on a future lesson whose throughput nobody predicted.
- **The objective is unchanged per lesson.** This is a strictly monotone transform of main's existing reward function, so the optimal factory for each lesson is provably identical to main's. Only the cross-lesson gradient allocation changes: multiplicative scale gaps become additive offsets, which baselines (critic or group mean) remove for free.
- **Cost handling is untouched.** `entity_cost_scale` and `cost_efficiency` keep their current meaning and their docstring is unchanged.
- `--reward-symlog-r0 0` disables the compression; that path is main's reward exactly, and stays tested.

### Why compress the cost-adjusted reward instead of subtracting a log-space cost term

The obvious alternative, `log1p(thput_raw / r0) - log1p(entity_cost_scale * cost)`, is wrong at the bottom: it pays a **negative** reward (−0.02 to −0.2) to a factory that delivers nothing, so an empty grid outscores a nearly-complete non-delivering one — a direct incentive to build nothing. Nesting avoids that for free, because the cost multiplier is bounded in (0, 1] and `log1p` is non-negative on it.

The two forms are otherwise the same function. For `x/r0 >> 1`, `log1p(x·ce/r0) → ln(x/r0) − ln(1/ce)` — i.e. the additive penalty falls out asymptotically. Measured difference across the real (thput, cost) range:

| thput | cost | nested | additive | diff |
|---:|---:|---:|---:|---:|
| 0.000 | 242.5 | 0.0000 | −0.2171 | +0.2171 |
| 0.043 | 62.5 | 1.6188 | 1.6068 | +0.0120 |
| 0.172 | 82.0 | 2.8271 | 2.8226 | +0.0045 |
| 4.380 | 242.5 | 5.8679 | 5.8674 | +0.0006 |
| 15.000 | 20.0 | 7.2941 | 7.2941 | +0.0000 |

They agree to <0.005 for every delivering factory and diverge only where the additive form was wrong.

## Tradeoff worth noting

**A concave transform is mildly risk-averse** under stochastic outcomes (prefers a reliable 5/s over a coin flip between 0 and 15). Probably fine — arguably desirable — for factory building, but it is a real change in preferences under uncertainty.

This also does **not** create signal where reward is zero; the collapsed-assembler recovery problem is untouched.

## Tests

- `TestReward` checks whichever scheme the env is configured for, with `test_entity_cost_reduces_reward_multiplicatively_without_log` pinning main's exact behaviour at `r0=0`.
- `test_zero_throughput_cost_penalty_is_never_negative` is parametrised over `r0 ∈ {0.0, 0.01}` — the guarantee now holds under both schemes, which is the point of the nested form.
- `TestLogRewardScaleCompression` is the end-to-end guard on the point of the change: builds a solved MOVE_ONE_ITEM and a solved MEMORISE_4_INGREDIENT_RECIPES factory and asserts the reward ratio stays under 10x while the raw items/s ratio exceeds 50x.
- `test_reward_symlog_r0_default` pins the default.

Full suite: 3187 passed, 708 skipped. `ruff check` and `ty check` clean. PPO smoke test passes (the container's `torch.compile` CPU-inductor backend fails to compile on this image — reproduced identically on unmodified `main`, unrelated to this change; smoke run verified with dynamo disabled).

## Next step

Not included here, since they would confound the comparison: `norm_adv=False` and `ent_coef=0` for the finetune config. Intended validation is `/ci compare ppo --start-from <sft ckpt>` — PR (compressed) vs main (uncompressed) — with the pass/fail being whether the assembler lessons hold their SFT throughput instead of collapsing.