### PR TITLE
Fix nonzero PPO approx_kl: attention stack ignored --dropout

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -111,6 +111,12 @@ _CH_FOOTPRINT = Channel.FOOTPRINT.value
 # "buildable" is exactly "not UNAVAILABLE" — only the one sentinel is named.
 _FOOTPRINT_UNAVAILABLE = Footprint.UNAVAILABLE.value
 
+# Largest approx_kl a frozen actor can legitimately produce: the rollout and the
+# update run different compiled handles at different batch sizes, so their
+# log-probs differ by ~5e-4 of graph-fusion FP ordering. Exported so the
+# regression test and the in-loop warm-up assert share one number.
+_WARMUP_KL_TOL = 1e-3
+
 
 def apply_placement_action(
     world_CWH: torch.Tensor,
@@ -1249,7 +1255,7 @@ class _SelfAttnStack(nn.Module):
     is zero-init, so the stage is identity at init and shape-preserving
     (grid-sized in == grid-sized out)."""
 
-    def __init__(self, channels, dim, heads, layers, num_tokens, pos_embed):
+    def __init__(self, channels, dim, heads, layers, num_tokens, pos_embed, dropout):
         super().__init__()
         # MultiheadAttention needs dim % heads == 0; snap heads down to the
         # largest divisor <= the requested count so any (dim, heads) the sweep
@@ -1261,10 +1267,16 @@ class _SelfAttnStack(nn.Module):
         self.pos_embed = (
             nn.Parameter(torch.zeros(1, num_tokens, dim)) if pos_embed else None
         )
+        # dropout MUST come from the caller: TransformerEncoderLayer defaults it
+        # to 0.1, and PPO cannot tolerate a stochastic forward at all — the
+        # rollout and the update would draw different masks, so the recomputed
+        # log-probs (and hence every importance ratio and approx_kl) would be
+        # wrong even with the actor frozen.
         enc_layer = nn.TransformerEncoderLayer(
             d_model=dim,
             nhead=heads,
             dim_feedforward=2 * dim,
+            dropout=dropout,
             batch_first=True,
             norm_first=True,
         )
@@ -1403,6 +1415,7 @@ class AgentCNN(nn.Module):
                 layers=attn_layers,
                 num_tokens=self.width * self.height,
                 pos_embed=bool(attn_pos_embed),
+                dropout=dropout,
             )
         num_params_encoder = sum(p.numel() for p in self.encoder.parameters())
         print(

--- a/ppo.py
+++ b/ppo.py
@@ -1267,11 +1267,6 @@ class _SelfAttnStack(nn.Module):
         self.pos_embed = (
             nn.Parameter(torch.zeros(1, num_tokens, dim)) if pos_embed else None
         )
-        # dropout MUST come from the caller: TransformerEncoderLayer defaults it
-        # to 0.1, and PPO cannot tolerate a stochastic forward at all — the
-        # rollout and the update would draw different masks, so the recomputed
-        # log-probs (and hence every importance ratio and approx_kl) would be
-        # wrong even with the actor frozen.
         enc_layer = nn.TransformerEncoderLayer(
             d_model=dim,
             nhead=heads,
@@ -2337,11 +2332,6 @@ if __name__ == "__main__":
             if args.target_kl is not None and approx_kl > args.target_kl:
                 break
 
-        # With the actor frozen the recomputed log-probs must equal the acting
-        # ones, so approx_kl can only be rollout-vs-update FP noise. Anything
-        # larger means the policy forward is not a deterministic function of
-        # (weights, obs, action) — every importance ratio, and target_kl with
-        # them, is then measuring the artifact instead of policy movement.
         if in_warmup:
             assert approx_kl < _WARMUP_KL_TOL, (
                 f"approx_kl={float(approx_kl):.4g} during critic warm-up "

--- a/ppo.py
+++ b/ppo.py
@@ -2337,6 +2337,19 @@ if __name__ == "__main__":
             if args.target_kl is not None and approx_kl > args.target_kl:
                 break
 
+        # With the actor frozen the recomputed log-probs must equal the acting
+        # ones, so approx_kl can only be rollout-vs-update FP noise. Anything
+        # larger means the policy forward is not a deterministic function of
+        # (weights, obs, action) — every importance ratio, and target_kl with
+        # them, is then measuring the artifact instead of policy movement.
+        if in_warmup:
+            assert approx_kl < _WARMUP_KL_TOL, (
+                f"approx_kl={float(approx_kl):.4g} during critic warm-up "
+                f"(actor frozen, so it must be ~0). The policy forward is "
+                f"non-deterministic: check for active dropout (`--dropout 0`) "
+                f"or a rollout/update bookkeeping mismatch."
+            )
+
         # Value-head (critic) diagnostics, global + per-lesson.
         critic_metrics = _critic_diagnostics(
             values_B.cpu().numpy(), returns_B.cpu().numpy(),

--- a/tests/test_rl_from_checkpoint.py
+++ b/tests/test_rl_from_checkpoint.py
@@ -23,7 +23,9 @@ os.environ["WANDB_DISABLED"] = "true"
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from ppo import AgentCNN, PpoArgs, FactorioEnv, make_env, layer_init  # noqa: E402
+from ppo import (  # noqa: E402
+    AgentCNN, PpoArgs, FactorioEnv, make_env, layer_init, _WARMUP_KL_TOL,
+)
 from helpers import Channel  # noqa: E402
 from factorion import LessonKind  # noqa: E402
 
@@ -206,3 +208,240 @@ class TestCriticHeadStd:
         assert head_weight is agent.critic_head[-1].weight  # in place
         assert not torch.equal(before, head_weight)
         assert head_weight.norm().item() == pytest.approx(0.02, abs=1e-3)
+
+
+
+# The policy forward must be a deterministic function of (weights, obs, action):
+# PPO's importance ratio divides the update's recomputed log-prob by the
+# rollout's, so any stochasticity corrupts every ratio, every clipfrac and
+# approx_kl — even with the actor frozen. Regression guards for run gs1nqoni,
+# where `nn.TransformerEncoderLayer`'s default dropout=0.1 stayed active (it is
+# not reached by `--dropout`), giving approx_kl 0.27-0.36 during critic warm-up
+# and tripping target_kl after epoch 1 of 8 on every iteration.
+#
+# Every forward below is hoisted into a module-scoped fixture: the assertions
+# are one-liners but a forward is the expensive part, so each is done once.
+
+_ATTN_KW = dict(layers=(16, 16, 16), attn_dim=32, attn_heads=4, attn_layers=1)
+
+
+def _finetune_agent(envs):
+    """An agent whose attention stage is NOT the identity.
+
+    `_SelfAttnStack.out_proj` is zero-init, so a freshly built agent's
+    attention stage is exact identity and anything stochastic inside it cannot
+    reach the outputs — a non-deterministic forward is invisible from scratch
+    and only surfaces once `--start-from` loads a checkpoint that has trained.
+    Every guard below needs a non-identity stage to have any teeth. The std is
+    picked so the test arch (1 attention layer, dim 32) reproduces the same
+    artifact magnitude the production arch did (approx_kl ~0.3), which is what
+    makes the clipfrac and target_kl guards sensitive too.
+    """
+    agent = AgentCNN(envs, **_ATTN_KW)
+    with torch.no_grad():
+        torch.nn.init.normal_(agent.attn.out_proj.weight, std=0.15)
+    return agent
+
+
+def _pack_action(action):
+    """The rollout's storage layout: [x, y, entity, direction, item, misc, eot]."""
+    x_B, y_B = action["xy"].unbind(dim=1)
+    return torch.stack([x_B, y_B, action["entity"], action["direction"],
+                        action["item"], action["misc"],
+                        action["eot"].long()], dim=1)
+
+
+def _test_envs(registered_env, num_envs=2, size=5):
+    return gym.vector.SyncVectorEnv(
+        [make_env(ENV_ID, i, False, size, "t") for i in range(num_envs)]
+    )
+
+
+@pytest.fixture(scope="module")
+def forward_probe(registered_env):
+    """Sample an action, then recompute its log-prob/value four ways: twice in
+    train mode, once in eval mode, and the sampled value itself."""
+    envs = _test_envs(registered_env)
+    agent = _finetune_agent(envs)
+    torch.manual_seed(0)
+    obs = torch.randn(8, NUM_CHANNELS, 5, 5)
+
+    action, logp_sampled, _, _ = agent.get_action_and_value(obs)
+    stored = _pack_action(action)
+
+    agent.train()
+    _, logp_1, _, value_1 = agent.get_action_and_value(obs, stored)
+    _, logp_2, _, value_2 = agent.get_action_and_value(obs, stored)
+    eot_train = agent.eot_prob(obs)
+    agent.eval()
+    _, logp_eval, _, value_eval = agent.get_action_and_value(obs, stored)
+    eot_eval = agent.eot_prob(obs)
+    agent.train()
+
+    envs.close()
+    return {
+        "agent": agent,
+        "logp_sampled": logp_sampled, "logp_1": logp_1, "logp_2": logp_2,
+        "value_1": value_1, "value_2": value_2,
+        "logp_eval": logp_eval, "value_eval": value_eval,
+        "eot_train": eot_train, "eot_eval": eot_eval,
+    }
+
+
+class TestDeterministicPolicyForward:
+    def test_no_dropout_is_active_at_dropout_zero(self, forward_probe):
+        """`--dropout 0` must mean the whole network is deterministic, the
+        attention stage included."""
+        agent = forward_probe["agent"]
+        assert agent.training, "nn.Module defaults to train mode; PPO never flips it"
+        active = [
+            name for name, m in agent.named_modules()
+            if (isinstance(m, (torch.nn.Dropout, torch.nn.Dropout1d,
+                               torch.nn.Dropout2d, torch.nn.AlphaDropout))
+                and m.p > 0)
+            or (isinstance(m, torch.nn.MultiheadAttention) and m.dropout > 0)
+        ]
+        assert active == [], f"dropout active in train mode at dropout=0: {active}"
+
+    def test_replay_logprob_matches_sampled(self, forward_probe):
+        """The log-prob round-trip through the rollout's storage layout, on a
+        trained-checkpoint agent in train mode — exactly how PPO runs. This is
+        the ratio PPO divides by; if it is wrong, everything downstream is."""
+        torch.testing.assert_close(
+            forward_probe["logp_sampled"], forward_probe["logp_1"]
+        )
+
+    def test_repeated_calls_agree(self, forward_probe):
+        """Same weights, same obs, same action -> same log-prob and value.
+
+        The `critic/*` symptom: if the encoder features are stochastic then
+        V(s) is not a function of s, so the warm-up regresses the value head on
+        noise and `critic/explained_variance` cannot climb however long it runs.
+        """
+        torch.testing.assert_close(forward_probe["logp_1"], forward_probe["logp_2"])
+        torch.testing.assert_close(forward_probe["value_1"], forward_probe["value_2"])
+
+    def test_train_and_eval_mode_agree(self, forward_probe):
+        """train() and eval() must compute the same function.
+
+        The `eval/thput` vs `rollout/thput` symptom: `run_rollout_eval` calls
+        `agent.eval()` while the PPO rollout runs in train mode, so a mode-
+        dependent forward shows up as an unexplained gap between the two at
+        iteration 1 — before a single gradient step, on identical weights. A
+        train/eval gap at step 0 is always a bug, never a property of the model.
+        """
+        torch.testing.assert_close(forward_probe["logp_1"], forward_probe["logp_eval"])
+        torch.testing.assert_close(forward_probe["value_1"], forward_probe["value_eval"])
+        torch.testing.assert_close(forward_probe["eot_train"], forward_probe["eot_eval"])
+
+
+@pytest.fixture(scope="module")
+def warmup_iteration(registered_env):
+    """One critic-warm-up iteration end to end, mirroring ppo.py's bookkeeping.
+
+    Rolls out a real vector env into the storage layout the loop uses (int64
+    packed actions, float32 log-probs, (steps, envs, ...) reshaped steps-major),
+    then runs the warm-up's v_loss-only update over shuffled minibatches with
+    the actor frozen. Returns the per-minibatch approx_kl and clipfrac series,
+    in order, so the assertions can look at both the first update and the worst.
+    """
+    num_envs, num_steps, size, mb, epochs = 2, 4, 5, 4, 2
+    envs = _test_envs(registered_env, num_envs, size)
+    agent = _finetune_agent(envs)
+
+    critic_ids = {id(p) for p in agent.critic_head.parameters()}
+    for p in agent.parameters():
+        if id(p) not in critic_ids:
+            p.requires_grad_(False)
+    optimizer = torch.optim.Adam(agent.critic_head.parameters(), lr=1e-3)
+
+    obs_buf = torch.zeros((num_steps, num_envs, NUM_CHANNELS, size, size))
+    act_buf = torch.zeros((num_steps, num_envs, 7), dtype=torch.int64)
+    logp_buf = torch.zeros((num_steps, num_envs))
+    returns_buf = torch.zeros((num_steps, num_envs))
+
+    torch.manual_seed(0)
+    np.random.seed(0)
+    next_obs, _ = envs.reset(seed=0)
+    next_obs = torch.as_tensor(np.array(next_obs), dtype=torch.float32)
+    for step in range(num_steps):
+        obs_buf[step] = next_obs
+        with torch.no_grad():
+            action, logp, _, _ = agent.get_action_and_value(next_obs)
+        act_buf[step] = _pack_action(action)
+        logp_buf[step] = logp
+        act_np = act_buf[step].numpy()
+        next_obs, reward, _term, _trunc, _info = envs.step({
+            "xy": act_np[:, 0:2], "entity": act_np[:, 2],
+            "direction": act_np[:, 3], "item": act_np[:, 4],
+            "misc": act_np[:, 5], "eot": act_np[:, 6],
+        })
+        next_obs = torch.as_tensor(next_obs, dtype=torch.float32)
+        returns_buf[step] = torch.as_tensor(reward, dtype=torch.float32)
+
+    obs_B = obs_buf.reshape(-1, NUM_CHANNELS, size, size)
+    act_B = act_buf.reshape(-1, 7)
+    logp_B = logp_buf.reshape(-1)
+    returns_B = returns_buf.reshape(-1)
+
+    clip_coef = PpoArgs().clip_coef
+    idxs_B = np.arange(obs_B.shape[0])
+    kls, clipfracs = [], []
+    for _epoch in range(epochs):
+        np.random.shuffle(idxs_B)
+        for start in range(0, len(idxs_B), mb):
+            idxs = idxs_B[start:start + mb]
+            _a, newlogp, _e, newvalue = agent.get_action_and_value(
+                obs_B[idxs], act_B[idxs]
+            )
+            logratio = newlogp.reshape(-1) - logp_B[idxs]
+            ratio = logratio.exp()
+            kls.append(float(((ratio - 1) - logratio).mean()))
+            clipfracs.append(float(((ratio - 1.0).abs() > clip_coef).float().mean()))
+            optimizer.zero_grad(set_to_none=True)
+            (0.5 * ((newvalue.view(-1) - returns_B[idxs]) ** 2).mean()).backward()
+            optimizer.step()
+
+    envs.close()
+    return {"kls": kls, "clipfracs": clipfracs}
+
+
+class TestWarmupIterationKl:
+    """The `losses/*` panels that were carrying the signal in run gs1nqoni,
+    asserted on a real warm-up iteration — one test per panel."""
+
+    def test_first_update_is_exactly_on_policy(self, warmup_iteration):
+        """The first minibatch of the first epoch runs on weights bit-identical
+        to the acting ones (zero optimiser steps so far), so approx_kl and
+        clipfrac are pinned to 0 there — warm-up or not. The leftmost point of
+        those two curves is the cheapest correctness check a PPO run has.
+        """
+        assert warmup_iteration["kls"][0] < _WARMUP_KL_TOL
+        assert warmup_iteration["clipfracs"][0] == 0.0
+
+    def test_frozen_actor_keeps_kl_at_the_noise_floor(self, warmup_iteration):
+        """With the actor frozen the recomputed log-probs equal the acting ones,
+        so approx_kl stays at FP noise for the whole warm-up — the invariant
+        gs1nqoni violated at 0.27-0.36, ~700x the ~5e-4 FP budget."""
+        kls = warmup_iteration["kls"]
+        assert max(kls) < _WARMUP_KL_TOL, (
+            f"frozen actor produced approx_kl up to {max(kls):.4g} "
+            f"(tol {_WARMUP_KL_TOL}); the policy forward is not deterministic"
+        )
+
+    def test_clipping_never_engages_while_frozen(self, warmup_iteration):
+        """A frozen actor cannot move outside the clip range, so
+        `losses/clipfrac` must be flat 0 across the whole warm-up."""
+        assert max(warmup_iteration["clipfracs"]) == 0.0
+
+    def test_target_kl_does_not_trip(self, warmup_iteration):
+        """`target_kl` must measure policy movement, not a recompute artifact:
+        the epoch loop cannot break while the actor is frozen. When it breaks at
+        epoch 1 every iteration you are silently running 1 of `--update-epochs`
+        epochs, visible as a pinned, constant `perf/update_seconds`.
+        """
+        target_kl = PpoArgs().target_kl
+        assert target_kl is not None
+        assert max(warmup_iteration["kls"]) < target_kl, (
+            "target_kl would break the epoch loop with the actor frozen"
+        )


### PR DESCRIPTION
## Root cause

`nn.TransformerEncoderLayer` defaults `dropout=0.1`, and `_SelfAttnStack` never
overrode it. With `attn_layers=4` that is **12 active `Dropout(p=0.1)` modules
plus dropout inside each of the 4 `MultiheadAttention` blocks**, regardless of
`--dropout` (which only ever reached the encoder's `Dropout2d`). `ppo.py` never
calls `.train()`/`.eval()`, so the agent runs in `nn.Module`'s default train
mode for the entire loop.

Consequence: `rollout_act` and `update_act` draw **different dropout masks**, so
the recomputed log-probs disagree with the acting ones. Every importance ratio,
`losses/clipfrac`, and `losses/approx_kl` is computed against wrong
old-log-probs — even with the actor completely frozen.

Not a `torch.compile` / CUDA-graph problem. Reproduced on CPU in eager mode:

```
act-vs-replay logprob mismatch on identical weights/inputs (eager, CPU):
  train()   approx_kl=0.115415  max|dlogp|=1.1642  mean|dlogp|=0.3483
  eval()    approx_kl=0.000000  max|dlogp|=0.0000  mean|dlogp|=0.0000
```

`eager/eager` with an `.eval()` agent was already exactly `0.0`, which is why
the existing `test_eot_logprob_roundtrips` never caught it.

### Why it was invisible until `--start-from`

`_SelfAttnStack.out_proj` is zero-init, so at fresh init the attention stage is
**exact identity** and nothing stochastic inside it can reach the outputs. A
from-scratch PPO smoke run reports `approx_kl = 0.0` even with the bug present.
It only appears once `--start-from` loads a checkpoint whose `out_proj` has
trained — exactly what run `gs1nqoni` did.

## Fix

Plumb the existing `dropout` arg into `_SelfAttnStack` →
`nn.TransformerEncoderLayer(dropout=...)`. PPO's `dropout=0.0` now makes the
whole network deterministic; nothing else changes.

Dropout has no parameters, so **checkpoint compatibility is unaffected** in both
directions.

## Behaviour change to be aware of

SFT's attention dropout now follows `SftArgs.dropout` (**0.1827**) instead of
the previously hardcoded **0.1**. SFT calls `.train()`/`.eval()` correctly, so
dropout is a legitimate regularizer there — but this does change SFT training,
and it means the arch sweeps' `dropout` axis now actually controls the attention
stage. Flagging rather than folding a second decision in: say the word and I'll
pin the attention stage to `0.1` (or `0.0`) behind its own knob instead.

Inference-only consumers (`scripts/factory_builder.py`,
`factorion-mod/server/server.py`) use the `dropout=0.0` default and call
`.eval()`, so they are unaffected either way.

## Guards

**In-loop assert** (`ppo.py`) — a CPU test cannot reach the `reduce-overhead`
CUDA-graph paths, so the invariant is also checked at runtime: during critic
warm-up the actor is frozen, so `approx_kl` must sit at the FP-noise floor
(`_WARMUP_KL_TOL = 1e-3`, vs the ~5e-4 graph-fusion budget). Fires only when PPO
is broken, on GPU as well as CPU.

**8 regression tests** (`tests/test_rl_from_checkpoint.py`), one per W&B panel
that was carrying the signal. All perturb `out_proj` so the attention stage is
non-identity — without that they have no teeth. All 8 fail before the fix, pass
after, and the whole set runs in ~10s (every forward hoisted into a
module-scoped fixture) since it only ever needs to check things at step 0.

| Test | Invariant / symptom |
|---|---|
| `test_no_dropout_is_active_at_dropout_zero` | `--dropout 0` means the whole net is deterministic, attention included |
| `test_replay_logprob_matches_sampled` | the log-prob round-trip PPO's ratio divides by |
| `test_repeated_calls_agree` | same obs+action → same logp/value (the `critic/explained_variance` symptom: stochastic features mean `V(s)` isn't a function of `s`) |
| `test_train_and_eval_mode_agree` | `train()` == `eval()` (the `eval/thput` ≫ `rollout/thput` gap at iteration 1) |
| `test_first_update_is_exactly_on_policy` | `approx_kl` and `clipfrac` are 0 on the first minibatch — zero optimizer steps have happened |
| `test_frozen_actor_keeps_kl_at_the_noise_floor` | the invariant `gs1nqoni` violated at 0.27–0.36 |
| `test_clipping_never_engages_while_frozen` | `losses/clipfrac` flat 0 across warm-up |
| `test_target_kl_does_not_trip` | `target_kl` measures policy movement, not a recompute artifact |

## Checks

Run locally, all green: `ruff`, `ty`, `cargo fmt --check`, `cargo clippy -D
warnings`, `cargo test` (163 passed), `maturin develop --release`, `pytest
tests/` (3186 passed / 708 skipped), and the PPO smoke
(`iter1_signature.approx_kl = 0.0`, all 8 epochs run, warm-up assert silent).

Two caveats, both environmental rather than code:

- The container's CPU inductor is broken independently of this change — a torch
  AVX512 codegen bug (`error: operands to '?:' have different types
  VecMask<int,1> and VecMask<float,1>`) that reproduces on unmodified `main`.
  The PPO smoke was run with `TORCHDYNAMO_DISABLE=1`; the compiled paths need CI.
- The SFT smoke was SIGTERMed by the container before finishing (resource limit,
  not a failure) — leaving that one to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VxReZNgqXw59A4LsjyFEo

---
_Generated by [Claude Code](https://claude.ai/code/session_013VxReZNgqXw59A4LsjyFEo)_