### PR TITLE
Skip the reduce-overhead compile on CPU so CPU runs work

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -1206,6 +1206,16 @@ def assert_device_ok(device) -> None:
     )
 
 
+def maybe_compile(fn, device):
+    """`torch.compile(reduce-overhead)` on everything but CPU, where inductor's
+    vectoriser miscodegens the `_legal_tile_mask` select (`VecMask<int,1>` vs
+    `VecMask<float,1>` in one ternary) and g++ rejects the kernel before the
+    first rollout step. MPS keeps compiling: it reaches the Metal backend, not
+    the C++ one, and still fuses — it just skips the CUDA-graph replay, which
+    inductor only ever enables for a lone cuda device."""
+    return fn if device.type == "cpu" else torch.compile(fn, mode="reduce-overhead")
+
+
 def cuda_env_info() -> dict[str, str]:
     """Wheel CUDA build + host driver, recorded in every run's W&B config.
 
@@ -1991,9 +2001,9 @@ if __name__ == "__main__":
     # caller must cudagraph_mark_step_begin() before each call and not retain a
     # raw output past the next call — the rollout copies every output into
     # storage immediately, so that holds.
-    print("Compiling inference paths with torch.compile(reduce-overhead)")
-    rollout_act = torch.compile(agent.get_action_and_value, mode="reduce-overhead")
-    rollout_value = torch.compile(agent.get_value, mode="reduce-overhead")
+    print(f"Inference paths on {device.type}: {'eager' if device.type == 'cpu' else 'compiled'}")
+    rollout_act = maybe_compile(agent.get_action_and_value, device)
+    rollout_value = maybe_compile(agent.get_value, device)
     # Separate handle for the grad update path (B=minibatch, action given). The
     # CUDA graph spans the forward AND its backward (autograd reuses the captured
     # activations, valid because backward runs before the next mark_step_begin);
@@ -2002,7 +2012,7 @@ if __name__ == "__main__":
     # pools from interleaving. The warm-up requires_grad flip and the v_loss-only
     # vs joint-loss change just trigger a one-time recompile of the affected
     # graph.
-    update_act = torch.compile(agent.get_action_and_value, mode="reduce-overhead")
+    update_act = maybe_compile(agent.get_action_and_value, device)
 
     # Two param groups so the critic warm-up + LR annealing can address actor
     # and critic LRs independently; group[0]=actor keeps the existing

--- a/tests/test_compile_inference_paths.py
+++ b/tests/test_compile_inference_paths.py
@@ -1,0 +1,77 @@
+"""End-to-end tests for ``ppo.maybe_compile``.
+
+`reduce-overhead` exists to get CUDA-graph replay, so it is CUDA-only. Off CUDA
+it bought nothing but startup latency, and worse: inductor's CPU vectoriser
+miscodegens the `_legal_tile_mask` select (mixing `VecMask<int,1>` and
+`VecMask<float,1>` in one ternary), so every CPU run — including the CPU-only
+smoke test — died in the C++ backend before the first rollout step.
+"""
+
+import os
+import sys
+
+import pytest
+import torch
+import gymnasium as gym
+
+os.environ["WANDB_MODE"] = "disabled"
+os.environ["WANDB_DISABLED"] = "true"
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from ppo import AgentCNN, make_env, maybe_compile  # noqa: E402
+
+ENV_ID = "factorion/FactorioEnv-v0-maybe-compile-test"
+SIZE = 5
+
+
+@pytest.fixture(scope="module")
+def envs():
+    gym.register(id=ENV_ID, entry_point="ppo:FactorioEnv")
+    return gym.vector.SyncVectorEnv(
+        [make_env(ENV_ID, i, False, SIZE, "test") for i in range(2)]
+    )
+
+
+@pytest.fixture(scope="module")
+def agent(envs):
+    return AgentCNN(envs, layers=(16, 16, 16))
+
+
+def test_cpu_returns_fn_untouched(agent):
+    """On CPU the callable comes back as-is, so inductor is never invoked."""
+    fn = maybe_compile(agent.get_action_and_value, torch.device("cpu"))
+
+    assert fn == agent.get_action_and_value
+    # A dynamo wrapper would carry this.
+    assert not hasattr(fn, "_torchdynamo_orig_callable")
+
+
+@pytest.mark.parametrize("device_type", ["cuda", "mps"])
+def test_accelerators_still_compile(agent, device_type):
+    """Only CPU is excluded — the bug is in inductor's C++ backend, which MPS
+    (Metal) and CUDA never reach. torch.compile is lazy, so this asserts the
+    wrapper was requested without needing the hardware present."""
+    fn = maybe_compile(agent.get_action_and_value, torch.device(device_type))
+
+    assert fn != agent.get_action_and_value
+    assert fn._torchdynamo_orig_callable == agent.get_action_and_value
+
+
+def test_uncompiled_paths_still_act(agent, envs):
+    """The passed-through callables really run the policy, so the rollout gets
+    past the step that used to die in the C++ backend."""
+    cpu = torch.device("cpu")
+    rollout_act = maybe_compile(agent.get_action_and_value, cpu)
+    rollout_value = maybe_compile(agent.get_value, cpu)
+    obs = torch.randn(2, envs.single_observation_space.shape[0], SIZE, SIZE)
+
+    with torch.no_grad():
+        action_out, logp_B, entropy_B, value_B = rollout_act(obs)
+        value_only_B = rollout_value(obs)
+
+    assert action_out["xy"].shape == (2, 2)
+    assert logp_B.shape == (2,)
+    assert entropy_B.shape == (2,)
+    assert value_B.shape == (2,)
+    assert value_only_B.shape == (2,)


### PR DESCRIPTION
## The bug

Every CPU PPO run dies before the first training step — including the CPU-only PPO smoke test from the pre-completion checklist:

```
torch._inductor.exc.InductorError: CppCompileError: C++ compile error
...main.cpp:142:39: error: operands to '?:' have different types
  'at::vec::CPU_CAPABILITY::VecMask<int, 1>' and 'at::vec::CPU_CAPABILITY::VecMask<float, 1>'
```

Inductor's CPU vectoriser miscodegens the `_legal_tile_mask` select. The generated kernel builds an int32 mask in a lambda but pairs it with a float mask in the else arm of one ternary:

```cpp
auto tmp13 = ~tmp12;                    // VecMask<int32_t,1>
return tmp13;
...
auto tmp14 = tmp2 ? tmp3() : at::vec::VecMask<float,1>::from(static_cast<bool>(0));
```

g++ rejects it, and the `CppCompileError` surfaces as an `InductorError` out of the first `rollout_act()` call — so the run never reaches a rollout step. This is an upstream inductor bug (torch 2.12.1), triggered by our mask rather than caused by our code.

## The fix

The three inference handles now go through a one-line `maybe_compile(fn, device)` that passes the callable through untouched **on CPU only**.

MPS deliberately keeps compiling. The bug is in inductor's C++ backend (`cpp_builder` → g++), which MPS never reaches — it lowers through the Metal backend (`mps` is in inductor's `GPU_TYPES`) and still gets fusion. All it loses is CUDA-graph replay, which inductor already gates on a lone `cuda` device (`cudagraph_utils.py:283`), so `reduce-overhead` was silently degrading to plain `torch.compile` on MPS regardless. Excluding MPS would have disabled a working optimization on Mac dev for a bug it can't hit.

+14/−4 in `ppo.py`, with none of the existing rationale comments touched.

## Tests

New `tests/test_compile_inference_paths.py`:

- CPU returns the callable as-is, with no dynamo wrapper, so inductor is never invoked
- `cuda` and `mps` still get a compiled wrapper — `torch.compile` is lazy, so this pins the device gate without needing either accelerator present
- the passed-through CPU callables really run the policy (action + value of the expected shape)

## Verification

Passing: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`, `ruff check .`, `ty check .`, and the new test module (4 passed).

The full `pytest tests/` and both smoke tests are running against this commit; results to follow in a comment. An earlier PPO smoke run against the same CPU behaviour exited 0, with the run stepping (`taking step 10/256`) where it previously crashed.

Note that `tests/test_torch_compile.py` never caught this: it calls `torch.compile(agent)` in default mode, which — per the long-standing comment above the callsite — proxies `.get_action_and_value` straight to eager and compiles nothing.