### PR TITLE
Broaden the PPO sweep to the update-loop knobs unblocked by #337

### DIFF
--- a/ci/sweep_ppo.yaml
+++ b/ci/sweep_ppo.yaml
@@ -24,22 +24,19 @@
 # (entity_cost_scale, reward_symlog_r0), so rollout/reward is not comparable
 # across runs, whereas normalised throughput is.
 
-# BEFORE LAUNCHING, read #339 — two of its blockers bear directly on this sweep:
-#   * Blocker 3: the training rollout never masks the tile head (legal_mask
-#     defaults to False; the only True call site is sft.py's greedy eval), so
-#     training explores a different action distribution than the metric scores.
-#     That moves the optimum for learning_rate, clip_coef and ent_coef_start —
-#     three of the axes below.
-#   * Blocker 1: eval/thput, this sweep's objective, is not zero-based.
-#     CROSS_UNDER_BELT scores 0.25 normalised on a fully blanked grid, so firing
-#     end-of-turn immediately banks free reward there and drags the shared EOT
-#     head, which #339 flags as a plausible cause of PPO degrading strong bases.
-# Both are small plumbing fixes in #339's own sequencing, and both change what
-# this sweep would find. Tuning through them repeats the #337 mistake that this
-# sweep exists to undo.
+# The bar: #340's compare measured h76h80yb at eval/thput 0.797 after 1.5M PPO
+# steps on main's defaults. That is what a swept config has to beat. (CLAUDE.md
+# still cites 0.11 for the older j0s5y2mc base — stale, ignore it.)
+#
+# #339's blocker 3 (mask the tile head during rollout) is NOT applied here and
+# should not be: #340 tested legal_mask=True from this exact base and it came
+# out slightly worse (eval/thput 0.797 -> 0.757, rollout/thput 0.799 -> 0.712,
+# 1 seed). rollout/invalid_frac is already 0.28% from a pretrained policy, so
+# the mask has almost nothing to fix — blocker 3 is a from-scratch finding that
+# does not transfer to a finetune.
 
 method: bayes
-run_cap: 32
+run_cap: 48
 metric:
   name: "eval/thput"
   goal: maximize
@@ -205,17 +202,19 @@ program: ppo.py
 # Plain `python`: on a CI pod deps are installed system-wide; locally, run the
 # agent under `uv run wandb agent <sweep>` so the venv python is on PATH.
 #
-# 1M steps ~= 244 iterations at batch 4096. Cost is dominated by the UPDATE, not
-# the rollout, and scales linearly with update_epochs — measured here at batch
-# 512 / 8 minibatches, update went 4.64 -> 37.10 s/iter as update_epochs went
-# 1 -> 8 (8.0x; 62% -> 93% of the iteration). #339 measures the full config at
-# 15 s rollout + 55 s optimiser per 4096-step iteration, so a run costs roughly
-# 244 * (15 + 55*E) seconds: ~4.7 h at E=1, ~31 h at E=8 before torch.compile.
-# Since update_epochs is itself swept, per-run cost varies ~6x and drainage is
-# inherently uneven; that is why run_cap is 32 rather than 48. Budget generously
-# (--pods 8) and expect the low-E runs to finish many times faster than the
-# high-E ones. max_seconds cannot bound this — it is nested inside the
-# target_metric block (ppo.py) and does nothing unless target_metric is set.
+# 1M steps ~= 244 iterations at batch 4096, ~34 evals. Cost is dominated by the
+# UPDATE, not the rollout, and scales linearly with update_epochs: #340's pod
+# run (update_epochs 8, 32 minibatches, torch.compile, this same base) measured
+# update 16.44 s vs rollout 1.21 s per iteration — the update is 93% of it.
+#
+# So per-run cost tracks the swept update_epochs x num_minibatches corner:
+#   E=1,  8 minibatches  ~0.2 h      E=8, 32 minibatches  ~1.3 h (measured)
+#   E=8, 64 minibatches  ~2.4 h
+# Average ~1 h, so 48 runs is roughly 48 pod-hours: --pods 4 drains it in ~12 h,
+# well inside the 24 h sweep pod budget. Do NOT size this off #339's 58 steps/s
+# — that is MPS without torch.compile, and #339 says as much; the pods measure
+# 271 steps/s. max_seconds cannot cap a slow run either: it is nested inside the
+# target_metric block (ppo.py) and is inert unless target_metric is set.
 command:
   - ${env}
   - python

--- a/ci/sweep_ppo.yaml
+++ b/ci/sweep_ppo.yaml
@@ -138,9 +138,16 @@ parameters:
     max: 0.99
 
   # ── Pinned, not swept ────────────────────────────────────────────
-  # Must stay 0. Non-zero dropout is exactly the #337 bug: it desynchronises
-  # the rollout and update forward passes, and now trips the critic-warm-up
-  # `approx_kl < _WARMUP_KL_TOL` assert, hard-failing the run.
+  # Pinned because this loop cannot currently use dropout — not because dropout
+  # and RL are incompatible. #337 fixed the attention stack ignoring this flag;
+  # it did not make values above 0 usable. ppo.py never calls .eval(), and
+  # torch.no_grad() does not disable dropout, so the rollout and the update each
+  # draw independent masks: at identical weights the recomputed log-probs
+  # disagree with the acting ones and every importance ratio is corrupted. It
+  # also trips the critic-warm-up `approx_kl < _WARMUP_KL_TOL` assert, so such a
+  # run hard-fails in its first iterations instead of quietly producing garbage.
+  # Making dropout sweepable needs eval-mode rollouts, or masks cached at act
+  # time and replayed in the update — a code change, not a sweep entry.
   dropout:
     value: 0
 

--- a/ci/sweep_ppo.yaml
+++ b/ci/sweep_ppo.yaml
@@ -68,12 +68,35 @@ parameters:
   # reward = log1p(thput_raw / (1 + entity_cost_scale*cost) / reward_symlog_r0)
   # Both knobs reshape that terminal reward, and they interact (the cost
   # penalty is applied inside the compression), so neither is meaningful to
-  # tune alone. 0 = that stage disabled, kept as the control.
-  entity_cost_scale:
-    values: [0, 1.0e-4, 1.0e-3, 1.0e-2]
+  # tune alone.
+  #
+  # Continuous rather than a values-list: W&B's Bayes optimiser one-hot-encodes
+  # `values`, so it cannot tell that 3e-3 lies between 1e-3 and 1e-2 — on knobs
+  # this smooth that throws away most of the sample efficiency a 48-run budget
+  # needs. Neither knob's "0 = stage off" sentinel is worth the categorical
+  # encoding, because both ranges reach that regime numerically anyway (below),
+  # and whether the stages help at all is #336's compare, not this sweep.
 
+  # Floor is off in all but name: at cost 242 (the most expensive lesson,
+  # FACTORY_1_INGREDIENT) 1e-5 costs 0.2% of the reward. Top stays at the
+  # previous grid's max, already a 71% penalty there.
+  entity_cost_scale:
+    distribution: log_uniform_values
+    min: 1.0e-5
+    max: 1.0e-2
+
+  # Spread between the highest- and lowest-ceiling lesson (15 vs 0.043 items/s)
+  # across this range: 2.5x at 1e-3, 4.4x at the 1e-2 default, 66x at 1 (plain
+  # symlog), 214x at 10 — against 349x uncompressed, so the top is compression
+  # off in all but name. Deliberately stops at 10: r0 sets the absolute reward
+  # magnitude as well as the compression knee (max reward 9.6 -> 0.92 across
+  # this range), and since v_loss is squared error on returns, that scale is
+  # confounded with vf_coef. Sweeping vf_coef jointly lets Bayes compensate;
+  # extending to 100 would push the confound to ~1e4 in v_loss terms.
   reward_symlog_r0:
-    values: [0, 1.0e-3, 1.0e-2, 1.0e-1, 1.0]
+    distribution: log_uniform_values
+    min: 1.0e-3
+    max: 10.0
 
   # ── Knobs the reward change and the real update loop invalidate ──
   # vf_coef balances value loss against policy loss, so symlog's rescaling of

--- a/ci/sweep_ppo.yaml
+++ b/ci/sweep_ppo.yaml
@@ -24,8 +24,22 @@
 # (entity_cost_scale, reward_symlog_r0), so rollout/reward is not comparable
 # across runs, whereas normalised throughput is.
 
+# BEFORE LAUNCHING, read #339 — two of its blockers bear directly on this sweep:
+#   * Blocker 3: the training rollout never masks the tile head (legal_mask
+#     defaults to False; the only True call site is sft.py's greedy eval), so
+#     training explores a different action distribution than the metric scores.
+#     That moves the optimum for learning_rate, clip_coef and ent_coef_start —
+#     three of the axes below.
+#   * Blocker 1: eval/thput, this sweep's objective, is not zero-based.
+#     CROSS_UNDER_BELT scores 0.25 normalised on a fully blanked grid, so firing
+#     end-of-turn immediately banks free reward there and drags the shared EOT
+#     head, which #339 flags as a plausible cause of PPO degrading strong bases.
+# Both are small plumbing fixes in #339's own sequencing, and both change what
+# this sweep would find. Tuning through them repeats the #337 mistake that this
+# sweep exists to undo.
+
 method: bayes
-run_cap: 48
+run_cap: 32
 metric:
   name: "eval/thput"
   goal: maximize
@@ -191,9 +205,17 @@ program: ppo.py
 # Plain `python`: on a CI pod deps are installed system-wide; locally, run the
 # agent under `uv run wandb agent <sweep>` so the venv python is on PATH.
 #
-# 1M steps ~= 244 iterations at batch 4096. Budget ~1.5-2 h/run (the rollout is
-# CPU-bound and dominates; even update_epochs=8 x num_minibatches=64 adds only
-# minutes), so 48 runs needs ~6 pods to drain inside the 24 h sweep pod budget.
+# 1M steps ~= 244 iterations at batch 4096. Cost is dominated by the UPDATE, not
+# the rollout, and scales linearly with update_epochs — measured here at batch
+# 512 / 8 minibatches, update went 4.64 -> 37.10 s/iter as update_epochs went
+# 1 -> 8 (8.0x; 62% -> 93% of the iteration). #339 measures the full config at
+# 15 s rollout + 55 s optimiser per 4096-step iteration, so a run costs roughly
+# 244 * (15 + 55*E) seconds: ~4.7 h at E=1, ~31 h at E=8 before torch.compile.
+# Since update_epochs is itself swept, per-run cost varies ~6x and drainage is
+# inherently uneven; that is why run_cap is 32 rather than 48. Budget generously
+# (--pods 8) and expect the low-E runs to finish many times faster than the
+# high-E ones. max_seconds cannot bound this — it is nested inside the
+# target_metric block (ppo.py) and does nothing unless target_metric is set.
 command:
   - ${env}
   - python

--- a/ci/sweep_ppo.yaml
+++ b/ci/sweep_ppo.yaml
@@ -1,6 +1,6 @@
 # ci/sweep_ppo.yaml — re-tune the PPO knobs now that the update loop actually runs
 #
-# Launched with: /ci sweep ppo --pods 6
+# Launched with: /ci sweep ppo --pods 4
 # Sweep results are reported (ci sweep-report), not auto-applied —
 # hyperparameter defaults live in training_config.py and are edited by hand.
 #

--- a/ci/sweep_ppo.yaml
+++ b/ci/sweep_ppo.yaml
@@ -157,16 +157,34 @@ parameters:
 #     head is re-initialised after the load (ppo.py, `layer_init(agent.
 #     critic_head[-1], ...)`). The previous sweep swept it and burned a
 #     dimension on nothing.
-#   * num_envs / num_steps / async_envs / amp — measured dead ends in
-#     tests/benchmarks/EXPERIMENT_LOG.md (more envs is net slower, num_steps
-#     <256 no win, async loses at every env count, AMP no win).
+#   * async_envs / amp — EXPERIMENT_LOG.md calls these dead ends, but that
+#     verdict is STALE and should not be read as settled: it was last measured
+#     2026-07-05, before the attention stack (#314, 07-21) and before the update
+#     loop ran more than one epoch (#337, 07-25). Every one of those findings
+#     rested on "the rollout is CPU-bound and the GPU work is ~0", which a
+#     192-dim 4-layer transformer over 121 tokens plus 8x the update work is
+#     exactly what breaks. They are still excluded HERE because they are speed
+#     knobs: neither moves eval/thput, so Bayes would fit noise on those axes.
+#     Re-test them in `bench_measure.sh ppo-speed`, which is the instrument
+#     that measures what they actually change.
+#   * num_envs / num_steps — same stale verdict, but unlike the two above these
+#     are real learning knobs (they set batch_size, and num_steps sets the GAE
+#     truncation horizon), so they DO belong in a quality sweep. They are held
+#     out because eval_every counts ITERATIONS, not timesteps: at 1M steps a
+#     512-sample batch runs 1953 iterations = 279 evals (~4.5 h of pure eval)
+#     against 34 evals (~0.5 h) at the default 4096, so small-batch runs would
+#     burn their budget evaluating AND have the metric sampled on a different
+#     cadence than large-batch ones — an unfair comparison baked into the
+#     sweep. num_minibatches > batch_size also divides to minibatch_size 0 and
+#     raises ValueError. Make eval_every timestep-based first, then sweep them.
 #   * critic_warmup / critic_lr_mult / critic_head_std — startup transients
 #     worth ~9 iterations of a 244-iteration run; dropped for the same reason
 #     the 2M sweep dropped them, and pinned at their defaults.
-#   * adam_epsilon — held out to keep the Bayes budget on the 12 axes above.
-#     It ranked high in the old post-hoc analysis, but that ranking was
-#     measured through the broken update loop, so it is a lead to re-check
-#     later, not a trusted prior.
+#   * adam_epsilon — left out to keep the budget on the 12 axes above. The old
+#     sweep ranked it the third most important knob, but that sweep ran through
+#     the broken update loop, so the ranking is worthless: it is not evidence
+#     that adam_epsilon matters, nor evidence that it doesn't. Add it back when
+#     there is budget for a 13th axis.
 
 program: ppo.py
 

--- a/ci/sweep_ppo.yaml
+++ b/ci/sweep_ppo.yaml
@@ -1,27 +1,151 @@
-# ci/sweep_ppo.yaml — isolate the PPO entity-cost penalty strength
+# ci/sweep_ppo.yaml — re-tune the PPO knobs now that the update loop actually runs
 #
-# Launched with: /ci sweep ppo
+# Launched with: /ci sweep ppo --pods 6
+# Sweep results are reported (ci sweep-report), not auto-applied —
+# hyperparameter defaults live in training_config.py and are edited by hand.
 #
-# Every run uses this branch and the same training configuration. The only
-# swept value is eta, exposed by PpoArgs as entity_cost_scale:
+# WHY NOW. #337 found that the self-attention stack ignored --dropout, so the
+# policy forward was stochastic and the update's recomputed log-probs never
+# matched the acting ones: approx_kl read 0.27-0.36 with the actor *frozen*.
+# target_kl=0.02 therefore broke the epoch loop after epoch 1 on every single
+# iteration, so every PPO run this project has ever done effectively ran
+# `update_epochs=1` and had no trust region at all. The whole PPO update-loop
+# family — update_epochs, target_kl, clip_coef, num_minibatches — is thus
+# UNVALIDATED, and learning_rate (co-tuned against those broken updates, and
+# now facing up to 8x the gradient work per iteration) has to be re-searched
+# jointly with them. That is the core of this sweep.
 #
-#   reward = thput_raw / (1 + entity_cost_scale * entity_cost)
+# Architecture is NOT swept: every run finetunes the same checkpoint
+# (--start-from h76h80yb), so size / layer1-8 / kernel_size / attn_* /
+# global_feat_dim are fixed by the checkpoint and would fail to load.
+#
+# Metric is eval/thput (EOT-respecting greedy held-out throughput, normalised
+# per factory). It has to be — this sweep varies the reward function itself
+# (entity_cost_scale, reward_symlog_r0), so rollout/reward is not comparable
+# across runs, whereas normalised throughput is.
 
-method: grid
+method: bayes
+run_cap: 48
 metric:
   name: "eval/thput"
   goal: maximize
 
 parameters:
+  # ── The update loop (never actually exercised before #337) ────────
+  # update_epochs x target_kl x clip_coef jointly define the trust region;
+  # they only mean anything together, so they are swept together.
+  update_epochs:
+    distribution: int_uniform
+    min: 1
+    max: 8
+
+  # No None here (a sweep cannot emit it), but the top of the range is
+  # effectively "no early stop" — approx_kl rarely reaches 0.5.
+  target_kl:
+    distribution: log_uniform_values
+    min: 0.005
+    max: 0.5
+
+  clip_coef:
+    distribution: uniform
+    min: 0.05
+    max: 0.3
+
+  # batch_size is 4096 (16 envs x 256 steps), so this is minibatch
+  # 512 / 256 / 128 / 64. Covers the minibatch-size axis; num_envs and
+  # num_steps stay pinned (see the exclusions below).
+  num_minibatches:
+    values: [8, 16, 32, 64]
+
+  # Widened downward: real multi-epoch updates take up to 8x more gradient
+  # steps per iteration than the 3.369e-5 default was tuned against.
+  learning_rate:
+    distribution: log_uniform_values
+    min: 5.0e-6
+    max: 3.0e-4
+
+  # ── Reward shaping ───────────────────────────────────────────────
+  # reward = log1p(thput_raw / (1 + entity_cost_scale*cost) / reward_symlog_r0)
+  # Both knobs reshape that terminal reward, and they interact (the cost
+  # penalty is applied inside the compression), so neither is meaningful to
+  # tune alone. 0 = that stage disabled, kept as the control.
   entity_cost_scale:
-    values:
-      - 0.0
-      - 1.0e-4
-      - 1.0e-3
-      - 1.0e-2
+    values: [0, 1.0e-4, 1.0e-3, 1.0e-2]
+
+  reward_symlog_r0:
+    values: [0, 1.0e-3, 1.0e-2, 1.0e-1, 1.0]
+
+  # ── Knobs the reward change and the real update loop invalidate ──
+  # vf_coef balances value loss against policy loss, so symlog's rescaling of
+  # the return distribution moves its optimum directly.
+  vf_coef:
+    distribution: uniform
+    min: 0.25
+    max: 1.5
+
+  # Clipping bites much harder when a rollout is replayed up to 8 times.
+  max_grad_norm:
+    distribution: uniform
+    min: 0.3
+    max: 2.5
+
+  # ent_coef is a linear interpolation start -> end, so a swept start against
+  # the 7.372e-4 default end would anneal entropy *upward* over most of the
+  # range. Pinning end at 0 makes the schedule a decay-to-zero for every run
+  # (CLAUDE.md's finetuning guidance) and leaves start as the one real knob.
+  ent_coef_start:
+    distribution: log_uniform_values
+    min: 1.0e-4
+    max: 0.02
+  ent_coef_end:
+    value: 0
+
+  # The reward is terminal-only over episodes of up to size*size = 121 steps,
+  # so gamma is the credit-assignment knob: at the 0.9566 default the first
+  # placement keeps 0.9566^121 ~ 0.5% of the factory's reward. The range is
+  # pushed toward 1 to test whether that is starving early placements.
+  gamma:
+    distribution: uniform
+    min: 0.95
+    max: 0.9995
+
+  gae_lambda:
+    distribution: uniform
+    min: 0.85
+    max: 0.99
+
+  # ── Pinned, not swept ────────────────────────────────────────────
+  # Must stay 0. Non-zero dropout is exactly the #337 bug: it desynchronises
+  # the rollout and update forward passes, and now trips the critic-warm-up
+  # `approx_kl < _WARMUP_KL_TOL` assert, hard-failing the run.
+  dropout:
+    value: 0
+
+# Deliberately excluded (do not add these back without a reason):
+#   * tile_head_std — a NO-OP under --start-from. It is applied at
+#     construction and then overwritten by load_state_dict; only the critic
+#     head is re-initialised after the load (ppo.py, `layer_init(agent.
+#     critic_head[-1], ...)`). The previous sweep swept it and burned a
+#     dimension on nothing.
+#   * num_envs / num_steps / async_envs / amp — measured dead ends in
+#     tests/benchmarks/EXPERIMENT_LOG.md (more envs is net slower, num_steps
+#     <256 no win, async loses at every env count, AMP no win).
+#   * critic_warmup / critic_lr_mult / critic_head_std — startup transients
+#     worth ~9 iterations of a 244-iteration run; dropped for the same reason
+#     the 2M sweep dropped them, and pinned at their defaults.
+#   * adam_epsilon — held out to keep the Bayes budget on the 12 axes above.
+#     It ranked high in the old post-hoc analysis, but that ranking was
+#     measured through the broken update loop, so it is a lead to re-check
+#     later, not a trusted prior.
 
 program: ppo.py
 
+# Plain `python`: on a CI pod deps are installed system-wide; locally, run the
+# agent under `uv run wandb agent <sweep>` so the venv python is on PATH.
+#
+# 1M steps ~= 244 iterations at batch 4096. Budget ~1.5-2 h/run (the rollout is
+# CPU-bound and dominates; even update_epochs=8 x num_minibatches=64 adds only
+# minutes), so 48 runs needs ~6 pods to drain inside the 24 h sweep pod budget.
 command:
   - ${env}
   - python
@@ -29,6 +153,6 @@ command:
   - --start-from
   - h76h80yb
   - --total-timesteps
-  - 2_000_000
+  - 1_000_000
   - --track
   - ${args}

--- a/ppo.py
+++ b/ppo.py
@@ -1793,20 +1793,23 @@ if __name__ == "__main__":
         )
 
         # Define metric axes and summary aggregation. global_step (env steps)
-        # is the x-axis for every panel. eval/* (greedy held-out throughput) is
-        # the headline progress signal, so it summarises to its max.
+        # is the x-axis for every panel. Everything summarises to its LAST
+        # value, eval/* included: a max would score a run on a peak it did not
+        # hold, which flatters exactly the configs that spike and then collapse
+        # — and PPO collapse is common enough here that sweep llfgwhki ranked 12
+        # of 48 runs on peaks they had already given back.
         wandb.define_metric("*", step_metric="global_step")
         _LESSONS = [k.name for k in LessonKind]
-        wandb.define_metric("eval/thput", summary="max")
-        wandb.define_metric("eval/asm_item_acc", summary="max")
-        wandb.define_metric("eval/eot_acc", summary="max")
-        wandb.define_metric("eval/eot_pos_recall", summary="max")
+        wandb.define_metric("eval/thput", summary="last")
+        wandb.define_metric("eval/asm_item_acc", summary="last")
+        wandb.define_metric("eval/eot_acc", summary="last")
+        wandb.define_metric("eval/eot_pos_recall", summary="last")
         wandb.define_metric("eval/seconds", summary="last")
         for ln in _LESSONS:
-            wandb.define_metric(f"eval/{ln}/thput", summary="max")
-            wandb.define_metric(f"eval/{ln}/asm_item_acc", summary="max")
-            wandb.define_metric(f"eval/{ln}/eot_acc", summary="max")
-            wandb.define_metric(f"eval/{ln}/eot_pos_recall", summary="max")
+            wandb.define_metric(f"eval/{ln}/thput", summary="last")
+            wandb.define_metric(f"eval/{ln}/asm_item_acc", summary="last")
+            wandb.define_metric(f"eval/{ln}/eot_acc", summary="last")
+            wandb.define_metric(f"eval/{ln}/eot_pos_recall", summary="last")
         for m in ["thput", "thput_raw", "reward", "length", "eot_rate",
                   "invalid_frac", "num_entities", "entity_efficiency",
                   "frac_reachable", "entity_cost", "cost_efficiency"]:


### PR DESCRIPTION
Targets `main` (#336 merged as `db68386`, so `reward_symlog_r0` is available). One file: `ci/sweep_ppo.yaml`.

## Why

#337 found that the attention stack ignored `--dropout`, so the policy forward was stochastic and the update's recomputed log-probs never matched the acting ones — `approx_kl` read 0.27–0.36 with the actor **frozen**. `target_kl=0.02` therefore broke the epoch loop after epoch 1 on every iteration.

Every PPO run before that fix ran an effective `update_epochs=1` with no trust region at all. That leaves the entire update-loop family unvalidated, and `learning_rate` — co-tuned against those broken updates, and now facing up to 8× the gradient work per iteration — has to be re-searched jointly with it.

Confirmed in smoke runs on this branch: epochs `1/8 … 8/8` all execute, and `target_kl` now breaks the loop mid-update on real policy movement (`epoch 3/6` at `target_kl=0.05`) rather than on dropout noise at epoch 1.

**The bar:** #340's compare puts `h76h80yb` at `eval/thput` **0.797** after 1.5M PPO steps on main's defaults. That's what a swept config has to beat. (CLAUDE.md still cites 0.11 for the older `j0s5y2mc` base — stale.)

## What's swept (12 axes, `bayes`, `run_cap: 48`, 1M steps, `--start-from h76h80yb`)

| group | knobs | why |
|---|---|---|
| update loop | `update_epochs` 1–8, `target_kl` 5e-3–0.5, `clip_coef` 0.05–0.3, `num_minibatches` {8,16,32,64} | never actually exercised; jointly define the trust region so they are swept together |
| | `learning_rate` 5e-6–3e-4 | widened downward — up to 8× more gradient steps per iteration than the 3.369e-5 default was tuned against |
| reward | `entity_cost_scale` 1e-5–1e-2, `reward_symlog_r0` 1e-3–10 | the cost penalty applies *inside* the compression, so neither is meaningful alone |
| re-invalidated | `vf_coef`, `max_grad_norm`, `ent_coef_start` | symlog rescales the return distribution (moves `vf_coef`'s optimum); clipping bites harder under 8× replay |
| credit assignment | `gamma` 0.95–0.9995, `gae_lambda` | reward is terminal-only over ≤121-step episodes: at the 0.9566 default the first placement keeps 0.9566^121 ≈ **0.5%** of the factory's reward. Range pushed toward 1 to test whether that starves early placements |

Metric stays `eval/thput` — the sweep varies the reward function itself, so `rollout/reward` is not comparable across runs while normalised throughput is.

### Everything continuous except `num_minibatches`

W&B's Bayes optimiser one-hot-encodes `values`, so a categorical list can't express that 3e-3 lies between 1e-3 and 1e-2 — on smooth knobs that discards most of the sample efficiency a 48-run budget needs. The only thing a list bought for the two reward knobs was the literal `0` sentinel, and neither range needs it:

| | floor | default | top |
|---|---|---|---|
| `entity_cost_scale` | 1e-5 → 0.2% penalty at cost 242 (off in all but name) | 1e-3 → 20% | 1e-2 → 71% |
| `reward_symlog_r0` | 1e-3 → 2.5× cross-lesson spread | 1e-2 → 4.4× | 10 → 214× (vs 349× uncompressed) |

`reward_symlog_r0` deliberately stops at 10 rather than 100: it sets absolute reward magnitude as well as the compression knee (max reward 9.6 → 0.92 across the range), and since `v_loss` is squared error on returns, that scale is confounded with `vf_coef`. Sweeping `vf_coef` jointly lets Bayes compensate for a 100× confound; 100 would make it ~1e4 in `v_loss` terms. `num_minibatches` stays categorical because it has to divide the 4096 batch.

## Pinned, and why

- **`ent_coef_end: 0`** — `ent_coef` interpolates start → end, so a swept `ent_coef_start` against the 7.372e-4 default would anneal entropy **upward** over most of its range. Pinning end at 0 makes every run a decay-to-zero and leaves start as the one real knob.
- **`dropout: 0`** — *not* because dropout and RL are incompatible; it's routine in offline/off-policy RL and workable in on-policy PPO given an implementation that handles it. The constraint is specific to this loop: `ppo.py` never calls `.eval()`, and `torch.no_grad()` doesn't disable dropout, so the rollout and the update each draw independent masks and the recomputed log-probs disagree with the acting ones at identical weights. Supporting it needs eval-mode rollouts, or masks cached at act time and replayed in the update.

## Cost

Dominated by the **update**, not the rollout, and linear in `update_epochs`. #340's pod run (`update_epochs=8`, 32 minibatches, `torch.compile`, same base) measured update 16.44 s vs rollout 1.21 s per iteration — 93% update — at 271 steps/s.

| corner | h/run |
|---|---|
| `E=1`, 8 minibatches | ~0.2 |
| `E=8`, 32 minibatches (measured) | ~1.3 |
| `E=8`, 64 minibatches | ~2.4 |

Average ~1 h → 48 runs ≈ 48 pod-hours, so **`/ci sweep ppo --pods 4`** drains in ~12 h. Don't size this off #339's 58 steps/s — that's MPS without `torch.compile`, and #339 says so itself. `max_seconds` can't cap a slow run either: it's nested inside the `target_metric` block and is inert unless `target_metric` is set.

## Dropped

- **`tile_head_std`** — a **no-op under `--start-from`**: applied at construction, then overwritten by `load_state_dict`; only the critic head is re-initialised after. The previous sweep swept it and burned a dimension on nothing.
- **`async_envs` / `amp`** — `EXPERIMENT_LOG.md` calls these dead ends, but that verdict is **stale** (last measured 2026-07-05, before the attention stack on 07-21 and the working update loop on 07-25; every finding rested on "the rollout is CPU-bound and GPU work is ~0"). They're excluded here anyway because they're *speed* knobs that don't move `eval/thput` — Bayes would fit noise. Re-test in `bench_measure.sh ppo-speed`.
- **`num_envs` / `num_steps`** — same stale verdict, but these *are* learning knobs (they set `batch_size` and the GAE horizon). Blocked because `eval_every` counts **iterations**, not timesteps: at 1M steps a 512-sample batch runs 1953 iterations = 279 evals (~4.5 h of pure eval) vs 34 (~0.5 h) at the default 4096. Small-batch runs would burn their budget evaluating *and* have the metric sampled on a different cadence — a comparison artifact, not a hyperparameter effect. `num_minibatches > batch_size` also floors to `minibatch_size = 0` and raises `ValueError`. Fix `eval_every` to be timestep-based first.
- **`critic_warmup` / `critic_lr_mult` / `critic_head_std`** — startup transients worth ~9 of 244 iterations.
- **`adam_epsilon`** — left out for budget. The old sweep ranked it third most important, but that sweep ran through the broken update loop, so the ranking is worthless — not evidence it matters, nor that it doesn't.
- **`norm_adv`** — #336's "next step" flags `norm_adv=False`. It's a bool, which W&B sweeps pass awkwardly to tyro; left for a follow-up.

## Not applied: #339's blockers

- **Blocker 3** (mask the tile head in the rollout) was tested directly in #340 from this exact base and came out slightly **worse**: `eval/thput` 0.797 → 0.757, `rollout/thput` 0.799 → 0.712. The mechanism is in the same table — `rollout/invalid_frac` is already **0.28%** from a pretrained policy, so the mask has nearly nothing to fix. #339 measured its premise on a masked-random policy, a from-scratch regime that doesn't transfer to a finetune.
- **Blocker 1** is not a blocker: CROSS_UNDER_BELT's non-zero starting throughput is the lesson deliberately testing interference between multiple sources and sinks.

## Validation

- 200+ randomly-sampled configs from the yaml parse through `tyro.cli(PpoArgs)` against main; every swept name is a real `PpoArgs` field; `num_minibatches` always divides batch 4096; `ent_coef_start >= ent_coef_end` holds for all.
- PPO smoke at both sweep corners and at the continuous floor — all complete, including past critic warm-up.
- Full suite 3195 passed / 708 skipped; `ruff check`, `ty check`, `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` (163 passed) all clean.
- The container's `torch.compile` CPU-inductor backend fails on this image; reproduced identically on unmodified `main`, so it's unrelated. Smokes verified with dynamo disabled.