### PR TITLE
Keep the legal-tile mask sampleable when nothing is buildable

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -1260,7 +1260,11 @@ def _legal_tile_mask(x_BCWH):
     ent_BWH = x_BCWH[:, _CH_ENT]
     foot_BWH = x_BCWH[:, _CH_FOOTPRINT]
     legal_BWH = (ent_BWH == _EMPTY_ENT_ID) & (foot_BWH != _FOOTPRINT_UNAVAILABLE)
-    return legal_BWH.reshape(x_BCWH.shape[0], -1)
+    legal_BN = legal_BWH.reshape(x_BCWH.shape[0], -1)
+    # A grid with nowhere left to build would mask every tile to -inf, making
+    # log_softmax NaN and multinomial fault; leave those rows unconstrained (the
+    # env rejects the placement as it always has) rather than crash the rollout.
+    return legal_BN | ~legal_BN.any(dim=-1, keepdim=True)
 
 
 class _SelfAttnStack(nn.Module):

--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -1384,17 +1384,17 @@ class TestLegalTileMask:
         assert masked[0, 4] == float("-inf")
 
     def test_all_illegal_row_is_nan_free(self):
-        """A fully occupied grid leaves every tile illegal; the masked argmax
-        must still return a finite index (tile 0) rather than NaN-ing out."""
+        """A fully occupied grid leaves no legal tile; the row falls back to
+        unconstrained so the log-probs stay finite — masking it out entirely
+        would NaN log_softmax and fault multinomial on the sampling path."""
         size = 3
         obs = self._obs(size)
         obs[0, Channel.ENTITIES.value] = str2ent("transport_belt").value  # occupy everything
         logits = torch.randn(1, size * size)
 
         masked = logits.masked_fill(~_legal_tile_mask(obs), float("-inf"))
-        assert torch.isinf(masked).all(), "every tile should be masked to -inf"
-        idx = masked.argmax(dim=1).item()
-        assert idx == 0, "all-illegal row falls back to tile 0"
+        assert torch.equal(masked, logits), "all-illegal row must stay unconstrained"
+        assert not torch.isnan(torch.log_softmax(masked, dim=1)).any()
 
 
 class TestEotHead:

--- a/tests/test_spatial_agent.py
+++ b/tests/test_spatial_agent.py
@@ -528,6 +528,18 @@ class TestSampleAction:
         assert int(out["action"]["xy"][0, 0]) == 2
         assert int(out["action"]["xy"][0, 1]) == 3
 
+    def test_legal_mask_falls_back_when_nothing_is_buildable(self, agent):
+        """A grid with no legal tile must still yield a finite, sampleable
+        distribution — masking every tile to -inf NaNs the log-probs and faults
+        multinomial mid-rollout."""
+        obs = torch.zeros(2, NUM_CHANNELS, 5, 5)
+        obs[:, _CH_FOOTPRINT] = _FOOTPRINT_UNAVAILABLE
+        obs[:, _CH_ENT] = _EMPTY_ENT_ID + 1
+        for temperature in (0.0, 1.0):
+            out = agent.sample_action(obs, temperature=temperature, legal_mask=True)
+            assert torch.isfinite(out["logp"]).all()
+            assert torch.isfinite(out["entropy"]).all()
+
     def test_replayed_action_recovers_logp(self, agent):
         """Passing a stored action recomputes its exact log-prob regardless of
         temperature — the PPO-update path, unchanged by the refactor."""


### PR DESCRIPTION
Superseded — the fix was pushed directly onto `boyd-legal-mask-true` (#340) instead of stacking a second PR.