### PR TITLE
Change the factory grid to 20x20

### DIFF
--- a/ci/sweep_sft.yaml
+++ b/ci/sweep_sft.yaml
@@ -30,8 +30,6 @@ metric:
 
 parameters:
   # Pinned: monotonic in the metric, so Bayes would only saturate them.
-  size:
-    value: 11
   num_samples:
     value: 5000000
   epochs:

--- a/ppo.py
+++ b/ppo.py
@@ -600,7 +600,7 @@ def get_pretty_format(tensor, entity_dir_map):
 class FactorioEnv(gym.Env):
     def __init__(
         self,
-        size: int = 11,
+        size: int = SharedArgs.size,
         max_steps: Optional[int] = None,
         render_mode: Optional[str] = None,
         idx: Optional[int] = None,

--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -64,6 +64,7 @@ from ppo import (  # noqa: E402
     apply_placement_action,
     make_env,
 )
+from training_config import SharedArgs  # noqa: E402
 
 
 # Order shown in the palette and dropdowns.
@@ -131,7 +132,7 @@ HELP_LINES = [
 class Args:
     port: int = 8765
     """port for the local HTTP server"""
-    size: int = 11
+    size: int = SharedArgs.size
     """default grid size"""
     checkpoint: Optional[str] = None
     """path to a trained SFT/PPO checkpoint (.pt). If set, the UI shows

--- a/tests/test_grid_sizes.py
+++ b/tests/test_grid_sizes.py
@@ -68,10 +68,3 @@ class TestGridSizes:
             if terminated or truncated:
                 obs, info = env.reset()
         env.close()
-
-    def test_default_size_is_11(self):
-        """Default PpoArgs.size is 11, matching the canonical SFT checkpoint
-        (kkcv6xe3) so `ppo.py --start_from <ckpt>` loads without arch flags."""
-        from ppo import PpoArgs
-        args = PpoArgs()
-        assert args.size == 11

--- a/training_config.py
+++ b/training_config.py
@@ -35,7 +35,7 @@ class SharedArgs:
 
     seed: int = 1
     """seed of the experiment"""
-    size: int = 11
+    size: int = 20
     """the width and height of the factory grid"""
 
     # CNN encoder width per layer slot. The encoder uses every slot with
@@ -54,8 +54,8 @@ class SharedArgs:
     kernel_size: int = 3
     """CNN conv kernel size (odd); padding pinned to kernel_size // 2 ("same")"""
     attn_dim: int = 192
-    """model dim of the self-attention stage over the encoded map (the 121 grid
-    cells become tokens, so full attention is cheap and every head gets
+    """model dim of the self-attention stage over the encoded map (each grid
+    cell becomes a token, so full attention is cheap and every head gets
     grid-global information in one hop). The dominant win in the SFT arch
     sweeps; the second sweep (91w8vyea) preferred 192-256 over 128. 0 disables
     the stage, recovering a conv-only ablation baseline. Int not bool for W&B


### PR DESCRIPTION
## What

`SharedArgs.size` 11 → 20. That is the single source of truth, so PPO, SFT and the SFT sweep all move together, and the episode budget follows it (`max_steps = size * size`, so 121 → 400).

The rest of the diff removes the places that were carrying their own copy of the value rather than reading it:

- `FactorioEnv.__init__` and `scripts/factory_builder.py:Args` defaulted to a literal `11`; both now read `SharedArgs.size`.
- `ci/sweep_sft.yaml` pinned `size: 11`. Dropped entirely — the sweep command is `python ${program} --track ${args}` and `${args}` only expands swept parameters, so with no `size` key nothing passes `--size` and tyro takes the `SftArgs` default.
- `test_default_size_is_11` asserted the constant against itself. Deleted rather than renumbered.
- The `attn_dim` docstring said "the 121 grid cells become tokens". Reworded to "each grid cell becomes a token" so there is no number to go stale next time.

Net +6/−14.

Rebased onto main to pick up #349, which fixes the combinatorial blow-up in `find_belt_paths` that this change originally hit — `build_move_one_item` enumerated every shortest belt route (~C(2n, n), so 1.7e10 across a 20×20) and was OOM-killed at 15.4 GB inside the first hundred seeds. Nothing in this PR touches that; it just depends on it.

## Verification

Every lesson kind builds on the larger grid, re-run against main's implementation — 200/200 seeds for all 14 kinds, positive `max_throughput`, and no orphans beyond `SPLITTER_MERGE_SIDELOADED`'s sanctioned side-load decoys:

```
lesson                                   built   tp>0  orph      ents   maxtp
MOVE_ONE_ITEM                              200    200     0      1-32 15.0-15.0
SPLITTER_SPLIT                             200    200     0     10-52 7.5-7.5
SPLITTER_MERGE_SIDELOADED                  200    200     0     14-70 15.0-15.0
MOVE_VIA_UG_BELT                           200    200     0      6-46 15.0-15.0
MEMORISE_1_INGREDIENT_RECIPES              200    200     0       5-5 0.0-0.9
MEMORISE_2_INGREDIENT_RECIPES              200    200     0       7-7 0.0-0.9
MEMORISE_3_INGREDIENT_RECIPES              200    200     0       9-9 0.0-0.9
MEMORISE_4_INGREDIENT_RECIPES              200    200     0     11-11 0.0-0.2
MOVE_ONE_ITEM_CHAOS                        200    200     0      9-62 15.0-15.0
CROSS_UNDER_BELT                           200    200     0      4-36 15.0-15.0
FACTORY_1_INGREDIENT                       200    200     0     13-87 0.0-6.4
TRIAL_RECIPE_TREE_DEPTH_1                  200    200     0       0-0 1.0-10.0
TRIAL_RECIPE_TREE_DEPTH_2                  200    200     0       0-0 1.0-2.0
TRIAL_RECIPE_TREE_DEPTH_3                  200    200     0       0-0 1.0-2.0
```

Full pre-completion checklist, all on the final code:

| # | Check | Result |
| --- | --- | --- |
| 1 | `cargo fmt --check` + `clippy -- -D warnings` | clean |
| 2 | `cargo test` | 166 passed |
| 3 | `maturin develop --release` | builds |
| 4 | `pytest tests/` | 3247 passed, 708 skipped (2:07:43) |
| 5 | `ruff check .` | clean |
| 6 | `ty check .` | clean |
| 7 | PPO smoke, 5k timesteps | exit 0 |
| 8 | SFT smoke | exit 0, `val/thput 0.039` |

The PPO smoke completes with no workaround — rollout, GAE, all 8 optimiser epochs, greedy eval and checkpoint save, run signature `ppo-s20-…`. (On an earlier run it needed `TORCH_COMPILE_DISABLE=1` to get past a torch inductor CPU codegen bug; #347 on main fixes that, and this run had zero compile errors.)

## Follow-ups this does not do

- **Eval is now the dominant CPU cost.** In the smoke run one iteration was 2:46:31 wall — rollout 598 s, update 1874 s, and the rest `run_rollout_eval`. It is 168 held-out factories × up to 400 greedy steps ≈ 67k sequential forwards (vs ~20k at 11×11), each with ~11× the attention cost (400² vs 121² tokens). Irrelevant on the GPU pods where real runs happen; it makes CPU-local smoke runs slow.
- **The canonical SFT base `j0s5y2mc` no longer loads.** It was trained at 11×11 and the attention positional embedding is `(1, size*size, dim)`, so `--start-from j0s5y2mc` will shape-mismatch. A fresh SFT run at 20×20 is needed to re-establish the base and the `val/thput ≈ 0.11` bar.
- **The Factorio mod is still pinned to 11×11** (`GRID_SIZE` in `mod/control.lua`, `MOD_GRID_SIZE` in `server/server.py`) and hard-rejects checkpoints of another size. Left alone deliberately: bumping it to 20 would immediately break the documented default checkpoint `h76h80yb`, which is an 11×11 model, and there is no 20×20 checkpoint to point it at yet. Worth doing in the same change as re-pointing that default.