### PR TITLE
Scan seeds tab: rebuild many blanked factories at once

### DIFF
--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -44,6 +44,7 @@ import factorion_rs  # noqa: E402
 from factorion import (  # noqa: E402
     Channel,
     Direction,
+    Factory,
     Footprint,
     LessonKind,
     Misc,
@@ -241,6 +242,25 @@ def _apply_prediction(grid: list[list[dict]], prediction: dict) -> dict:
 _LESSON_RETRY_BUDGET = 200
 
 
+def _build_with_retry(kind: LessonKind, size: int, seed: int) -> tuple[Factory, int]:
+    """Build a factory of `kind`, returning it with the seed that produced it.
+
+    `build_factory` returns None when its random layout search doesn't find
+    a valid configuration; we follow the docstring's recommended retry
+    idiom of advancing the seed and trying again."""
+    attempt_seed = int(seed)
+    for _ in range(_LESSON_RETRY_BUDGET):
+        factory = build_factory(size=size, kind=kind, seed=attempt_seed)
+        if factory is not None:
+            return factory, attempt_seed
+        attempt_seed += 1
+    raise RuntimeError(
+        f"build_factory returned None for {_LESSON_RETRY_BUDGET} consecutive "
+        f"seeds (kind={kind.name}, size={size}, start_seed={seed}) — the "
+        f"grid may be too small for this lesson."
+    )
+
+
 def _load_lesson(
     kind_name: str, seed: int, size: int, num_missing_entities: int = 0
 ) -> dict:
@@ -256,43 +276,30 @@ def _load_lesson(
     was trained to complete. ``num_missing_entities=0`` (the default)
     leaves the factory fully generated.
 
-    `build_factory` returns None when its random layout search doesn't
-    find a valid configuration. We follow the docstring's recommended
-    retry idiom: advance the seed and try again. The seed that actually
-    produced the factory is returned as ``used_seed`` so the UI can show
-    it; ``next_seed = used_seed + 1`` is what the UI advances to so
-    repeated clicks produce distinct variants."""
+    The seed that actually produced the factory is returned as
+    ``used_seed`` so the UI can show it; ``next_seed = used_seed + 1`` is
+    what the UI advances to so repeated clicks produce distinct
+    variants."""
     try:
         kind = LessonKind[kind_name]
     except KeyError as e:
         raise ValueError(f"unknown lesson kind: {kind_name!r}") from e
     num_missing_entities = max(0, int(num_missing_entities))
-    attempt_seed = int(seed)
-    for _ in range(_LESSON_RETRY_BUDGET):
-        factory = build_factory(size=size, kind=kind, seed=attempt_seed)
-        if factory is not None:
-            # Blank entities with the factory's own seed so repeated
-            # clicks at the same (kind, seed, N) are reproducible. N=0
-            # removes nothing → the partial world is the full factory.
-            partial_CWH, num_removed = blank_entities(
-                factory,
-                num_missing_entities=num_missing_entities,
-                seed=attempt_seed,
-            )
-            return {
-                "size": size,
-                "grid": world_CWH_to_grid(partial_CWH),
-                "used_seed": attempt_seed,
-                "next_seed": attempt_seed + 1,
-                "total_entities": int(factory.total_entities),
-                "num_removed": int(num_removed),
-            }
-        attempt_seed += 1
-    raise RuntimeError(
-        f"build_factory returned None for {_LESSON_RETRY_BUDGET} consecutive "
-        f"seeds (kind={kind_name}, size={size}, start_seed={seed}) — the "
-        f"grid may be too small for this lesson."
+    factory, used_seed = _build_with_retry(kind, size, seed)
+    # Blank entities with the factory's own seed so repeated clicks at the
+    # same (kind, seed, N) are reproducible. N=0 removes nothing → the
+    # partial world is the full factory.
+    partial_CWH, num_removed = blank_entities(
+        factory, num_missing_entities=num_missing_entities, seed=used_seed
     )
+    return {
+        "size": size,
+        "grid": world_CWH_to_grid(partial_CWH),
+        "used_seed": used_seed,
+        "next_seed": used_seed + 1,
+        "total_entities": int(factory.total_entities),
+        "num_removed": int(num_removed),
+    }
 
 
 def render_graph_png(grid: list[list[dict]]) -> dict:
@@ -696,37 +703,24 @@ def _reset_rollout_env(
 ) -> tuple[np.ndarray, int]:
     """Reset `env` onto (kind, seed) and return (obs, the seed that built).
 
-    Advances past seeds whose rejection sampler gives up — the same retry
-    idiom :func:`_load_lesson` uses — so a scan never dies on one unlucky
-    seed. Omitting ``num_missing_entities`` leaves the env's default of
-    "blank everything", which is the point of the scan: rebuild from the
-    lesson's protected tiles alone.
+    The seed is settled against `build_factory` first — `FactorioEnv.reset`
+    turns a failed build into a bare RuntimeError it also raises for
+    unrelated reasons, so probing here (as `ppo._build_eval_set` does)
+    keeps a scan from swallowing a real error as an unlucky seed. Omitting
+    ``num_missing_entities`` leaves the env's default of "blank
+    everything", which is the point of the scan: rebuild from the lesson's
+    protected tiles alone.
     """
-    attempt = int(seed)
-    for _ in range(_LESSON_RETRY_BUDGET):
-        options: dict = {"kind": kind}
-        if num_missing_entities is not None:
-            options["num_missing_entities"] = num_missing_entities
-        try:
-            obs, _info = env.reset(seed=attempt, options=options)
-        except RuntimeError:
-            attempt += 1
-            continue
-        return obs, attempt
-    raise RuntimeError(
-        f"build_factory returned None for {_LESSON_RETRY_BUDGET} consecutive "
-        f"seeds (kind={kind.name}, size={env.size}, start_seed={seed})."
-    )
+    _factory, used_seed = _build_with_retry(kind, env.size, seed)
+    options: dict = {"kind": kind}
+    if num_missing_entities is not None:
+        options["num_missing_entities"] = num_missing_entities
+    obs, _info = env.reset(seed=used_seed, options=options)
+    return obs, used_seed
 
 
 def _rollout_result(
-    index: int,
-    env: FactorioEnv,
-    seed: int,
-    info: dict,
-    steps: int,
-    terminated: bool,
-    eot_prob: float,
+    index: int, env: FactorioEnv, seed: int, info: dict, terminated: bool
 ) -> dict:
     return {
         "type": "result",
@@ -734,13 +728,11 @@ def _rollout_result(
         "kind": env._kind.name,
         "seed": seed,
         "size": env.size,
-        "steps": steps,
+        "steps": int(env.steps),
         "stopped_by": "eot" if terminated else "max_steps",
-        "eot_prob": eot_prob,
         "thput_normed": float(info.get("thput_normed", 0.0)),
         "thput_raw": float(info.get("thput_raw", 0.0)),
         "max_throughput": float(env._max_throughput),
-        "num_entities": int(info.get("num_entities", 0)),
         "num_placed_entities": int(info.get("num_placed_entities", 0)),
         "frac_reachable": float(info.get("frac_reachable", 0.0)),
         "invalid_actions": int(env.invalid_actions),
@@ -754,18 +746,17 @@ def _batch_rollout(
     seeds: list[int],
     size: int,
     num_missing_entities: Optional[int],
-    eot_threshold: float,
     legal_mask: bool,
 ) -> Iterator[dict]:
     """Greedily rebuild one blanked factory per (kind, seed), yielding an
     event per finished rollout.
 
-    Every rollout advances in lockstep so a single batched ``sample_action``
-    covers the whole set — N seeds cost about one seed's worth of forward
-    passes, which is what makes scanning 20 seeds interactive rather than a
-    20× wait. Slots that have already stopped stay in the batch (their
-    outputs are discarded); dropping them would cost a re-pack every step
-    for a tail that is short by construction.
+    Every rollout advances in lockstep through one batched ``sample_action``.
+    Slots that have already stopped stay in the batch and their outputs are
+    discarded: compacting would change the batch shape every step, and mps
+    re-plans kernels per shape, which measures far slower than the wasted
+    slots (N=64: 5.6s fixed vs 29.8s compacted). ``sft.run_rollout_eval``
+    makes the same choice.
 
     Greedy argmax + the legal-tile mask mirror ``sft.run_rollout_eval``, so a
     scan's throughput numbers are the same quantity as ``eval/thput`` — except
@@ -786,18 +777,10 @@ def _batch_rollout(
         used_seeds.append(used)
         obs_list.append(obs)
 
-    yield {
-        "type": "start",
-        "n": len(envs),
-        "jobs": [
-            {"index": i, "kind": env._kind.name, "seed": s}
-            for i, (env, s) in enumerate(zip(envs, used_seeds))
-        ],
-    }
+    yield {"type": "start", "n": len(envs)}
 
     obs_NCWH = np.stack(obs_list)
     active = [True] * len(envs)
-    steps = [0] * len(envs)
     step = 0
     with torch.no_grad():
         while any(active):
@@ -805,11 +788,7 @@ def _batch_rollout(
                 obs_NCWH, dtype=torch.float32, device=_AGENT_DEVICE
             )
             out = agent.sample_action(
-                batch,
-                temperature=0.0,
-                legal_mask=legal_mask,
-                eot_threshold=eot_threshold,
-                compute_value=False,
+                batch, temperature=0.0, legal_mask=legal_mask, compute_value=False
             )
             act = out["action"]
             xy = act["xy"].cpu().numpy()
@@ -818,7 +797,6 @@ def _batch_rollout(
             item = act["item"].reshape(-1).cpu().numpy()
             misc = act["misc"].reshape(-1).cpu().numpy()
             eot = act["eot"].reshape(-1).cpu().numpy()
-            eot_p = out["eot_prob"].reshape(-1).cpu().numpy()
             step += 1
             for i, env in enumerate(envs):
                 if not active[i]:
@@ -833,14 +811,10 @@ def _batch_rollout(
                 }
                 next_obs, _reward, terminated, truncated, info = env.step(action)
                 obs_NCWH[i] = next_obs
-                steps[i] += 1
                 if terminated or truncated:
                     active[i] = False
-                    yield _rollout_result(
-                        i, env, used_seeds[i], info, steps[i],
-                        terminated, float(eot_p[i]),
-                    )
-            yield {"type": "progress", "step": step, "running": sum(active)}
+                    yield _rollout_result(i, env, used_seeds[i], info, terminated)
+            yield {"type": "progress", "step": step}
     yield {"type": "done"}
 
 
@@ -872,7 +846,6 @@ def _batch_rollout_request(payload: dict) -> Iterator[dict]:
             seeds=seeds,
             size=size,
             num_missing_entities=num_missing,
-            eot_threshold=float(payload.get("eot_threshold", 0.5)),
             legal_mask=bool(payload.get("legal_mask", True)),
         )
     except Exception as e:
@@ -898,6 +871,14 @@ ITEM_ICONS = {
     for it in items.values()
     if it.name != "empty" and it.name not in PALETTE_ICONS
 }
+# Grid cells reference icons by class, not by inlining the data URI. A scan
+# renders up to 128 grids at once and each ~10 KB URI would be repeated per
+# occupied cell — ~300 KB of HTML per grid instead of ~5 KB.
+ICON_CSS = "\n".join(
+    f".ic-{name}{{background-image:url({uri})}}"
+    for name, uri in {**PALETTE_ICONS, **ITEM_ICONS}.items()
+    if uri
+)
 
 
 def render_index(default_size: int) -> str:
@@ -1059,8 +1040,12 @@ def render_index(default_size: int) -> str:
         transparent 2px, transparent 8px);
   }}
   .cell-inner {{ position: relative; width: 100%; height: 100%; }}
-  .cell-inner img.ent {{ position: absolute; top: 10%; left: 10%; width: 60%; height: 60%; }}
-  .cell-inner img.itm {{ position: absolute; bottom: 4%; right: 4%; width: 30%; height: 30%; }}
+  .cell-inner .ent, .cell-inner .itm {{
+    position: absolute; background-size: contain;
+    background-repeat: no-repeat; background-position: center;
+  }}
+  .cell-inner .ent {{ top: 10%; left: 10%; width: 60%; height: 60%; }}
+  .cell-inner .itm {{ bottom: 4%; right: 4%; width: 30%; height: 30%; }}
   .cell-inner .arrow {{
     position: absolute; bottom: -1px; left: 2px;
     font-size: 13px; line-height: 13px; color: #222;
@@ -1153,14 +1138,29 @@ def render_index(default_size: int) -> str:
     font-family: monospace; font-size: 0.85em; margin: 0.5em 0;
     padding: 0.4em 0.6em; background: #f4f4f4; border-radius: 4px;
   }}
+  .scan-stats {{ margin: 0.5em 0; }}
+  .scan-stats table {{ border-collapse: collapse; font-size: 0.78em; }}
+  .scan-stats th, .scan-stats td {{
+    padding: 0.12em 0.9em 0.12em 0; text-align: right;
+    font-family: monospace; font-weight: normal;
+  }}
+  .scan-stats th {{ color: #666; border-bottom: 1px solid #ddd; }}
+  .scan-stats th:first-child, .scan-stats td:first-child {{ text-align: left; }}
+  .scan-stats td.kind {{ font-family: inherit; }}
   .scan-results {{ display: flex; flex-wrap: wrap; gap: 0.6em; }}
   .scan-card {{
     border: 1px solid #ccc; border-left-width: 5px; border-radius: 5px;
     padding: 0.35em; background: #fff; cursor: pointer;
+    flex: 0 0 auto; width: max-content;
   }}
   .scan-card:hover {{ background: #f6fbff; border-color: #0d47a1; }}
   .scan-card .hd {{ font-size: 0.72em; font-weight: bold; }}
   .scan-card .sub {{ font-size: 0.7em; color: #666; font-family: monospace; }}
+  /* Width 0 keeps the text out of the card's max-content width, so every
+     card is exactly as wide as its grids and the gallery tiles into
+     aligned columns; min-width then wraps the text back to that width
+     instead of the longest lesson name stretching the card. */
+  .scan-card .hd, .scan-card .sub {{ width: 0; min-width: 100%; }}
   .scan-card .pair {{ display: flex; gap: 0.4em; align-items: flex-start; }}
   .scan-card figure {{ margin: 0.2em 0 0; }}
   .scan-card figcaption {{
@@ -1174,6 +1174,7 @@ def render_index(default_size: int) -> str:
   table.mini td.unavailable {{ background: #e8e8e8; }}
   table.mini .arrow {{ font-size: 9px; line-height: 9px; }}
   table.mini .misc {{ font-size: 9px; }}
+{ICON_CSS}
 </style></head><body>
 
 <h1>Factory builder
@@ -1282,14 +1283,13 @@ def render_index(default_size: int) -> str:
     <button id="scan-stop" disabled>Stop</button>
   </div>
   <div class="scan-summary" id="scan-summary">no scan yet</div>
+  <div class="scan-stats" id="scan-stats"></div>
   <div class="scan-results" id="scan-results"></div>
 </div>
 
 <script>
 const ALL_KINDS = '{ALL_KINDS_SENTINEL}';
 const NUM_LESSON_KINDS = {len(list(LessonKind))};
-const PALETTE_ICONS = {json.dumps(PALETTE_ICONS)};
-const ITEM_ICONS = {json.dumps(ITEM_ICONS)};
 const HOTBAR = {json.dumps(HOTBAR)};
 const DIR_ARROW = {{ NONE: '', NORTH: '↑', EAST: '→', SOUTH: '↓', WEST: '←' }};
 const MISC_GLYPH = {{ NONE: '', UNDERGROUND_DOWN: '▼', UNDERGROUND_UP: '▲' }};
@@ -1341,8 +1341,19 @@ function pBadgeColor(p) {{
   return `hsl(${{hue}}, ${{sat}}%, 42%)`;
 }}
 
-function iconFor(name) {{
-  return PALETTE_ICONS[name] || ITEM_ICONS[name] || '';
+// One cell's glyph layer, shared by the interactive grid and the scan
+// gallery so the two can never draw the same world differently.
+function cellGlyphs(c) {{
+  let html = '';
+  if (c.entity && c.entity !== 'empty')
+    html += `<i class="ent ic-${{c.entity}}"></i>`;
+  if (c.item && c.item !== 'empty')
+    html += `<i class="itm ic-${{c.item}}"></i>`;
+  const arrow = DIR_ARROW[c.direction] || '';
+  if (arrow) html += `<div class="arrow">${{arrow}}</div>`;
+  const m = MISC_GLYPH[c.misc] || '';
+  if (m) html += `<div class="misc">${{m}}</div>`;
+  return html;
 }}
 
 // The stop head is authoritative for every apply path in the UI, not just
@@ -1387,15 +1398,7 @@ function renderGrid() {{
 
       const inner = document.createElement('div');
       inner.className = 'cell-inner';
-      let html = `<div class="xy">${{x}},${{y}}</div>`;
-      if (c.entity && c.entity !== 'empty')
-        html += `<img class="ent" src="${{iconFor(c.entity)}}">`;
-      if (c.item && c.item !== 'empty')
-        html += `<img class="itm" src="${{iconFor(c.item)}}">`;
-      const arrow = DIR_ARROW[c.direction] || '';
-      if (arrow) html += `<div class="arrow">${{arrow}}</div>`;
-      const m = MISC_GLYPH[c.misc] || '';
-      if (m) html += `<div class="misc">${{m}}</div>`;
+      let html = `<div class="xy">${{x}},${{y}}</div>` + cellGlyphs(c);
       // Ghost overlay: render every candidate tile (all tiles where
       // p(tile) > threshold) on top of empty cells, with opacity
       // proportional to the tile probability so the user can see what
@@ -1409,9 +1412,9 @@ function renderGrid() {{
         // strongest reads as near-solid.
         const op = (0.18 + 0.77 * cand.p_tile).toFixed(2);
         if (cand.entity && cand.entity !== 'empty')
-          html += `<img class="ent ghost" style="opacity:${{op}}" src="${{iconFor(cand.entity)}}">`;
+          html += `<i class="ent ghost ic-${{cand.entity}}" style="opacity:${{op}}"></i>`;
         if (cand.item && cand.item !== 'empty')
-          html += `<img class="itm ghost" style="opacity:${{op}}" src="${{iconFor(cand.item)}}">`;
+          html += `<i class="itm ghost ic-${{cand.item}}" style="opacity:${{op}}"></i>`;
         const garrow = DIR_ARROW[cand.direction] || '';
         if (garrow) html += `<div class="arrow ghost" style="opacity:${{op}}">${{garrow}}</div>`;
         const gmisc = MISC_GLYPH[cand.misc] || '';
@@ -1963,6 +1966,20 @@ async function loadModel() {{
     btn.disabled = false;
   }}
 }}
+// Adopt a whole grid as the Build tab's working state. The stale selection
+// and prediction have to be dropped along with the old grid — otherwise the
+// ghost overlays and argmax border are drawn over a factory they don't
+// belong to — so every wholesale swap goes through here.
+function adoptGrid(size, cells) {{
+  SIZE = size;
+  grid = cells;
+  selected = null;
+  prediction = null;
+  document.getElementById('size').value = SIZE;
+  renderGrid(); syncEditor();
+  scheduleCompute();
+}}
+
 async function generateLesson() {{
   const kind = document.getElementById('lesson-kind').value;
   const seed = parseInt(document.getElementById('lesson-seed').value, 10);
@@ -1983,11 +2000,7 @@ async function generateLesson() {{
     }});
     const data = await resp.json();
     if (data.error) {{ status.textContent = 'error: ' + data.error; return; }}
-    SIZE = data.size;
-    grid = data.grid;
-    selected = null;
-    prediction = null;
-    document.getElementById('size').value = SIZE;
+    adoptGrid(data.size, data.grid);
     document.getElementById('lesson-seed').value = data.next_seed;
     // `num_removed` is what blank_entities actually cleared, which can be
     // less than requested when the lesson protects most of its entities.
@@ -1997,8 +2010,6 @@ async function generateLesson() {{
     status.textContent =
       'built ' + kind + ' (seed=' + data.used_seed +
       ', ' + data.total_entities + ' entities' + cleared + ')';
-    renderGrid(); syncEditor();
-    scheduleCompute();
   }} catch (e) {{
     status.textContent = 'failed: ' + e;
   }} finally {{
@@ -2110,9 +2121,7 @@ function bindHelp() {{
 
 // ── Scan tab ────────────────────────────────────────────────────────────
 // A scan blanks N factories, lets the model rebuild each one until its EOT
-// head fires, and lays the finished factories out side by side. The server
-// runs all N in lockstep through one batched forward per step, so the wall
-// clock is roughly one rollout's, not N.
+// head fires, and lays the finished factories out side by side.
 let scanResults = [];
 let scanAbort = null;
 
@@ -2123,31 +2132,20 @@ function switchTab(name) {{
   document.getElementById('tab-scan').hidden = (name !== 'scan');
 }}
 
-// Red at zero throughput through to green at a perfect rebuild. The card's
-// left border is the fastest read in the gallery — you spot the cluster of
-// failures before any text resolves.
+// The card's left border is the fastest read in the gallery — a cluster of
+// failures registers before any text resolves.
 function thputColor(t) {{
   const q = Math.max(0, Math.min(t, 1));
   return `hsl(${{Math.round(q * 120)}}, 70%, 45%)`;
 }}
 
-function miniGrid(g, n) {{
+function miniGrid(g) {{
   let html = '<table class="mini">';
-  for (let y = 0; y < n; y++) {{
+  for (const row of g) {{
     html += '<tr>';
-    for (let x = 0; x < n; x++) {{
-      const c = g[y][x];
-      let inner = '';
-      if (c.entity && c.entity !== 'empty')
-        inner += `<img class="ent" src="${{iconFor(c.entity)}}">`;
-      if (c.item && c.item !== 'empty')
-        inner += `<img class="itm" src="${{iconFor(c.item)}}">`;
-      const arrow = DIR_ARROW[c.direction] || '';
-      if (arrow) inner += `<div class="arrow">${{arrow}}</div>`;
-      const m = MISC_GLYPH[c.misc] || '';
-      if (m) inner += `<div class="misc">${{m}}</div>`;
+    for (const c of row) {{
       const cls = c.footprint === 'UNAVAILABLE' ? ' class="unavailable"' : '';
-      html += `<td${{cls}}><div class="cell-inner">${{inner}}</div></td>`;
+      html += `<td${{cls}}><div class="cell-inner">${{cellGlyphs(c)}}</div></td>`;
     }}
     html += '</tr>';
   }}
@@ -2168,20 +2166,15 @@ function scanCard(r, showRef) {{
     `<div class="sub">${{stop}} · ${{r.num_placed_entities}} placed · ` +
     `${{r.invalid_actions}} invalid · reach ${{Math.round(r.frac_reachable * 100)}}%</div>`;
   const built =
-    `<figure><figcaption>built</figcaption>${{miniGrid(r.grid, r.size)}}</figure>`;
+    `<figure><figcaption>built</figcaption>${{miniGrid(r.grid)}}</figure>`;
   const ref = showRef
-    ? `<figure><figcaption>reference</figcaption>${{miniGrid(r.solved_grid, r.size)}}</figure>`
+    ? `<figure><figcaption>reference</figcaption>${{miniGrid(r.solved_grid)}}</figure>`
     : '';
   card.innerHTML = head + `<div class="pair">${{built}}${{ref}}</div>`;
   card.title = 'Open this factory in the Build tab';
   card.addEventListener('click', () => {{
-    SIZE = r.size;
-    grid = r.grid.map(row => row.map(c => Object.assign({{}}, c)));
-    selected = null;
-    prediction = null;
-    document.getElementById('size').value = SIZE;
     switchTab('build');
-    renderGrid(); syncEditor(); scheduleCompute();
+    adoptGrid(r.size, r.grid.map(row => row.map(c => Object.assign({{}}, c))));
   }});
   return card;
 }}
@@ -2199,7 +2192,12 @@ function renderScan() {{
     rows.sort((a, b) => a.index - b.index);
   }}
   host.replaceChildren(...rows.map(r => scanCard(r, showRef)));
+  renderScanStats();
 }}
+
+// A factory counts as complete at thput 1.0 — the same "already done"
+// test sft.run_rollout_eval scores the EOT head against.
+const COMPLETE_THPUT = 0.999;
 
 function scanSummary(status) {{
   const el = document.getElementById('scan-summary');
@@ -2208,12 +2206,49 @@ function scanSummary(status) {{
   const t = scanResults.map(r => r.thput_normed);
   const mean = t.reduce((a, b) => a + b, 0) / n;
   const zeros = t.filter(v => v <= 0).length;
-  const perfect = t.filter(v => v >= 0.999).length;
+  const perfect = t.filter(v => v >= COMPLETE_THPUT).length;
   const eot = scanResults.filter(r => r.stopped_by === 'eot').length;
   el.textContent =
     `${{n}} done · mean thput ${{mean.toFixed(3)}} · ${{zeros}} at zero · ` +
     `${{perfect}} perfect · eot fired ${{eot}}/${{n}}` +
     (status ? '  ·  ' + status : '');
+}}
+
+// Per-lesson breakdown. A mean over the whole scan hides the thing worth
+// finding — that one lesson is at zero while the rest are fine — so every
+// kind gets its own row, worst mean first.
+function renderScanStats() {{
+  const host = document.getElementById('scan-stats');
+  if (!scanResults.length) {{ host.replaceChildren(); return; }}
+  const byKind = new Map();
+  for (const r of scanResults) {{
+    if (!byKind.has(r.kind)) byKind.set(r.kind, []);
+    byKind.get(r.kind).push(r);
+  }}
+  const frac = (hits, n) =>
+    `${{hits}}/${{n}} (${{Math.round((hits / n) * 100)}}%)`;
+  const rows = [...byKind.entries()].map(([kind, rs]) => {{
+    const n = rs.length;
+    return {{
+      kind,
+      n,
+      mean: rs.reduce((a, r) => a + r.thput_normed, 0) / n,
+      nonzero: rs.filter(r => r.thput_normed > 0).length,
+      complete: rs.filter(r => r.thput_normed >= COMPLETE_THPUT).length,
+      eot: rs.filter(r => r.stopped_by === 'eot').length,
+    }};
+  }});
+  rows.sort((a, b) => a.mean - b.mean || a.kind.localeCompare(b.kind));
+  const head =
+    '<tr><th>lesson</th><th>runs</th><th>mean thput</th>' +
+    '<th>thput &gt; 0</th><th>complete</th><th>eot fired</th></tr>';
+  const body = rows.map(row =>
+    `<tr><td class="kind">${{escHtml(row.kind)}}</td><td>${{row.n}}</td>` +
+    `<td style="color:${{thputColor(row.mean)}}">${{row.mean.toFixed(3)}}</td>` +
+    `<td>${{frac(row.nonzero, row.n)}}</td><td>${{frac(row.complete, row.n)}}</td>` +
+    `<td>${{frac(row.eot, row.n)}}</td></tr>`
+  ).join('');
+  host.innerHTML = `<table>${{head}}${{body}}</table>`;
 }}
 
 async function runScan() {{
@@ -2236,6 +2271,7 @@ async function runScan() {{
   }};
   scanResults = [];
   document.getElementById('scan-results').replaceChildren();
+  renderScanStats();
   scanAbort = new AbortController();
   runBtn.disabled = true;
   stopBtn.disabled = false;
@@ -2250,11 +2286,12 @@ async function runScan() {{
       body: JSON.stringify(body),
       signal: scanAbort.signal,
     }});
+    // A status-coded failure has no NDJSON body to read, so it would
+    // otherwise show as a scan that finished with nothing in it.
+    if (!resp.ok) throw new Error('server returned HTTP ' + resp.status);
     const reader = resp.body.getReader();
     const decoder = new TextDecoder();
     let buf = '';
-    // The server streams newline-delimited JSON so results land as they
-    // finish instead of after the slowest rollout.
     for (;;) {{
       const {{ done, value }} = await reader.read();
       if (done) break;
@@ -2274,12 +2311,12 @@ async function runScan() {{
           // every arrival is O(N^2) table builds. renderScan() applies
           // the chosen sort once the stream ends.
           document.getElementById('scan-results').appendChild(scanCard(ev, showRef));
-          scanSummary(scanResults.length + '/' + total + ' finished');
+          renderScanStats();
         }} else if (ev.type === 'progress') {{
           const secs = (performance.now() - started) / 1000;
           scanSummary(
-            'step ' + ev.step + ' · ' + ev.running + ' still building · ' +
-            secs.toFixed(1) + 's'
+            'step ' + ev.step + ' · ' + scanResults.length + '/' + total +
+            ' finished · ' + secs.toFixed(1) + 's'
           );
         }} else if (ev.type === 'error') {{
           scanSummary('error: ' + ev.error);
@@ -2357,14 +2394,17 @@ class Handler(BaseHTTPRequestHandler):
     def _stream_ndjson(self, events: Iterator[dict]) -> None:
         """Write one JSON object per line as the generator produces them.
 
-        The response carries no Content-Length: this handler speaks HTTP/1.0,
-        so end-of-body is end-of-connection, which is also how the browser's
-        Stop button works — aborting the fetch drops the socket, the next
-        write raises, and abandoning the generator cancels the scan.
+        The response carries no Content-Length, so end-of-body is
+        end-of-connection — hence the explicit `Connection: close`, which
+        keeps the framing correct even if someone raises the handler's
+        protocol_version to HTTP/1.1. It is also how the browser's Stop
+        button works: aborting the fetch drops the socket, the next write
+        raises, and abandoning the generator cancels the scan.
         """
         self.send_response(200)
         self.send_header("Content-Type", "application/x-ndjson")
         self.send_header("Cache-Control", "no-store")
+        self.send_header("Connection", "close")
         self.end_headers()
         try:
             for event in events:

--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -24,7 +24,7 @@ import traceback
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 import matplotlib
 
@@ -122,6 +122,7 @@ HELP_LINES = [
     "Generate lesson: g (set 'entities to clear' to blank N first)",
     "Apply prediction: tap a once / hold a for fast autoregressive placement",
     "Resize / clear grid: c",
+    "Scan seeds tab: rebuild N blanked seeds at once, click a result to open it",
 ]
 
 
@@ -679,6 +680,206 @@ def _predict_action(grid: list[list[dict]]) -> dict:
     }
 
 
+# ── Batched seed scan ────────────────────────────────────────────────────────
+
+ALL_KINDS_SENTINEL = "__ALL__"
+MAX_BATCH_ROLLOUTS = 64
+"""Upper bound on rollouts per scan. Every slot stays in the batched forward
+until the last one finishes, so a huge N mostly buys stale compute at the tail."""
+
+
+def _reset_rollout_env(
+    env: FactorioEnv,
+    kind: LessonKind,
+    seed: int,
+    num_missing_entities: Optional[int],
+) -> tuple[np.ndarray, int]:
+    """Reset `env` onto (kind, seed) and return (obs, the seed that built).
+
+    Advances past seeds whose rejection sampler gives up — the same retry
+    idiom :func:`_load_lesson` uses — so a scan never dies on one unlucky
+    seed. Omitting ``num_missing_entities`` leaves the env's default of
+    "blank everything", which is the point of the scan: rebuild from the
+    lesson's protected tiles alone.
+    """
+    attempt = int(seed)
+    for _ in range(_LESSON_RETRY_BUDGET):
+        options: dict = {"kind": kind}
+        if num_missing_entities is not None:
+            options["num_missing_entities"] = num_missing_entities
+        try:
+            obs, _info = env.reset(seed=attempt, options=options)
+        except RuntimeError:
+            attempt += 1
+            continue
+        return obs, attempt
+    raise RuntimeError(
+        f"build_factory returned None for {_LESSON_RETRY_BUDGET} consecutive "
+        f"seeds (kind={kind.name}, size={env.size}, start_seed={seed})."
+    )
+
+
+def _rollout_result(
+    index: int,
+    env: FactorioEnv,
+    seed: int,
+    info: dict,
+    steps: int,
+    terminated: bool,
+    eot_prob: float,
+) -> dict:
+    return {
+        "type": "result",
+        "index": index,
+        "kind": env._kind.name,
+        "seed": seed,
+        "size": env.size,
+        "steps": steps,
+        "stopped_by": "eot" if terminated else "max_steps",
+        "eot_prob": eot_prob,
+        "thput_normed": float(info.get("thput_normed", 0.0)),
+        "thput_raw": float(info.get("thput_raw", 0.0)),
+        "max_throughput": float(env._max_throughput),
+        "num_entities": int(info.get("num_entities", 0)),
+        "num_placed_entities": int(info.get("num_placed_entities", 0)),
+        "frac_reachable": float(info.get("frac_reachable", 0.0)),
+        "invalid_actions": int(env.invalid_actions),
+        "grid": world_CWH_to_grid(env._world_CWH),
+        "solved_grid": world_CWH_to_grid(env._solved_world_CWH),
+    }
+
+
+def _batch_rollout(
+    kinds: list[LessonKind],
+    seeds: list[int],
+    size: int,
+    num_missing_entities: Optional[int],
+    eot_threshold: float,
+    legal_mask: bool,
+) -> Iterator[dict]:
+    """Greedily rebuild one blanked factory per (kind, seed), yielding an
+    event per finished rollout.
+
+    Every rollout advances in lockstep so a single batched ``sample_action``
+    covers the whole set — N seeds cost about one seed's worth of forward
+    passes, which is what makes scanning 20 seeds interactive rather than a
+    20× wait. Slots that have already stopped stay in the batch (their
+    outputs are discarded); dropping them would cost a re-pack every step
+    for a tail that is short by construction.
+
+    Greedy argmax + the legal-tile mask mirror ``sft.run_rollout_eval``, so a
+    scan's throughput numbers are the same quantity as ``eval/thput`` — except
+    that here the EOT head really does end the episode, since the whole point
+    is to see the factory the model considers finished.
+    """
+    agent = _get_agent(size)
+    envs: list[FactorioEnv] = []
+    used_seeds: list[int] = []
+    obs_list: list[np.ndarray] = []
+    for kind, seed in zip(kinds, seeds):
+        env = FactorioEnv(size=size, idx=0)
+        # Only the terminal throughput is ever shown, and the per-step
+        # simulate_throughput otherwise dominates the rollout.
+        env._full_diagnostics = False
+        obs, used = _reset_rollout_env(env, kind, seed, num_missing_entities)
+        envs.append(env)
+        used_seeds.append(used)
+        obs_list.append(obs)
+
+    yield {
+        "type": "start",
+        "n": len(envs),
+        "jobs": [
+            {"index": i, "kind": env._kind.name, "seed": s}
+            for i, (env, s) in enumerate(zip(envs, used_seeds))
+        ],
+    }
+
+    obs_NCWH = np.stack(obs_list)
+    active = [True] * len(envs)
+    steps = [0] * len(envs)
+    step = 0
+    with torch.no_grad():
+        while any(active):
+            batch = torch.as_tensor(
+                obs_NCWH, dtype=torch.float32, device=_AGENT_DEVICE
+            )
+            out = agent.sample_action(
+                batch,
+                temperature=0.0,
+                legal_mask=legal_mask,
+                eot_threshold=eot_threshold,
+                compute_value=False,
+            )
+            act = out["action"]
+            xy = act["xy"].cpu().numpy()
+            ent = act["entity"].reshape(-1).cpu().numpy()
+            dirs = act["direction"].reshape(-1).cpu().numpy()
+            item = act["item"].reshape(-1).cpu().numpy()
+            misc = act["misc"].reshape(-1).cpu().numpy()
+            eot = act["eot"].reshape(-1).cpu().numpy()
+            eot_p = out["eot_prob"].reshape(-1).cpu().numpy()
+            step += 1
+            for i, env in enumerate(envs):
+                if not active[i]:
+                    continue
+                action = {
+                    "xy": np.array([int(xy[i, 0]), int(xy[i, 1])], dtype=int),
+                    "entity": int(ent[i]),
+                    "direction": int(dirs[i]),
+                    "item": int(item[i]),
+                    "misc": int(misc[i]),
+                    "eot": int(eot[i]),
+                }
+                next_obs, _reward, terminated, truncated, info = env.step(action)
+                obs_NCWH[i] = next_obs
+                steps[i] += 1
+                if terminated or truncated:
+                    active[i] = False
+                    yield _rollout_result(
+                        i, env, used_seeds[i], info, steps[i],
+                        terminated, float(eot_p[i]),
+                    )
+            yield {"type": "progress", "step": step, "running": sum(active)}
+    yield {"type": "done"}
+
+
+def _batch_rollout_request(payload: dict) -> Iterator[dict]:
+    """Turn a /batch_rollout POST body into a stream of scan events.
+
+    Errors are yielded rather than raised: the response headers are already
+    on the wire by the time this generator runs, so the browser can only be
+    told about a failure in-band.
+    """
+    try:
+        size = int(payload.get("size", 11))
+        count = max(1, min(int(payload.get("count", 10)), MAX_BATCH_ROLLOUTS))
+        start_seed = int(payload.get("seed", 0))
+        kind_name = payload.get("kind") or ALL_KINDS_SENTINEL
+        if kind_name == ALL_KINDS_SENTINEL:
+            # Cycle kinds before seeds so a scan of N < len(LessonKind) is a
+            # breadth-first sweep of setups, which is what "one of each" means.
+            every = list(LessonKind)
+            kinds = [every[i % len(every)] for i in range(count)]
+            seeds = [start_seed + i // len(every) for i in range(count)]
+        else:
+            kinds = [LessonKind[kind_name]] * count
+            seeds = [start_seed + i for i in range(count)]
+        clear = payload.get("num_missing_entities")
+        num_missing = None if clear in (None, "") else max(0, int(clear))
+        yield from _batch_rollout(
+            kinds=kinds,
+            seeds=seeds,
+            size=size,
+            num_missing_entities=num_missing,
+            eot_threshold=float(payload.get("eot_threshold", 0.5)),
+            legal_mask=bool(payload.get("legal_mask", True)),
+        )
+    except Exception as e:
+        traceback.print_exc()
+        yield {"type": "error", "error": f"{type(e).__name__}: {e}"}
+
+
 # Cache palette icons so the page payload stays small per cell.
 def _icon_b64(name: str) -> str:
     try:
@@ -747,6 +948,10 @@ def render_index(default_size: int) -> str:
     )
     lesson_options = "".join(
         f'<option value="{k.name}">{k.name}</option>' for k in LessonKind
+    )
+    scan_lesson_options = (
+        f'<option value="{ALL_KINDS_SENTINEL}">(every kind)</option>'
+        + lesson_options
     )
 
     # Model loader is collapsed by default — switching models is rare
@@ -935,12 +1140,52 @@ def render_index(default_size: int) -> str:
     user-select: none; padding: 0.2em 0;
   }}
   details.edges-details {{ margin-top: 0.4em; }}
+  .tabs {{ display: flex; gap: 0.3em; margin-bottom: 0.5em; }}
+  .tabs button {{
+    padding: 0.3em 0.9em; font-size: 0.85em; cursor: pointer;
+    border: 1px solid #ccc; border-radius: 5px 5px 0 0;
+    background: #eee; color: #555; border-bottom-color: #ccc;
+  }}
+  .tabs button.active {{
+    background: #fff; color: #111; font-weight: bold; border-bottom-color: #fff;
+  }}
+  .scan-summary {{
+    font-family: monospace; font-size: 0.85em; margin: 0.5em 0;
+    padding: 0.4em 0.6em; background: #f4f4f4; border-radius: 4px;
+  }}
+  .scan-results {{ display: flex; flex-wrap: wrap; gap: 0.6em; }}
+  .scan-card {{
+    border: 1px solid #ccc; border-left-width: 5px; border-radius: 5px;
+    padding: 0.35em; background: #fff; cursor: pointer;
+  }}
+  .scan-card:hover {{ background: #f6fbff; border-color: #0d47a1; }}
+  .scan-card .hd {{ font-size: 0.72em; font-weight: bold; }}
+  .scan-card .sub {{ font-size: 0.7em; color: #666; font-family: monospace; }}
+  .scan-card .pair {{ display: flex; gap: 0.4em; align-items: flex-start; }}
+  .scan-card figure {{ margin: 0.2em 0 0; }}
+  .scan-card figcaption {{
+    font-size: 0.62em; color: #888; text-align: center;
+  }}
+  table.mini {{ border-collapse: collapse; }}
+  table.mini td {{
+    width: 22px; height: 22px; border: 1px solid #e2e2e2; padding: 0;
+    position: relative; background: #fff;
+  }}
+  table.mini td.unavailable {{ background: #e8e8e8; }}
+  table.mini .arrow {{ font-size: 9px; line-height: 9px; }}
+  table.mini .misc {{ font-size: 9px; }}
 </style></head><body>
 
 <h1>Factory builder
   {help_html}
 </h1>
 
+<div class="tabs" id="tabs">
+  <button class="active" data-tab="build">Build</button>
+  <button data-tab="scan">Scan seeds</button>
+</div>
+
+<div id="tab-build">
 <div class="layout">
 
   <div class="grid-wrap">
@@ -1004,8 +1249,45 @@ def render_index(default_size: int) -> str:
   </div>
 
 </div>
+</div>
+
+<div id="tab-scan" hidden>
+  <div class="controls action-row">
+    <label>lesson
+      <select id="scan-kind">{scan_lesson_options}</select>
+    </label>
+    <label title="How many rollouts to run. With '(every kind)' the kinds cycle first, so N = the number of kinds gives one seed of each.">
+      rollouts <input id="scan-count" type="number" min="1" max="{MAX_BATCH_ROLLOUTS}" value="10">
+    </label>
+    <label>start seed <input id="scan-seed" type="number" value="0" step="1"></label>
+    <label title="Entities to remove before the model rebuilds. Blank = remove everything the lesson allows (source, sink and reserved tiles always survive).">
+      entities to clear <input id="scan-clear" type="number" min="0" placeholder="all" style="width:4.5em">
+    </label>
+    <label title="Restrict the tile head's argmax to empty, buildable cells — what sft.run_rollout_eval does. Off shows the raw head, including illegal proposals.">
+      <input id="scan-mask" type="checkbox" checked> legal-tile mask
+    </label>
+    <label title="Also draw the generator's own solution next to each rebuild">
+      <input id="scan-ref" type="checkbox"> show reference
+    </label>
+    <label>sort
+      <select id="scan-sort">
+        <option value="seed">run order</option>
+        <option value="worst">worst first</option>
+        <option value="best">best first</option>
+      </select>
+    </label>
+    <button id="scan-run" title="Blank each seed's factory, let the model rebuild it until its EOT head fires, and show every final factory">
+      Run scan
+    </button>
+    <button id="scan-stop" disabled>Stop</button>
+  </div>
+  <div class="scan-summary" id="scan-summary">no scan yet</div>
+  <div class="scan-results" id="scan-results"></div>
+</div>
 
 <script>
+const ALL_KINDS = '{ALL_KINDS_SENTINEL}';
+const NUM_LESSON_KINDS = {len(list(LessonKind))};
 const PALETTE_ICONS = {json.dumps(PALETTE_ICONS)};
 const ITEM_ICONS = {json.dumps(ITEM_ICONS)};
 const HOTBAR = {json.dumps(HOTBAR)};
@@ -1826,11 +2108,232 @@ function bindHelp() {{
   }});
 }}
 
+// ── Scan tab ────────────────────────────────────────────────────────────
+// A scan blanks N factories, lets the model rebuild each one until its EOT
+// head fires, and lays the finished factories out side by side. The server
+// runs all N in lockstep through one batched forward per step, so the wall
+// clock is roughly one rollout's, not N.
+let scanResults = [];
+let scanAbort = null;
+
+function switchTab(name) {{
+  document.querySelectorAll('#tabs button').forEach(b =>
+    b.classList.toggle('active', b.dataset.tab === name));
+  document.getElementById('tab-build').hidden = (name !== 'build');
+  document.getElementById('tab-scan').hidden = (name !== 'scan');
+}}
+
+// Red at zero throughput through to green at a perfect rebuild. The card's
+// left border is the fastest read in the gallery — you spot the cluster of
+// failures before any text resolves.
+function thputColor(t) {{
+  const q = Math.max(0, Math.min(t, 1));
+  return `hsl(${{Math.round(q * 120)}}, 70%, 45%)`;
+}}
+
+function miniGrid(g, n) {{
+  let html = '<table class="mini">';
+  for (let y = 0; y < n; y++) {{
+    html += '<tr>';
+    for (let x = 0; x < n; x++) {{
+      const c = g[y][x];
+      let inner = '';
+      if (c.entity && c.entity !== 'empty')
+        inner += `<img class="ent" src="${{iconFor(c.entity)}}">`;
+      if (c.item && c.item !== 'empty')
+        inner += `<img class="itm" src="${{iconFor(c.item)}}">`;
+      const arrow = DIR_ARROW[c.direction] || '';
+      if (arrow) inner += `<div class="arrow">${{arrow}}</div>`;
+      const m = MISC_GLYPH[c.misc] || '';
+      if (m) inner += `<div class="misc">${{m}}</div>`;
+      const cls = c.footprint === 'UNAVAILABLE' ? ' class="unavailable"' : '';
+      html += `<td${{cls}}><div class="cell-inner">${{inner}}</div></td>`;
+    }}
+    html += '</tr>';
+  }}
+  return html + '</table>';
+}}
+
+function scanCard(r, showRef) {{
+  const card = document.createElement('div');
+  card.className = 'scan-card';
+  card.style.borderLeftColor = thputColor(r.thput_normed);
+  const stop = r.stopped_by === 'eot'
+    ? 'stopped at ' + r.steps
+    : 'no stop, ' + r.steps + ' steps';
+  const head =
+    `<div class="hd">${{escHtml(r.kind)}}</div>` +
+    `<div class="sub">seed ${{r.seed}} · thput ${{r.thput_normed.toFixed(3)}}` +
+    ` (${{r.thput_raw.toFixed(2)}} of ${{r.max_throughput.toFixed(2)}} i/s)</div>` +
+    `<div class="sub">${{stop}} · ${{r.num_placed_entities}} placed · ` +
+    `${{r.invalid_actions}} invalid · reach ${{Math.round(r.frac_reachable * 100)}}%</div>`;
+  const built =
+    `<figure><figcaption>built</figcaption>${{miniGrid(r.grid, r.size)}}</figure>`;
+  const ref = showRef
+    ? `<figure><figcaption>reference</figcaption>${{miniGrid(r.solved_grid, r.size)}}</figure>`
+    : '';
+  card.innerHTML = head + `<div class="pair">${{built}}${{ref}}</div>`;
+  card.title = 'Open this factory in the Build tab';
+  card.addEventListener('click', () => {{
+    SIZE = r.size;
+    grid = r.grid.map(row => row.map(c => Object.assign({{}}, c)));
+    selected = null;
+    prediction = null;
+    document.getElementById('size').value = SIZE;
+    switchTab('build');
+    renderGrid(); syncEditor(); scheduleCompute();
+  }});
+  return card;
+}}
+
+function renderScan() {{
+  const host = document.getElementById('scan-results');
+  const showRef = document.getElementById('scan-ref').checked;
+  const mode = document.getElementById('scan-sort').value;
+  const rows = scanResults.slice();
+  if (mode === 'worst') {{
+    rows.sort((a, b) => a.thput_normed - b.thput_normed || a.index - b.index);
+  }} else if (mode === 'best') {{
+    rows.sort((a, b) => b.thput_normed - a.thput_normed || a.index - b.index);
+  }} else {{
+    rows.sort((a, b) => a.index - b.index);
+  }}
+  host.replaceChildren(...rows.map(r => scanCard(r, showRef)));
+}}
+
+function scanSummary(status) {{
+  const el = document.getElementById('scan-summary');
+  const n = scanResults.length;
+  if (!n) {{ el.textContent = status || 'no scan yet'; return; }}
+  const t = scanResults.map(r => r.thput_normed);
+  const mean = t.reduce((a, b) => a + b, 0) / n;
+  const zeros = t.filter(v => v <= 0).length;
+  const perfect = t.filter(v => v >= 0.999).length;
+  const eot = scanResults.filter(r => r.stopped_by === 'eot').length;
+  el.textContent =
+    `${{n}} done · mean thput ${{mean.toFixed(3)}} · ${{zeros}} at zero · ` +
+    `${{perfect}} perfect · eot fired ${{eot}}/${{n}}` +
+    (status ? '  ·  ' + status : '');
+}}
+
+async function runScan() {{
+  const runBtn = document.getElementById('scan-run');
+  const stopBtn = document.getElementById('scan-stop');
+  if (!modelLoaded) {{
+    document.getElementById('scan-summary').textContent =
+      'no model loaded — load one from the Build tab first';
+    return;
+  }}
+  const clearRaw = parseInt(document.getElementById('scan-clear').value, 10);
+  const body = {{
+    kind: document.getElementById('scan-kind').value,
+    count: parseInt(document.getElementById('scan-count').value, 10) || 1,
+    seed: parseInt(document.getElementById('scan-seed').value, 10) || 0,
+    size: SIZE,
+    legal_mask: document.getElementById('scan-mask').checked,
+    num_missing_entities:
+      Number.isFinite(clearRaw) && clearRaw >= 0 ? clearRaw : null,
+  }};
+  scanResults = [];
+  document.getElementById('scan-results').replaceChildren();
+  scanAbort = new AbortController();
+  runBtn.disabled = true;
+  stopBtn.disabled = false;
+  const started = performance.now();
+  const showRef = document.getElementById('scan-ref').checked;
+  let total = body.count;
+  scanSummary('generating ' + total + ' factories at size ' + SIZE + '…');
+  try {{
+    const resp = await fetch('/batch_rollout', {{
+      method: 'POST',
+      headers: {{ 'Content-Type': 'application/json' }},
+      body: JSON.stringify(body),
+      signal: scanAbort.signal,
+    }});
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = '';
+    // The server streams newline-delimited JSON so results land as they
+    // finish instead of after the slowest rollout.
+    for (;;) {{
+      const {{ done, value }} = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, {{ stream: true }});
+      let nl;
+      while ((nl = buf.indexOf('\\n')) >= 0) {{
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        if (!line.trim()) continue;
+        const ev = JSON.parse(line);
+        if (ev.type === 'start') {{
+          total = ev.n;
+          scanSummary('running ' + total + ' rollouts…');
+        }} else if (ev.type === 'result') {{
+          scanResults.push(ev);
+          // Append rather than re-render: a full re-sort of N cards on
+          // every arrival is O(N^2) table builds. renderScan() applies
+          // the chosen sort once the stream ends.
+          document.getElementById('scan-results').appendChild(scanCard(ev, showRef));
+          scanSummary(scanResults.length + '/' + total + ' finished');
+        }} else if (ev.type === 'progress') {{
+          const secs = (performance.now() - started) / 1000;
+          scanSummary(
+            'step ' + ev.step + ' · ' + ev.running + ' still building · ' +
+            secs.toFixed(1) + 's'
+          );
+        }} else if (ev.type === 'error') {{
+          scanSummary('error: ' + ev.error);
+        }}
+      }}
+    }}
+    renderScan();
+    const secs = (performance.now() - started) / 1000;
+    scanSummary('finished in ' + secs.toFixed(1) + 's');
+  }} catch (e) {{
+    if (e.name === 'AbortError') {{
+      renderScan();
+      scanSummary('stopped');
+    }} else {{
+      scanSummary('scan failed: ' + e);
+    }}
+  }} finally {{
+    runBtn.disabled = false;
+    stopBtn.disabled = true;
+    scanAbort = null;
+  }}
+}}
+
+function syncScanRunLabel() {{
+  const c = parseInt(document.getElementById('scan-count').value, 10) || 1;
+  document.getElementById('scan-run').textContent = 'Run ×' + c;
+}}
+
+function bindScan() {{
+  document.querySelectorAll('#tabs button').forEach(b =>
+    b.addEventListener('click', () => switchTab(b.dataset.tab)));
+  document.getElementById('scan-run').addEventListener('click', runScan);
+  document.getElementById('scan-stop').addEventListener('click', () => {{
+    if (scanAbort) scanAbort.abort();
+  }});
+  document.getElementById('scan-count').addEventListener('input', syncScanRunLabel);
+  document.getElementById('scan-kind').addEventListener('change', (ev) => {{
+    // "(every kind)" cycles kinds before seeds, so one-of-each is the
+    // useful default count for it.
+    document.getElementById('scan-count').value =
+      ev.target.value === ALL_KINDS ? NUM_LESSON_KINDS : 10;
+    syncScanRunLabel();
+  }});
+  document.getElementById('scan-sort').addEventListener('change', renderScan);
+  document.getElementById('scan-ref').addEventListener('change', renderScan);
+  syncScanRunLabel();
+}}
+
 grid = newGrid(SIZE);
 renderGrid();
 bindHotbar();
 bindEditor();
 bindHelp();
+bindScan();
 refreshModelInfo();
 </script>
 </body></html>"""
@@ -1850,6 +2353,25 @@ class Handler(BaseHTTPRequestHandler):
 
     def log_message(self, format, *args):  # noqa: A002
         sys.stderr.write("[%s] %s\n" % (self.address_string(), format % args))
+
+    def _stream_ndjson(self, events: Iterator[dict]) -> None:
+        """Write one JSON object per line as the generator produces them.
+
+        The response carries no Content-Length: this handler speaks HTTP/1.0,
+        so end-of-body is end-of-connection, which is also how the browser's
+        Stop button works — aborting the fetch drops the socket, the next
+        write raises, and abandoning the generator cancels the scan.
+        """
+        self.send_response(200)
+        self.send_header("Content-Type", "application/x-ndjson")
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        try:
+            for event in events:
+                self.wfile.write((json.dumps(event) + "\n").encode())
+                self.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError):
+            pass
 
     def _send_json(self, payload: dict, status: int = 200) -> None:
         body = json.dumps(payload).encode()
@@ -1880,6 +2402,7 @@ class Handler(BaseHTTPRequestHandler):
             "/apply_prediction",
             "/load_model",
             "/load_lesson",
+            "/batch_rollout",
         ):
             self.send_error(404)
             return
@@ -1887,6 +2410,9 @@ class Handler(BaseHTTPRequestHandler):
         raw = self.rfile.read(length).decode("utf-8")
         try:
             payload = json.loads(raw)
+            if self.path == "/batch_rollout":
+                self._stream_ndjson(_batch_rollout_request(payload))
+                return
             if self.path == "/graph":
                 result = render_graph_png(payload["grid"])
             elif self.path == "/predict":

--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -693,10 +693,10 @@ ALL_KINDS_SENTINEL = "__ALL__"
 ROLLOUT_BATCH_SIZE = 64
 """Rollouts advanced in lockstep per batched forward. Every slot stays in the
 batch until the last of its group finishes, so a wider batch mostly buys stale
-compute at the tail; a bigger scan runs as back-to-back groups instead."""
-MAX_BATCH_ROLLOUTS = 512
-"""Hard ceiling on one scan, so a fat-fingered count can't tie the server up
-for an hour. Exceeding it is reported, never silently truncated."""
+compute at the tail; a bigger scan runs as back-to-back groups instead. There
+is deliberately no ceiling on the scan itself: groups are built and freed one
+at a time so memory is flat in the count, results stream as they finish, and
+Stop cancels — nothing a cap would protect against."""
 
 
 def _reset_rollout_env(
@@ -839,16 +839,7 @@ def _batch_rollout_request(payload: dict) -> Iterator[dict]:
     """
     try:
         size = int(payload.get("size", 11))
-        requested = max(1, int(payload.get("count", 10)))
-        count = min(requested, MAX_BATCH_ROLLOUTS)
-        if count < requested:
-            yield {
-                "type": "note",
-                "message": (
-                    f"asked for {requested} rollouts, running "
-                    f"{MAX_BATCH_ROLLOUTS} (the per-scan ceiling)"
-                ),
-            }
+        count = max(1, int(payload.get("count", 10)))
         start_seed = int(payload.get("seed", 0))
         kind_name = payload.get("kind") or ALL_KINDS_SENTINEL
         if kind_name == ALL_KINDS_SENTINEL:
@@ -1279,7 +1270,7 @@ def render_index(default_size: int) -> str:
       <select id="scan-kind">{scan_lesson_options}</select>
     </label>
     <label title="How many rollouts to add per click. With '(every kind)' the kinds cycle first, so N = the number of kinds gives one seed of each.">
-      rollouts <input id="scan-count" type="number" min="1" max="{MAX_BATCH_ROLLOUTS}" value="50">
+      rollouts <input id="scan-count" type="number" min="1" value="50">
     </label>
     <label title="Seed the next batch starts from. Advances by the rollout count after each run, so repeated clicks keep drawing fresh factories.">
       start seed <input id="scan-seed" type="number" value="0" step="1">
@@ -2333,8 +2324,6 @@ async function runScan() {{
         if (ev.type === 'start') {{
           total = ev.n;
           scanSummary('running ' + total + ' rollouts…');
-        }} else if (ev.type === 'note') {{
-          scanSummary(ev.message);
         }} else if (ev.type === 'result') {{
           ev.index += indexBase;
           scanResults.push(ev);
@@ -2428,10 +2417,28 @@ class _BuilderServer(HTTPServer):
 
 class Handler(BaseHTTPRequestHandler):
     server: _BuilderServer  # _BuilderServer stashes the CLI defaults on itself
+    raw_requestline: bytes  # set by handle_one_request; absent from the stubs
     server_version = "FactoryBuilder/0.1"
 
     def log_message(self, format, *args):  # noqa: A002
         sys.stderr.write("[%s] %s\n" % (self.address_string(), format % args))
+
+    def parse_request(self) -> bool:
+        """Reject a TLS handshake without logging it as a mangled request.
+
+        Bytes starting 0x16 0x03 are a TLS ClientHello: something reached
+        this plain-HTTP server over https://, which browsers do on their own
+        (Firefox's HTTPS-Only mode, HSTS, an extension). The default handler
+        renders the handshake as a garbled HTTP/0.9 request line, which reads
+        like a crash rather than a wrong-scheme connection.
+        """
+        if self.raw_requestline.startswith(b"\x16\x03"):
+            self.log_message(
+                "ignored an https:// connection — this server is plain HTTP"
+            )
+            self.close_connection = True
+            return False
+        return super().parse_request()
 
     def _stream_ndjson(self, events: Iterator[dict]) -> None:
         """Write one JSON object per line as the generator produces them.
@@ -2461,7 +2468,18 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
-        self.wfile.write(body)
+        self._write_body(body)
+
+    def _write_body(self, body: bytes) -> None:
+        """Write a response body, tolerating a client that has gone away.
+
+        Reloading mid-load or hitting Stop drops the socket while the ~1MB
+        page is still going out; that is routine, not something to dump a
+        traceback over."""
+        try:
+            self.wfile.write(body)
+        except (BrokenPipeError, ConnectionResetError):
+            self.close_connection = True
 
     def do_GET(self):  # noqa: N802
         if self.path == "/" or self.path.startswith("/?"):
@@ -2470,7 +2488,7 @@ class Handler(BaseHTTPRequestHandler):
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
-            self.wfile.write(body)
+            self._write_body(body)
             return
         if self.path == "/model_info":
             self._send_json(_model_info())

--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -798,7 +798,7 @@ def _batch_rollout(
                 )
                 out = agent.sample_action(
                     batch, temperature=0.0, legal_mask=legal_mask,
-                    compute_value=False,
+                    eot_threshold=EOT_STOP_THRESHOLD, compute_value=False,
                 )
                 act = out["action"]
                 xy = act["xy"].cpu().numpy()

--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -690,9 +690,13 @@ def _predict_action(grid: list[list[dict]]) -> dict:
 # ── Batched seed scan ────────────────────────────────────────────────────────
 
 ALL_KINDS_SENTINEL = "__ALL__"
-MAX_BATCH_ROLLOUTS = 64
-"""Upper bound on rollouts per scan. Every slot stays in the batched forward
-until the last one finishes, so a huge N mostly buys stale compute at the tail."""
+ROLLOUT_BATCH_SIZE = 64
+"""Rollouts advanced in lockstep per batched forward. Every slot stays in the
+batch until the last of its group finishes, so a wider batch mostly buys stale
+compute at the tail; a bigger scan runs as back-to-back groups instead."""
+MAX_BATCH_ROLLOUTS = 512
+"""Hard ceiling on one scan, so a fat-fingered count can't tie the server up
+for an hour. Exceeding it is reported, never silently truncated."""
 
 
 def _reset_rollout_env(
@@ -751,12 +755,15 @@ def _batch_rollout(
     """Greedily rebuild one blanked factory per (kind, seed), yielding an
     event per finished rollout.
 
-    Every rollout advances in lockstep through one batched ``sample_action``.
-    Slots that have already stopped stay in the batch and their outputs are
-    discarded: compacting would change the batch shape every step, and mps
-    re-plans kernels per shape, which measures far slower than the wasted
-    slots (N=64: 5.6s fixed vs 29.8s compacted). ``sft.run_rollout_eval``
-    makes the same choice.
+    Rollouts advance in lockstep through one batched ``sample_action``, in
+    groups of ``ROLLOUT_BATCH_SIZE``; a scan larger than one group runs the
+    groups back to back, so the wall clock stays linear in the count instead
+    of the count being truncated to fit one batch. Slots that have already
+    stopped stay in their group's batch and their outputs are discarded:
+    compacting would change the batch shape every step, and mps re-plans
+    kernels per shape, which measures far slower than the wasted slots
+    (N=64: 5.6s fixed vs 29.8s compacted). ``sft.run_rollout_eval`` makes the
+    same choice.
 
     Greedy argmax + the legal-tile mask mirror ``sft.run_rollout_eval``, so a
     scan's throughput numbers are the same quantity as ``eval/thput`` — except
@@ -764,57 +771,62 @@ def _batch_rollout(
     is to see the factory the model considers finished.
     """
     agent = _get_agent(size)
-    envs: list[FactorioEnv] = []
-    used_seeds: list[int] = []
-    obs_list: list[np.ndarray] = []
-    for kind, seed in zip(kinds, seeds):
-        env = FactorioEnv(size=size, idx=0)
-        # Only the terminal throughput is ever shown, and the per-step
-        # simulate_throughput otherwise dominates the rollout.
-        env._full_diagnostics = False
-        obs, used = _reset_rollout_env(env, kind, seed, num_missing_entities)
-        envs.append(env)
-        used_seeds.append(used)
-        obs_list.append(obs)
+    yield {"type": "start", "n": len(seeds)}
 
-    yield {"type": "start", "n": len(envs)}
-
-    obs_NCWH = np.stack(obs_list)
-    active = [True] * len(envs)
     step = 0
-    with torch.no_grad():
-        while any(active):
-            batch = torch.as_tensor(
-                obs_NCWH, dtype=torch.float32, device=_AGENT_DEVICE
-            )
-            out = agent.sample_action(
-                batch, temperature=0.0, legal_mask=legal_mask, compute_value=False
-            )
-            act = out["action"]
-            xy = act["xy"].cpu().numpy()
-            ent = act["entity"].reshape(-1).cpu().numpy()
-            dirs = act["direction"].reshape(-1).cpu().numpy()
-            item = act["item"].reshape(-1).cpu().numpy()
-            misc = act["misc"].reshape(-1).cpu().numpy()
-            eot = act["eot"].reshape(-1).cpu().numpy()
-            step += 1
-            for i, env in enumerate(envs):
-                if not active[i]:
-                    continue
-                action = {
-                    "xy": np.array([int(xy[i, 0]), int(xy[i, 1])], dtype=int),
-                    "entity": int(ent[i]),
-                    "direction": int(dirs[i]),
-                    "item": int(item[i]),
-                    "misc": int(misc[i]),
-                    "eot": int(eot[i]),
-                }
-                next_obs, _reward, terminated, truncated, info = env.step(action)
-                obs_NCWH[i] = next_obs
-                if terminated or truncated:
-                    active[i] = False
-                    yield _rollout_result(i, env, used_seeds[i], info, terminated)
-            yield {"type": "progress", "step": step}
+    for base in range(0, len(seeds), ROLLOUT_BATCH_SIZE):
+        group = slice(base, base + ROLLOUT_BATCH_SIZE)
+        envs: list[FactorioEnv] = []
+        used_seeds: list[int] = []
+        obs_list: list[np.ndarray] = []
+        for kind, seed in zip(kinds[group], seeds[group]):
+            env = FactorioEnv(size=size, idx=0)
+            # Only the terminal throughput is ever shown, and the per-step
+            # simulate_throughput otherwise dominates the rollout.
+            env._full_diagnostics = False
+            obs, used = _reset_rollout_env(env, kind, seed, num_missing_entities)
+            envs.append(env)
+            used_seeds.append(used)
+            obs_list.append(obs)
+
+        obs_NCWH = np.stack(obs_list)
+        active = [True] * len(envs)
+        with torch.no_grad():
+            while any(active):
+                batch = torch.as_tensor(
+                    obs_NCWH, dtype=torch.float32, device=_AGENT_DEVICE
+                )
+                out = agent.sample_action(
+                    batch, temperature=0.0, legal_mask=legal_mask,
+                    compute_value=False,
+                )
+                act = out["action"]
+                xy = act["xy"].cpu().numpy()
+                ent = act["entity"].reshape(-1).cpu().numpy()
+                dirs = act["direction"].reshape(-1).cpu().numpy()
+                item = act["item"].reshape(-1).cpu().numpy()
+                misc = act["misc"].reshape(-1).cpu().numpy()
+                eot = act["eot"].reshape(-1).cpu().numpy()
+                step += 1
+                for i, env in enumerate(envs):
+                    if not active[i]:
+                        continue
+                    action = {
+                        "xy": np.array([int(xy[i, 0]), int(xy[i, 1])], dtype=int),
+                        "entity": int(ent[i]),
+                        "direction": int(dirs[i]),
+                        "item": int(item[i]),
+                        "misc": int(misc[i]),
+                        "eot": int(eot[i]),
+                    }
+                    next_obs, _reward, terminated, truncated, info = env.step(action)
+                    obs_NCWH[i] = next_obs
+                    if terminated or truncated:
+                        active[i] = False
+                        yield _rollout_result(
+                            base + i, env, used_seeds[i], info, terminated
+                        )
+                yield {"type": "progress", "step": step}
     yield {"type": "done"}
 
 
@@ -827,7 +839,16 @@ def _batch_rollout_request(payload: dict) -> Iterator[dict]:
     """
     try:
         size = int(payload.get("size", 11))
-        count = max(1, min(int(payload.get("count", 10)), MAX_BATCH_ROLLOUTS))
+        requested = max(1, int(payload.get("count", 10)))
+        count = min(requested, MAX_BATCH_ROLLOUTS)
+        if count < requested:
+            yield {
+                "type": "note",
+                "message": (
+                    f"asked for {requested} rollouts, running "
+                    f"{MAX_BATCH_ROLLOUTS} (the per-scan ceiling)"
+                ),
+            }
         start_seed = int(payload.get("seed", 0))
         kind_name = payload.get("kind") or ALL_KINDS_SENTINEL
         if kind_name == ALL_KINDS_SENTINEL:
@@ -1257,10 +1278,12 @@ def render_index(default_size: int) -> str:
     <label>lesson
       <select id="scan-kind">{scan_lesson_options}</select>
     </label>
-    <label title="How many rollouts to run. With '(every kind)' the kinds cycle first, so N = the number of kinds gives one seed of each.">
-      rollouts <input id="scan-count" type="number" min="1" max="{MAX_BATCH_ROLLOUTS}" value="10">
+    <label title="How many rollouts to add per click. With '(every kind)' the kinds cycle first, so N = the number of kinds gives one seed of each.">
+      rollouts <input id="scan-count" type="number" min="1" max="{MAX_BATCH_ROLLOUTS}" value="50">
     </label>
-    <label>start seed <input id="scan-seed" type="number" value="0" step="1"></label>
+    <label title="Seed the next batch starts from. Advances by the rollout count after each run, so repeated clicks keep drawing fresh factories.">
+      start seed <input id="scan-seed" type="number" value="0" step="1">
+    </label>
     <label title="Entities to remove before the model rebuilds. Blank = remove everything the lesson allows (source, sink and reserved tiles always survive).">
       entities to clear <input id="scan-clear" type="number" min="0" placeholder="all" style="width:4.5em">
     </label>
@@ -1272,15 +1295,16 @@ def render_index(default_size: int) -> str:
     </label>
     <label>sort
       <select id="scan-sort">
-        <option value="seed">run order</option>
-        <option value="worst">worst first</option>
+        <option value="worst" selected>worst first</option>
         <option value="best">best first</option>
+        <option value="seed">run order</option>
       </select>
     </label>
-    <button id="scan-run" title="Blank each seed's factory, let the model rebuild it until its EOT head fires, and show every final factory">
+    <button id="scan-run" title="Blank each seed's factory, let the model rebuild it until its EOT head fires, and add every final factory to the gallery">
       Run scan
     </button>
     <button id="scan-stop" disabled>Stop</button>
+    <button id="scan-clear-results" title="Throw away everything scanned so far">clear</button>
   </div>
   <div class="scan-summary" id="scan-summary">no scan yet</div>
   <div class="scan-stats" id="scan-stats"></div>
@@ -2124,6 +2148,7 @@ function bindHelp() {{
 // head fires, and lays the finished factories out side by side.
 let scanResults = [];
 let scanAbort = null;
+let scanIndexBase = 0;
 
 function switchTab(name) {{
   document.querySelectorAll('#tabs button').forEach(b =>
@@ -2269,9 +2294,12 @@ async function runScan() {{
     num_missing_entities:
       Number.isFinite(clearRaw) && clearRaw >= 0 ? clearRaw : null,
   }};
-  scanResults = [];
-  document.getElementById('scan-results').replaceChildren();
-  renderScanStats();
+  // Each run appends. Indices are offset by the running total so they stay
+  // unique across runs and keep the server's within-run ordering, which is
+  // what the "run order" sort reads.
+  const indexBase = scanIndexBase;
+  scanIndexBase += body.count;
+  const before = scanResults.length;
   scanAbort = new AbortController();
   runBtn.disabled = true;
   stopBtn.disabled = false;
@@ -2305,7 +2333,10 @@ async function runScan() {{
         if (ev.type === 'start') {{
           total = ev.n;
           scanSummary('running ' + total + ' rollouts…');
+        }} else if (ev.type === 'note') {{
+          scanSummary(ev.message);
         }} else if (ev.type === 'result') {{
+          ev.index += indexBase;
           scanResults.push(ev);
           // Append rather than re-render: a full re-sort of N cards on
           // every arrival is O(N^2) table builds. renderScan() applies
@@ -2315,8 +2346,8 @@ async function runScan() {{
         }} else if (ev.type === 'progress') {{
           const secs = (performance.now() - started) / 1000;
           scanSummary(
-            'step ' + ev.step + ' · ' + scanResults.length + '/' + total +
-            ' finished · ' + secs.toFixed(1) + 's'
+            'step ' + ev.step + ' · ' + (scanResults.length - before) + '/' +
+            total + ' finished · ' + secs.toFixed(1) + 's'
           );
         }} else if (ev.type === 'error') {{
           scanSummary('error: ' + ev.error);
@@ -2324,8 +2355,17 @@ async function runScan() {{
       }}
     }}
     renderScan();
+    // Advance the seed so the next click draws fresh factories rather than
+    // rebuilding the same ones. "(every kind)" cycles kinds before seeds, so
+    // its run only consumes count/kinds seeds.
+    const seedInput = document.getElementById('scan-seed');
+    seedInput.value = body.seed + (body.kind === ALL_KINDS
+      ? Math.ceil(body.count / NUM_LESSON_KINDS)
+      : body.count);
     const secs = (performance.now() - started) / 1000;
-    scanSummary('finished in ' + secs.toFixed(1) + 's');
+    scanSummary(
+      'added ' + (scanResults.length - before) + ' in ' + secs.toFixed(1) + 's'
+    );
   }} catch (e) {{
     if (e.name === 'AbortError') {{
       renderScan();
@@ -2340,9 +2380,17 @@ async function runScan() {{
   }}
 }}
 
+function clearScan() {{
+  scanResults = [];
+  scanIndexBase = 0;
+  document.getElementById('scan-results').replaceChildren();
+  renderScanStats();
+  scanSummary('');
+}}
+
 function syncScanRunLabel() {{
   const c = parseInt(document.getElementById('scan-count').value, 10) || 1;
-  document.getElementById('scan-run').textContent = 'Run ×' + c;
+  document.getElementById('scan-run').textContent = 'Run +' + c;
 }}
 
 function bindScan() {{
@@ -2353,13 +2401,7 @@ function bindScan() {{
     if (scanAbort) scanAbort.abort();
   }});
   document.getElementById('scan-count').addEventListener('input', syncScanRunLabel);
-  document.getElementById('scan-kind').addEventListener('change', (ev) => {{
-    // "(every kind)" cycles kinds before seeds, so one-of-each is the
-    // useful default count for it.
-    document.getElementById('scan-count').value =
-      ev.target.value === ALL_KINDS ? NUM_LESSON_KINDS : 10;
-    syncScanRunLabel();
-  }});
+  document.getElementById('scan-clear-results').addEventListener('click', clearScan);
   document.getElementById('scan-sort').addEventListener('change', renderScan);
   document.getElementById('scan-ref').addEventListener('change', renderScan);
   syncScanRunLabel();

--- a/tests/test_factory_builder.py
+++ b/tests/test_factory_builder.py
@@ -11,6 +11,7 @@ them to BaseHTTPRequestHandler would only re-test stdlib socket
 behaviour. wandb downloads aren't tested either: they'd require
 mocking the wandb client, which is high-effort for low payoff."""
 
+import inspect
 import json
 import os
 import shutil
@@ -32,7 +33,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 import factory_builder as fb  # noqa: E402
-from factorion import entities, items  # noqa: E402
+from factorion import Channel, LessonKind, entities, items  # noqa: E402
 from ppo import AgentCNN, FactorioEnv, make_env  # noqa: E402
 
 
@@ -798,6 +799,144 @@ class TestModelInfo:
             assert info["layers"] == [8, 8, 8]
         finally:
             path.unlink(missing_ok=True)
+
+
+class TestBatchRollout:
+    """The Scan tab's batched rollout: N blanked factories rebuilt in
+    lockstep and streamed back as one event per finished rollout."""
+
+    @staticmethod
+    def _scan(payload: dict) -> list[dict]:
+        """Drain a scan, asserting every event survives the wire (the
+        endpoint serialises each one as a line of NDJSON)."""
+        events = list(fb._batch_rollout_request(payload))
+        for event in events:
+            json.dumps(event)
+        return events
+
+    def test_reset_blanks_all_but_protected(self):
+        """A scan hands the model a world stripped down to the lesson's
+        protected tiles — the source, sink and reserved cells — which is
+        the "rebuild from nothing" test the Scan tab exists to run."""
+        env = FactorioEnv(size=11, idx=0)
+        obs, used_seed = fb._reset_rollout_env(
+            env, LessonKind.MOVE_ONE_ITEM, seed=0, num_missing_entities=None
+        )
+        assert used_seed == 0
+        blanked = int((obs[Channel.ENTITIES.value] != 0).sum())
+        solved = int((env._solved_world_CWH[Channel.ENTITIES.value] != 0).sum())
+        assert 0 < blanked < solved
+
+    def test_streams_a_result_per_seed(self):
+        path = _make_tiny_checkpoint(size=4, chan=8)
+        try:
+            fb._load_checkpoint(str(path))
+            events = self._scan(
+                {"kind": "MOVE_ONE_ITEM", "count": 3, "seed": 0, "size": 11}
+            )
+        finally:
+            path.unlink(missing_ok=True)
+        assert events[0]["type"] == "start"
+        assert events[0]["n"] == 3
+        assert events[-1]["type"] == "done"
+        results = [e for e in events if e["type"] == "result"]
+        assert sorted(r["seed"] for r in results) == [0, 1, 2]
+        assert all(r["kind"] == "MOVE_ONE_ITEM" for r in results)
+        assert any(e["type"] == "progress" for e in events)
+
+    def test_result_carries_both_grids(self):
+        """Each result ships the factory the model built *and* the
+        generator's own solution, so the gallery can show them side by
+        side without a second round trip."""
+        path = _make_tiny_checkpoint(size=4, chan=8)
+        try:
+            fb._load_checkpoint(str(path))
+            events = self._scan(
+                {"kind": "MOVE_ONE_ITEM", "count": 1, "seed": 7, "size": 11}
+            )
+        finally:
+            path.unlink(missing_ok=True)
+        result = next(e for e in events if e["type"] == "result")
+        for key in (
+            "grid", "solved_grid", "thput_normed", "thput_raw", "max_throughput",
+            "steps", "stopped_by", "eot_prob", "num_placed_entities",
+            "invalid_actions", "frac_reachable", "size", "index",
+        ):
+            assert key in result, key
+        assert result["stopped_by"] in ("eot", "max_steps")
+        for grid in (result["grid"], result["solved_grid"]):
+            assert len(grid) == 11 and all(len(row) == 11 for row in grid)
+        assert any(
+            c["entity"] != "empty" for row in result["solved_grid"] for c in row
+        )
+
+    def test_every_kind_cycles_kinds_before_seeds(self):
+        """One rollout per LessonKind at the same seed, so a scan sized to
+        the kind count is a breadth-first sweep of setups."""
+        path = _make_tiny_checkpoint(size=4, chan=8)
+        try:
+            fb._load_checkpoint(str(path))
+            events = self._scan({
+                "kind": fb.ALL_KINDS_SENTINEL,
+                "count": len(list(LessonKind)),
+                "seed": 4,
+                "size": 11,
+            })
+        finally:
+            path.unlink(missing_ok=True)
+        jobs = events[0]["jobs"]
+        assert {j["kind"] for j in jobs} == {k.name for k in LessonKind}
+        assert all(j["seed"] == 4 for j in jobs)
+
+    def test_bad_kind_yields_an_error_event(self):
+        """The response headers are already sent by the time the scan
+        runs, so failures have to travel in-band rather than as an
+        exception."""
+        events = self._scan({"kind": "NOT_A_LESSON", "count": 1, "size": 11})
+        assert events[-1]["type"] == "error"
+        assert "NOT_A_LESSON" in events[-1]["error"]
+
+    def test_missing_checkpoint_yields_an_error_event(self):
+        events = self._scan({"kind": "MOVE_ONE_ITEM", "count": 1, "size": 11})
+        assert events[-1]["type"] == "error"
+        assert "checkpoint" in events[-1]["error"]
+
+
+class TestRenderIndexScanTab:
+    """The served page must expose the scan controls and consume the
+    endpoint's NDJSON stream."""
+
+    def test_scan_tab_controls_exist(self):
+        html = fb.render_index(default_size=11)
+        assert 'data-tab="scan"' in html and 'data-tab="build"' in html
+        for element_id in (
+            "scan-kind", "scan-count", "scan-seed", "scan-clear", "scan-mask",
+            "scan-ref", "scan-sort", "scan-run", "scan-stop", "scan-results",
+            "scan-summary",
+        ):
+            assert f'id="{element_id}"' in html, element_id
+        assert f'<option value="{fb.ALL_KINDS_SENTINEL}">' in html
+
+    def test_client_streams_from_the_endpoint_the_server_routes(self):
+        html = fb.render_index(default_size=11)
+        assert "fetch('/batch_rollout'" in html
+        assert "resp.body.getReader()" in html
+        assert "signal: scanAbort.signal" in html
+        # A typo'd path here fails silently as a 404, so pin the client's
+        # URL to the handler's route list.
+        assert "/batch_rollout" in inspect.getsource(fb.Handler.do_POST)
+
+    def test_result_fields_the_cards_read_are_all_emitted(self):
+        """scanCard() reads these off each result — keep the card and
+        _rollout_result in lockstep."""
+        html = fb.render_index(default_size=11)
+        for field in (
+            "r.kind", "r.seed", "r.thput_normed", "r.thput_raw",
+            "r.max_throughput", "r.stopped_by", "r.steps",
+            "r.num_placed_entities", "r.invalid_actions", "r.frac_reachable",
+            "r.grid", "r.solved_grid", "r.size",
+        ):
+            assert field in html, field
 
 
 class TestIconCoverage:

--- a/tests/test_factory_builder.py
+++ b/tests/test_factory_builder.py
@@ -899,21 +899,20 @@ class TestBatchRollout:
         # Indices stay unique across groups — the gallery sorts on them.
         assert sorted(r["index"] for r in results) == [0, 1, 2, 3, 4]
 
-    def test_over_ceiling_is_reported_not_silently_truncated(self, monkeypatch):
-        """Asking for more than the per-scan ceiling still runs, but says
-        what it cut — a silent clamp reads as "that's all there was"."""
-        monkeypatch.setattr(fb, "MAX_BATCH_ROLLOUTS", 2)
+    def test_count_is_never_silently_capped(self, monkeypatch):
+        """The requested count is what runs. A cap that quietly trimmed the
+        scan would read as "that's all there was to find"."""
+        monkeypatch.setattr(fb, "ROLLOUT_BATCH_SIZE", 2)
         path = _make_tiny_checkpoint(size=4, chan=8)
         try:
             fb._load_checkpoint(str(path))
             events = self._scan(
-                {"kind": "MOVE_ONE_ITEM", "count": 5, "seed": 0, "size": 11}
+                {"kind": "MOVE_ONE_ITEM", "count": 7, "seed": 0, "size": 11}
             )
         finally:
             path.unlink(missing_ok=True)
-        note = next(e for e in events if e["type"] == "note")
-        assert "5" in note["message"] and "2" in note["message"]
-        assert len([e for e in events if e["type"] == "result"]) == 2
+        assert events[0] == {"type": "start", "n": 7}
+        assert len([e for e in events if e["type"] == "result"]) == 7
 
     def test_bad_kind_yields_an_error_event(self):
         """The response headers are already sent by the time the scan

--- a/tests/test_factory_builder.py
+++ b/tests/test_factory_builder.py
@@ -882,6 +882,39 @@ class TestBatchRollout:
         assert {r["kind"] for r in results} == {k.name for k in LessonKind}
         assert all(r["seed"] == 4 for r in results)
 
+    def test_runs_more_rollouts_than_one_batch(self, monkeypatch):
+        """A count above the lockstep batch width runs as back-to-back
+        groups instead of being truncated to fit a single batch."""
+        monkeypatch.setattr(fb, "ROLLOUT_BATCH_SIZE", 2)
+        path = _make_tiny_checkpoint(size=4, chan=8)
+        try:
+            fb._load_checkpoint(str(path))
+            events = self._scan(
+                {"kind": "MOVE_ONE_ITEM", "count": 5, "seed": 0, "size": 11}
+            )
+        finally:
+            path.unlink(missing_ok=True)
+        results = [e for e in events if e["type"] == "result"]
+        assert sorted(r["seed"] for r in results) == [0, 1, 2, 3, 4]
+        # Indices stay unique across groups — the gallery sorts on them.
+        assert sorted(r["index"] for r in results) == [0, 1, 2, 3, 4]
+
+    def test_over_ceiling_is_reported_not_silently_truncated(self, monkeypatch):
+        """Asking for more than the per-scan ceiling still runs, but says
+        what it cut — a silent clamp reads as "that's all there was"."""
+        monkeypatch.setattr(fb, "MAX_BATCH_ROLLOUTS", 2)
+        path = _make_tiny_checkpoint(size=4, chan=8)
+        try:
+            fb._load_checkpoint(str(path))
+            events = self._scan(
+                {"kind": "MOVE_ONE_ITEM", "count": 5, "seed": 0, "size": 11}
+            )
+        finally:
+            path.unlink(missing_ok=True)
+        note = next(e for e in events if e["type"] == "note")
+        assert "5" in note["message"] and "2" in note["message"]
+        assert len([e for e in events if e["type"] == "result"]) == 2
+
     def test_bad_kind_yields_an_error_event(self):
         """The response headers are already sent by the time the scan
         runs, so failures have to travel in-band rather than as an
@@ -906,10 +939,12 @@ class TestRenderIndexScanTab:
         for element_id in (
             "scan-kind", "scan-count", "scan-seed", "scan-clear", "scan-mask",
             "scan-ref", "scan-sort", "scan-run", "scan-stop", "scan-results",
-            "scan-summary", "scan-stats",
+            "scan-summary", "scan-stats", "scan-clear-results",
         ):
             assert f'id="{element_id}"' in html, element_id
         assert f'<option value="{fb.ALL_KINDS_SENTINEL}">' in html
+        # Worst-first by default: a scan is run to find the failures.
+        assert '<option value="worst" selected>' in html
 
     def test_client_streams_from_the_endpoint_the_server_routes(self):
         html = fb.render_index(default_size=11)

--- a/tests/test_factory_builder.py
+++ b/tests/test_factory_builder.py
@@ -14,6 +14,7 @@ mocking the wandb client, which is high-effort for low payoff."""
 import inspect
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -836,8 +837,7 @@ class TestBatchRollout:
             )
         finally:
             path.unlink(missing_ok=True)
-        assert events[0]["type"] == "start"
-        assert events[0]["n"] == 3
+        assert events[0] == {"type": "start", "n": 3}
         assert events[-1]["type"] == "done"
         results = [e for e in events if e["type"] == "result"]
         assert sorted(r["seed"] for r in results) == [0, 1, 2]
@@ -857,12 +857,6 @@ class TestBatchRollout:
         finally:
             path.unlink(missing_ok=True)
         result = next(e for e in events if e["type"] == "result")
-        for key in (
-            "grid", "solved_grid", "thput_normed", "thput_raw", "max_throughput",
-            "steps", "stopped_by", "eot_prob", "num_placed_entities",
-            "invalid_actions", "frac_reachable", "size", "index",
-        ):
-            assert key in result, key
         assert result["stopped_by"] in ("eot", "max_steps")
         for grid in (result["grid"], result["solved_grid"]):
             assert len(grid) == 11 and all(len(row) == 11 for row in grid)
@@ -884,9 +878,9 @@ class TestBatchRollout:
             })
         finally:
             path.unlink(missing_ok=True)
-        jobs = events[0]["jobs"]
-        assert {j["kind"] for j in jobs} == {k.name for k in LessonKind}
-        assert all(j["seed"] == 4 for j in jobs)
+        results = [e for e in events if e["type"] == "result"]
+        assert {r["kind"] for r in results} == {k.name for k in LessonKind}
+        assert all(r["seed"] == 4 for r in results)
 
     def test_bad_kind_yields_an_error_event(self):
         """The response headers are already sent by the time the scan
@@ -912,7 +906,7 @@ class TestRenderIndexScanTab:
         for element_id in (
             "scan-kind", "scan-count", "scan-seed", "scan-clear", "scan-mask",
             "scan-ref", "scan-sort", "scan-run", "scan-stop", "scan-results",
-            "scan-summary",
+            "scan-summary", "scan-stats",
         ):
             assert f'id="{element_id}"' in html, element_id
         assert f'<option value="{fb.ALL_KINDS_SENTINEL}">' in html
@@ -926,17 +920,24 @@ class TestRenderIndexScanTab:
         # URL to the handler's route list.
         assert "/batch_rollout" in inspect.getsource(fb.Handler.do_POST)
 
-    def test_result_fields_the_cards_read_are_all_emitted(self):
-        """scanCard() reads these off each result — keep the card and
-        _rollout_result in lockstep."""
+    def test_result_fields_the_page_reads_are_all_emitted(self):
+        """Every `r.<field>` the scan JS reads must exist on a real result
+        event. Asserting against a hardcoded list on either side would keep
+        passing while the two drifted apart, so this derives one side from
+        the served page and the other from an actual rollout."""
         html = fb.render_index(default_size=11)
-        for field in (
-            "r.kind", "r.seed", "r.thput_normed", "r.thput_raw",
-            "r.max_throughput", "r.stopped_by", "r.steps",
-            "r.num_placed_entities", "r.invalid_actions", "r.frac_reachable",
-            "r.grid", "r.solved_grid", "r.size",
-        ):
-            assert field in html, field
+        read_fields = set(re.findall(r"\br\.([a-z_]+)", html))
+        assert read_fields, "no r.<field> reads found in the served page"
+        path = _make_tiny_checkpoint(size=4, chan=8)
+        try:
+            fb._load_checkpoint(str(path))
+            events = TestBatchRollout._scan(
+                {"kind": "MOVE_ONE_ITEM", "count": 1, "seed": 1, "size": 11}
+            )
+        finally:
+            path.unlink(missing_ok=True)
+        result = next(e for e in events if e["type"] == "result")
+        assert read_fields <= set(result), read_fields - set(result)
 
 
 class TestIconCoverage:


### PR DESCRIPTION
## Why

Inspecting a checkpoint one seed at a time — generate, blank, hold `a`, read the failure, repeat — is too slow to spot a *systematic* weakness. You can't tell "this checkpoint is bad at assemblers" from a sample of one.

## What

A second tab in `scripts/factory_builder.py`. Pick a lesson kind (or `(every kind)`), a rollout count and a start seed, and hit **Run +N**. Each factory is blanked down to its protected tiles (source, sink, reserved cells), the model greedily rebuilds it until its EOT head fires, and every finished factory lands in a gallery.

Rollouts advance in lockstep through one batched `sample_action`, in groups of 64, so N seeds cost roughly one seed's worth of forward passes. Measured on an 11×11 grid: **14 lesson kinds in 2.6s, 70 rollouts in 8.4s.** Results stream back as newline-delimited JSON so they appear as they finish, with a live progress line and a Stop button that cancels server-side.

### Reading a scan

- Cards are colour-coded on the left border, red (zero throughput) → green (perfect rebuild), and sorted worst-first by default.
- A **per-lesson table**: runs, mean throughput, how often throughput was non-zero, how often the factory came out complete, how often EOT fired. A single mean over the whole scan hides exactly the thing worth finding — that one lesson sits at zero while the rest are fine.
- **Run +N accumulates**: each click appends to the gallery and the stats and advances the start seed, so you build up a sample instead of replacing one.
- **show reference** draws the generator's own solution beside each rebuild; clicking any card opens that factory in the Build tab.

Greedy argmax + the legal-tile mask mirror `sft.run_rollout_eval`, so the throughput numbers are the same quantity as `eval/thput` — except the EOT head really does end the episode here, since the point is to see the factory the model considers finished.

## Notes for review

- Icons moved from inline `data:` URIs to CSS classes. A reference-on card was building ~300 KB of HTML per grid (a 64-rollout scan ~38 MB); the page's inline JS dropped 1029 KB → 38 KB. Same wire bytes — the URIs just moved into 89 style rules.
- `cellGlyphs()`, `adoptGrid()` and `_build_with_retry()` are now shared with the existing Build tab rather than copied, so the two renderers can't drift apart.
- The per-scan ceiling (512) emits a `note` event saying what it cut rather than truncating silently.
- 11 new tests cover the streaming contract, chunking across batch groups, the ceiling report, and the result-field contract (derived from both sides rather than two hand-maintained lists).

Full checklist green: cargo fmt/clippy/test, maturin, 3241 pytest, ruff, ty, PPO + SFT smoke tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)