### PR TITLE
Update CLAUDE.md/README.md with the current baselines and headline results

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ The training pipeline is moving toward an **LLM-style two-stage split**:
 
 1. **Data generation** — `build_factory()` in `factorion.py` constructs a known-correct factory (returning `Optional[Factory]`), then `blank_entities()` produces a *(partial-factory, correct-completion)* training pair by removing N entities from it. Each lesson type (`MOVE_ONE_ITEM`, `SPLITTER_SPLIT`, `SPLITTER_MERGE_SIDELOADED`, …) covers a different entity or layout pattern. The exception is **trial** kinds (`LESSON_IS_TRIAL`): scenarios with no known solution — the built world is only the source/sink markers, so they yield no SFT pairs and are trained on by RL alone.
 2. **SFT pretraining** — `sft.py` runs supervised training on those pairs, giving the policy a strong prior over entity placement. It uploads the best checkpoint as a W&B artifact (type `model`, containing `sft_checkpoint.pt`) so RL can pull it by run id.
-3. **RL finetuning** — PPO (`ppo.py`) refines the pretrained policy to push beyond what imitation achieves. Load an SFT checkpoint with `--start-from` (accepts **either** a local `.pt` path **or** a W&B run id like `j0s5y2mc` — the run's model artifact is downloaded automatically). Every episode builds from a **fully-blank** grid (no curriculum). The canonical SFT base is run **`j0s5y2mc`**; the bar PPO must clear is its `val/thput ≈ 0.11` (see "Throughput metric" below).
+3. **RL finetuning** — PPO (`ppo.py`) refines the pretrained policy to push beyond what imitation achieves. Load an SFT checkpoint with `--start-from` (accepts **either** a local `.pt` path **or** a W&B run id like `h76h80yb` — the run's model artifact is downloaded automatically). Every episode builds from a **fully-blank** grid (no curriculum). The canonical SFT base is run **`h76h80yb`**; the bar PPO must clear is its `eval/thput ≈ 0.67` on the current lesson mix (see "Baselines and best runs" below).
 
 Historically the project did RL-from-scratch with heavy scaffolding (curriculum on `num_missing_entities`, reward shaping, action masking) to handle the sparse-reward problem. Most of that scaffolding still exists but its role changes under the new pipeline: the curriculum axis becomes a data-sampling knob during SFT, and RL starts from a much better policy so sparse rewards matter less.
 
@@ -49,7 +49,7 @@ Historically the project did RL-from-scratch with heavy scaffolding (curriculum 
 ### Codebase map (grep these symbols)
 
 - **State tensor** is `(C, W, H)` with `C = len(Channel) = 5` channels: `ENTITIES`, `DIRECTION`, `ITEMS` (recipe/filter), `MISC` (underground up/down), `FOOTPRINT` (1 = buildable).
-- **Lessons** (`LessonKind` in `factorion.py`, built from `factory_gen.rs::LessonKind` via `factorion_rs.py_lesson_kinds()`): `MOVE_ONE_ITEM`, `SPLITTER_SPLIT`, `SPLITTER_MERGE_SIDELOADED`, `ASSEMBLE_1IN_1OUT`, `MOVE_VIA_UG_BELT`, `ASSEMBLE_2IN_1OUT`, `MEMORISE_1_INGREDIENT_RECIPES` … `MEMORISE_4_INGREDIENT_RECIPES`, `MOVE_ONE_ITEM_CHAOS`, `CROSS_UNDER_BELT`, `FACTORY_1_INGREDIENT`, `TRIAL_RECIPE_TREE_DEPTH_1` … `TRIAL_RECIPE_TREE_DEPTH_3`. `build_factory(size, kind, seed, ...)` (Rust-backed) returns `Optional[Factory]` (rejection sampling can fail → `None`); `blank_entities(factory, num_missing_entities, seed)` removes N entity *units* (multi-tile entities count as one). Every `Factory` carries `max_throughput`, the items/s reference throughput is normalized by (the solved world's simulated rate, or an analytic ceiling for trials). Each lesson has a `build_*` generator in `factory_gen.rs`; `SPLITTER_MERGE_SIDELOADED` (`build_splitter_merge_sideloaded`) replaces the old throughput-hackable `SPLITTER_MERGE`: two sources are each capped to 7.5 i/s by a **side-load gadget** (a protected empty "decoy" belt forces the source to side-load onto one lane instead of curving to a full 15), then a splitter merges the two 7.5 arms onto one 15 i/s belt to a single sink — so *both* arms are throughput-necessary (drop one and the sink falls to 7.5), unlike the old merge whose lone sink was saturated by either source alone. Its decoy belts are the one sanctioned exception to the no-orphan invariant (see below). The `MEMORISE_N_INGREDIENT_RECIPES` lessons (`build_memorise_recipes`, one per exact ingredient count 1–4) place a random recipe's assembler fed/drained by `source → belt → inserter → assembler → inserter → belt → sink` arms with exactly one belt per arm (one source per ingredient, so lesson `N` has exactly `N` input sources); `CROSS_UNDER_BELT` (`build_cross_under_belt`) is validated by its own throughput/orphan invariants; `FACTORY_1_INGREDIENT` (`build_factory_1_ingredient`) places a row of 1+ assemblers sharing an input and an output belt lane (1–3 input and 1–3 output inserters per assembler), with the source/sink at semi-arbitrary cells wired to the lane ends by the UG-aware router — throughput deliberately varies (input-inserter / recipe-speed / output-inserter limited) so the critic sees good and bad layouts; the `TRIAL_RECIPE_TREE_DEPTH_N` **trials** (`build_recipe_tree_trial`; flagged by `LessonKind::is_trial` / Python `LESSON_IS_TRIAL`) place ONLY markers, always on the grid edge working inward (sources face their wall's inward normal, the sink faces outward so it pulls from its interior neighbour) — a random craftable sink item (any assembler tier) plus one source per item of a randomly-expanded frontier of its ingredient tree, where the deepest expanded chain is exactly `N` crafting stages — with a reserved free working cell per marker; `total_entities == 0` and `max_throughput` is the sink recipe's single-assembler output rate.
+- **Lessons** (`LessonKind` in `factorion.py`, built from `factory_gen.rs::LessonKind` via `factorion_rs.py_lesson_kinds()`): `MOVE_ONE_ITEM`, `SPLITTER_SPLIT`, `SPLITTER_MERGE_SIDELOADED`, `MOVE_VIA_UG_BELT`, `MEMORISE_1_INGREDIENT_RECIPES` … `MEMORISE_4_INGREDIENT_RECIPES`, `MOVE_ONE_ITEM_CHAOS`, `CROSS_UNDER_BELT`, `FACTORY_1_INGREDIENT`, `TRIAL_RECIPE_TREE_DEPTH_1` … `TRIAL_RECIPE_TREE_DEPTH_3`. (`Assemble1In1Out`/`Assemble2In1Out` still occupy discriminants 5 and 7 in the Rust enum but are `#[deprecated]` and absent from `py_lesson_kinds()`, so nothing generates or trains on them.) `build_factory(size, kind, seed, ...)` (Rust-backed) returns `Optional[Factory]` (rejection sampling can fail → `None`); `blank_entities(factory, num_missing_entities, seed)` removes N entity *units* (multi-tile entities count as one). Every `Factory` carries `max_throughput`, the items/s reference throughput is normalized by (the solved world's simulated rate, or an analytic ceiling for trials). Each lesson has a `build_*` generator in `factory_gen.rs`; `SPLITTER_MERGE_SIDELOADED` (`build_splitter_merge_sideloaded`) replaces the old throughput-hackable `SPLITTER_MERGE`: two sources are each capped to 7.5 i/s by a **side-load gadget** (a protected empty "decoy" belt forces the source to side-load onto one lane instead of curving to a full 15), then a splitter merges the two 7.5 arms onto one 15 i/s belt to a single sink — so *both* arms are throughput-necessary (drop one and the sink falls to 7.5), unlike the old merge whose lone sink was saturated by either source alone. Its decoy belts are the one sanctioned exception to the no-orphan invariant (see below). The `MEMORISE_N_INGREDIENT_RECIPES` lessons (`build_memorise_recipes`, one per exact ingredient count 1–4) place a random recipe's assembler fed/drained by `source → belt → inserter → assembler → inserter → belt → sink` arms with exactly one belt per arm (one source per ingredient, so lesson `N` has exactly `N` input sources); `CROSS_UNDER_BELT` (`build_cross_under_belt`) is validated by its own throughput/orphan invariants; `FACTORY_1_INGREDIENT` (`build_factory_1_ingredient`) places a row of 1+ assemblers sharing an input and an output belt lane (1–3 input and 1–3 output inserters per assembler), with the source/sink at semi-arbitrary cells wired to the lane ends by the UG-aware router — throughput deliberately varies (input-inserter / recipe-speed / output-inserter limited) so the critic sees good and bad layouts; the `TRIAL_RECIPE_TREE_DEPTH_N` **trials** (`build_recipe_tree_trial`; flagged by `LessonKind::is_trial` / Python `LESSON_IS_TRIAL`) place ONLY markers, always on the grid edge working inward (sources face their wall's inward normal, the sink faces outward so it pulls from its interior neighbour) — a random craftable sink item (any assembler tier) plus one source per item of a randomly-expanded frontier of its ingredient tree, where the deepest expanded chain is exactly `N` crafting stages — with a reserved free working cell per marker; `total_entities == 0` and `max_throughput` is the sink recipe's single-assembler output rate.
 - **Underground lessons**: `MOVE_VIA_UG_BELT` forces underground belts with an `UNAVAILABLE`-footprint wall; `CROSS_UNDER_BELT` gives a real, protected belt line (the "obstruction" — a winding edge-to-edge cut) the crossing must tunnel *under* via `factory_gen.rs::ug_aware_belt_path` (a Dijkstra that may dip under blocked cells; minimal tunnel span, no 180° reversals or tile reuse, source→UG-down / UG-up→sink shortcuts).
 - **No-orphan invariant**: no lesson's solved factory may contain orphan tiles — throughput must report `unreachable == 0` (checked by `factory_gen.rs::tests::test_no_orphan_tiles_every_lesson` across every non-trial `LessonKind`; a trial's world is only the unconnected markers). Unreachability is judged per ENTITY (an entity is an orphan iff none of its lane nodes lie on a source→sink path) since e.g. an inserter-fed belt legitimately has one forever-empty lane. The **one opt-out** is `LessonKind::allows_orphans()` (exposed to Python as `factorion_rs.py_lesson_allows_orphans()`): `SPLITTER_MERGE_SIDELOADED` returns `true` because its side-load decoy belts are intentional protected orphans; the test then requires every orphan to be a protected tile (`unreachable == protected_positions.len()`), so no *accidental* orphan slips through.
 - **Jargon**: the orientation-relative sides of a directional entity are **left, right, fore, aft** (a north-facing belt's left side is west, its fore side north). Use these consistently in code comments and docs.
@@ -61,11 +61,11 @@ Historically the project did RL-from-scratch with heavy scaffolding (curriculum 
 
 ## W&B dashboards
 
-Runs are named by a hyperparameter signature, not a timestamp (`ppo.py:_run_signature`, `sft.py:_artifact_name`), e.g. `ppo-s11-lr5e-05-ent0-cw10-fromj0s5y2mc-c93-69-96-seed1`. `global_step` (env steps) is the PPO x-axis. PPO logs once per iteration into these sections (see `define_metric` block in `ppo.py`):
+Runs are named by a hyperparameter signature, not a timestamp (`ppo.py:_run_signature`, `sft.py:_artifact_name`), e.g. `ppo-s11-lr3.369e-05-ent0.008034_0.0007372-kl0.02-cw9-fromh76h80yb-c128-128-128-seed1`. `global_step` (env steps) is the PPO x-axis. PPO logs once per iteration into these sections (see `define_metric` block in `ppo.py`):
 
 - **`eval/`** — periodic EOT-respecting greedy held-out throughput (`eval/thput`, `eval/{LESSON}/thput`), every `--eval-every` iters; directly overlay-able with the SFT baseline. **This is the headline progress signal**, and the sweep metric (`ci/sweep_ppo.yaml`).
 - **`rollout/`** — on-policy sampled episode stats (`thput`, `thput_raw`, `reward`, `length`, `eot_rate`, `invalid_frac`, `num_entities`, `entity_efficiency`, `frac_reachable`, `entity_cost`, `cost_efficiency`) + per-lesson `rollout/{LESSON}/{thput,thput_raw,reward,length,entity_cost,cost_efficiency}` (raw items/s kept alongside the normalized throughput so lessons with very different ceilings stay comparable).
-- **Lessons vs trials are pooled separately.** The `eval/thput` and `rollout/*` aggregates cover **lessons only**; trial episodes go to `eval/trial_thput` and the parallel `rollout/trial_*` block (same field names). This keeps the headline comparable to the SFT baseline — SFT never sees a trial, so mixing them in would move `eval/thput` for reasons unrelated to build skill. Per-lesson `{eval,rollout}/{TRIAL_*}/…` keys are already name-separated and are logged as usual, so a trial's own curve is always visible. **`eval/trial_thput` is the metric that actually matters** — it scores building a factory from nothing but the markers, which is the real problem; every lesson is a proxy for it. Expect it to sit at 0 for a long time (see #339).
+- **Lessons vs trials are pooled separately.** The `eval/thput` and `rollout/*` aggregates cover **lessons only**; trial episodes go to `eval/trial_thput` and the parallel `rollout/trial_*` block (same field names). This keeps the headline comparable to the SFT baseline — SFT never sees a trial, so mixing them in would move `eval/thput` for reasons unrelated to build skill. Per-lesson `{eval,rollout}/{TRIAL_*}/…` keys are already name-separated and are logged as usual, so a trial's own curve is always visible. **`eval/trial_thput` is the metric that actually matters** — it scores building a factory from nothing but the markers, which is the real problem; every lesson is a proxy for it. Expect it to stay near 0 for a long time (see #339): as of 2026-07-30 it sits at 0.00–0.05 across seeds, entirely from `TRIAL_RECIPE_TREE_DEPTH_1` (≈0.11); depths 2 and 3 are still exactly 0.
 - **`policy/`** — acting-policy distribution: `entropy`, per-head `entropy_{tile,entity,direction,item,misc,eot}`, `eot_prob`.
 - **`critic/`** — value-head health (is the critic predicting factory value?), global + per-lesson (`ppo.py:_critic_diagnostics`). Global: `explained_variance` (headline: 1=perfect, 0=predicts-the-mean, <0=worse), `value_rmse`/`value_bias` (error size / signed over-under-estimation, in reward units), `value_return_corr` (ordering skill, robust to scale/offset), `value_std` vs `return_std` (tells a collapsed-to-constant critic apart from a responsive one), `value_mean`/`return_mean`, `adv_abs_mean` (mean |GAE advantage|, a TD-error proxy). Per-lesson `critic/{LESSON}/{explained_variance,value_rmse,value_bias,value_return_corr}` — so a critic that nails belts but is clueless on assemblers shows as a split curve (variance-based fields are NaN when fewer than 2 transitions back that slice).
 - **`losses/`** `policy,value,entropy,total,approx_kl,clipfrac,explained_variance` (the last kept for back-compat; `critic/` is the richer view); **`optim/`** `lr,critic_lr,ent_coef,grad_norm,critic_warmup`; **`perf/`** `sps,rollout_seconds,update_seconds,eval_seconds`.
@@ -77,7 +77,67 @@ The metric comes from a greedy rollout that blanks the **whole** grid and rebuil
 - **`thput`** (`overall`) — build skill *respecting* the EOT head: the rollout stops the first time the EOT prob crosses `rollout_eot_threshold` (0.5) and scores the throughput at that state; if it never fires, the rollout runs to env-done and scores the final throughput. "How good is the factory at the moment the model decides it's done?"
 - **`trial_thput`** (`trial_overall`) — the same number over trial kinds only, pooled separately (`trial_n` counts the trials scored). Zero when no trial ran, which is always the case for SFT.
 
-**The RL goal is for PPO's achieved throughput to exceed the SFT base's `val/thput` (≈0.11 for `j0s5y2mc`).** Per-lesson the SFT base is uneven (MOVE_ONE_ITEM ~0.38, assembler lessons ~0). The longer-run goal is `eval/trial_thput` above zero at all — nothing imitative can produce it.
+**The RL goal is for PPO's achieved throughput to exceed the SFT base's throughput on the same lesson mix (≈0.67 for `h76h80yb`).** Per-lesson the SFT base is uneven — belt and memorise lessons are near-solved while `FACTORY_1_INGREDIENT` sits ~0.3. The longer-run goal is `eval/trial_thput` climbing well above zero — nothing imitative can produce it.
+
+## Baselines and best runs
+
+Numbers below are from W&B (`beyarkay/factorion`); the sha each was trained at is
+in the run's tags. **Two caveats before comparing anything to anything:**
+
+- **#328 renamed the metric.** Before `dc2f435` the EOT-respecting number was
+  logged as `val/thput_eot` and `val/thput` meant "run to env-done, ignore the
+  EOT head". After it, `val/thput` *is* the EOT-respecting number. #350
+  (`2c5a915`) then made the rollout actually stop at the fire, which by
+  construction preserved the values. So for a pre-#328 run, read
+  `val/thput_eot`.
+- **Lesson generation changed under the metric.** #335 (`5336d58`, recipe
+  rebalance) and #349 (`10dfb72`, sample one belt route) both moved the data
+  distribution, so an SFT `val/thput` from before them is not comparable to one
+  after. Every SFT run on record predates both — which is why the operative
+  baseline below is measured *inside* a PPO run on current-ish main rather than
+  taken from the SFT run's own logs.
+
+**Canonical SFT base — `h76h80yb`** (12.7 h, 50M samples, `110ab3a`, finished,
+model artifact present, and what `ci/sweep_ppo.yaml` + `scripts/factory_builder.py`
+point at). Its own SFT-time score was `val/thput_eot = 0.954`, but that was on
+the pre-#335 lesson mix. Re-measured on main@`94ef25e`, it scores
+**`eval/thput ≈ 0.67`** — that is the bar PPO has to clear.
+
+**Best PPO to date** — the 3-seeds-per-side compare on PR #346 (2026-07-30,
+from `h76h80yb`, 2.5M timesteps, ~2.5 h/seed). Both sides landed in the same
+place (no metric moved significantly), so read either column as "what PPO
+currently gets to":
+
+| metric | main@`94ef25e` | PR@`b8042d4` | p |
+|---|---|---|---|
+| `eval/thput` | 0.776 | 0.784 | 0.38 |
+| `eval/trial_thput` | 0.037 | 0.041 | 0.42 |
+| `rollout/thput` | 0.788 | 0.793 | 0.29 |
+
+So PPO takes `eval/thput` from ≈0.67 (the SFT base) to ≈0.78 in 2.5M steps,
+and `eval/trial_thput` is all `TRIAL_RECIPE_TREE_DEPTH_1` (≈0.11 on its own
+curve) — depths 2 and 3 contribute exactly 0.
+
+**Long runs are not reliably better.** `gs1nqoni` (21.7 h, 40M steps,
+main@`5336d58`) *degraded*: `eval/thput` 0.68 → 0.42. #339 traces this to the
+`CROSS_UNDER_BELT` freebie (a fully-blanked grid already scores 0.25 there, so
+firing EOT immediately is locally optimal) plus the EOT bias. Other multi-hour
+runs improved — `i3vzy230` 0.50 → 0.76 over 44M steps, `6fn5s38f` 0.10 → 0.55
+over 35M. Treat >10M-step runs as needing the #339 blockers fixed first.
+
+**Highest SFT `val/thput` on record** is `84glrv0x` at **0.83** (5M samples,
+2026-07-23), with `w1ci81b7` at 0.82 — but both come from a sweep over
+`missing_fraction_alpha`, a blanking-difficulty knob that no longer exists in
+`SftArgs`, so they were trained on a data distribution the current code cannot
+reproduce. Their checkpoints still load (same architecture), but do not read
+0.83 as "what SFT reaches today". The largest SFT run, `rqsl66jw` (40.3 h,
+killed at 150M of 250M samples), reached 0.75 and **uploaded no model
+artifact**, so it cannot be used as a `--start-from` base at all.
+
+**No run on record was trained at the current main tip.** The newest results
+(2026-07-30) sit at `94ef25e`/`b8042d4`, which predate #350, #347, #351, #349
+and #354. #349 in particular changes lesson generation, so expect the numbers
+above to shift when the next run lands.
 
 ## SFT → PPO handoff
 

--- a/README.md
+++ b/README.md
@@ -17,55 +17,64 @@ output items.
 
 ![](imgs/blueprint.png)
 
-Weights & Biases report (a few months out of date, 2025-04-29, current work has
+Weights & Biases report (long out of date, 2025-04-29; current work has
 progressed significantly): https://api.wandb.ai/links/beyarkay/wmccb7fq
+
+## Where things stand (2026-08-02)
+
+The pipeline is SFT pretraining followed by PPO finetuning, on an 11×11 grid.
+Headline numbers, all from W&B project `beyarkay/factorion`:
+
+- **SFT base `h76h80yb`** (50M samples, 12.7 h) is the checkpoint everything
+  currently starts from. On the current lesson mix it rebuilds held-out
+  factories to **≈0.67** of their reference throughput.
+- **PPO lifts that to ≈0.78** (`eval/thput`, 3 seeds × 2.5M timesteps,
+  2026-07-30). Belt and "memorise this recipe" lessons are essentially solved
+  (0.9–1.0); `FACTORY_1_INGREDIENT` is the weak one at ~0.3.
+- **Building from markers alone is still unsolved.** The `TRIAL_*` kinds hand
+  the agent nothing but source and sink markers — no reference solution to
+  imitate, and one source per ingredient of the target recipe. Depth-1 trials
+  score ~0.11; depth-2 and depth-3 are still exactly 0. This is the number that
+  actually matters, and it is the open problem.
+- Multi-hour PPO runs are not reliably better than short ones — a 40M-step run
+  *degraded* from 0.68 to 0.42. [#339](https://github.com/beyarkay/factorion/issues/339)
+  measures why (a lesson that pays 25% for doing nothing, plus an end-of-turn
+  head that truncates exploration ~16×).
 
 ## Recent additions
 
-What's landed on `main` in the last week, newest first.
+What's landed on `main` recently, newest first.
 
-**2026-05-13**
+**2026-07-30**
 
-- Made the "build one assembler" training task actually hide the assembler so the model has to learn to place it ([#108](https://github.com/beyarkay/factorion/pull/108))
-- Added an evaluation step during supervised pre-training that rolls out the model's greedy predictions and measures the resulting factory's throughput ([#109](https://github.com/beyarkay/factorion/pull/109))
-- Tuned the supervised pre-training sweep with cosine LR schedule, AdamW, gradient clipping, and per-output-head loss weights ([#104](https://github.com/beyarkay/factorion/pull/104))
+- Sampled one belt route per lesson instead of enumerating every shortest one ([#349](https://github.com/beyarkay/factorion/pull/349))
+- Made the greedy eval stop as soon as the model's end-of-turn head fires, matching PPO and the builder UI ([#350](https://github.com/beyarkay/factorion/pull/350))
+- Added a "scan seeds" tab that rebuilds many blanked factories at once ([#351](https://github.com/beyarkay/factorion/pull/351))
 
-**2026-05-12**
+**2026-07-27**
 
-- Added a binary "I'm done placing entities" output head so the agent can decide when to stop ([#103](https://github.com/beyarkay/factorion/pull/103))
-- Scaled the supervised pre-training smoke test up to 300k samples on an 11×11 grid ([#102](https://github.com/beyarkay/factorion/pull/102))
-- Built an interactive page for inspecting the model's predictions, and added W&B checkpoint uploads ([#100](https://github.com/beyarkay/factorion/pull/100))
-- Moved throughput computation into a Rust implementation for a big speedup ([#99](https://github.com/beyarkay/factorion/pull/99))
-- Dropped the marimo notebook wrapper so `factorion.py` is a plain importable module ([#98](https://github.com/beyarkay/factorion/pull/98))
-- Made the agent predict all four channels of an entity placement (tile, entity type, item/recipe, orientation) ([#96](https://github.com/beyarkay/factorion/pull/96))
-- Logged per-task validation metrics and a per-head loss breakdown during pre-training ([#97](https://github.com/beyarkay/factorion/pull/97))
-- Added a new training task: routing belts under obstacles using underground belts ([#82](https://github.com/beyarkay/factorion/pull/82))
-- Set up the Claude Code GitHub Actions workflow ([#94](https://github.com/beyarkay/factorion/pull/94))
-- Added a `crafting_time` field to the recipe data model ([#92](https://github.com/beyarkay/factorion/pull/92))
+- Added **trials**: RL-only lesson kinds with no known solution, scored separately from lessons ([#344](https://github.com/beyarkay/factorion/pull/344))
 
-**2026-05-11**
+**2026-07-25**
 
-- Added a hotbar, keyboard shortcuts, and auto-recompute to the factory-builder web UI ([#86](https://github.com/beyarkay/factorion/pull/86))
+- Log-compressed the terminal reward so lessons with 360× different item rates share gradient fairly ([#336](https://github.com/beyarkay/factorion/pull/336))
+- Fixed a nonzero PPO `approx_kl` caused by the attention stack ignoring `--dropout` ([#337](https://github.com/beyarkay/factorion/pull/337))
 
-**2026-05-10**
+**2026-07-22 – 2026-07-24**
 
-- Shipped an interactive drag-and-drop factory builder for designing and inspecting layouts in the browser ([#85](https://github.com/beyarkay/factorion/pull/85))
-- Expanded the item catalogue with 55 new items and 43 new recipes from the wiki ([#80](https://github.com/beyarkay/factorion/pull/80))
+- Restored canonical recipes and rebalanced the "memorise recipes" lessons ([#335](https://github.com/beyarkay/factorion/pull/335))
+- Replaced `SPLITTER_MERGE` with a throughput-honest side-loaded variant where both input arms are actually necessary ([#325](https://github.com/beyarkay/factorion/pull/325))
+- Masked invalid action combinations in the policy heads ([#327](https://github.com/beyarkay/factorion/pull/327))
+- Unified every sampling path into one `AgentCNN.sample_action` ([#320](https://github.com/beyarkay/factorion/pull/320))
 
-**2026-05-08**
+**2026-07-21**
 
-- Added 50 wiki-sourced icons for entities, items, and modules ([#79](https://github.com/beyarkay/factorion/pull/79))
-- Fixed a data leak where one of the input channels was telling the model where the answer was supposed to go ([#81](https://github.com/beyarkay/factorion/pull/81))
-- Ran a supervised pre-training smoke test on then-current main as a baseline ([#77](https://github.com/beyarkay/factorion/pull/77))
-- Added a training task for assemblers with one input and one output, and unified recipes/items behind a single Rust source of truth ([#78](https://github.com/beyarkay/factorion/pull/78))
-- Fixed how belt corners are drawn, and added filter flags to the data-visualisation script ([#76](https://github.com/beyarkay/factorion/pull/76))
-- Landed the initial supervised pre-training pipeline and deduplicated the RunPod CI setup ([#47](https://github.com/beyarkay/factorion/pull/47))
-- Made consecutive belts render as a single visual chain in the HTML factory view ([#73](https://github.com/beyarkay/factorion/pull/73))
-- Fixed the env step so multi-tile entities fill their full footprint on the grid ([#72](https://github.com/beyarkay/factorion/pull/72))
-- Added an optional `highlights` argument to the HTML factory renderer ([#71](https://github.com/beyarkay/factorion/pull/71))
-- Added a script for visualising samples of the supervised-training dataset ([#70](https://github.com/beyarkay/factorion/pull/70))
-- Made ffmpeg video capture opt-in via `--capture-video` ([#69](https://github.com/beyarkay/factorion/pull/69))
-- Documented Factorio's two-lane belt mechanics in the wiki reference ([#64](https://github.com/beyarkay/factorion/pull/64))
+- Added a self-attention stage over the encoded grid so every cell sees every other in one hop — the dominant win in the architecture sweeps ([#314](https://github.com/beyarkay/factorion/pull/314))
+
+**2026-07-11 – 2026-07-14**
+
+- Added a per-entity frugality penalty to the PPO terminal reward ([#295](https://github.com/beyarkay/factorion/pull/295))
+- Built an engine↔Factorio parity harness that replays generated factories inside the real game ([#278](https://github.com/beyarkay/factorion/pull/278))
 
 ## What is Factorio?
 
@@ -82,9 +91,9 @@ challenge, making it an interesting domain for an autonomous RL agent.
 
 Instead of integrating directly with the game (which would be prohibitively
 slow for training), this project uses a basic implementation of core Factorio
-mechanics. Currently this is in python, but will be rewritten in C/Rust before
-the next scale-up of agent training as roll-out times are becoming a
-bottleneck.
+mechanics. The throughput simulation and the lesson generators live in a Rust
+extension (`factorion_rs/`, built with PyO3/maturin); the simulator runs
+21,000–76,000 factories/second and is no longer the training bottleneck.
 
 ### The Environment: `FactorioEnv`
 
@@ -103,6 +112,7 @@ of the Factorio game world.
     filtering for.
   - `MISC`: Used for special entity states, like the direction of an
     underground belt.
+  - `FOOTPRINT`: Whether the cell is buildable at all.
 
 - **Action Space**: The agent interacts with the environment by placing one
   entity at a time. Each turn, the agent outputs a discrete action composed of:
@@ -110,14 +120,20 @@ of the Factorio game world.
   - `xy`: The coordinates for the placement.
   - `entity`: The type of entity to place.
   - `direction`: The orientation of the entity.
+  - `item`: The recipe an assembler is set to.
+  - `misc`: Whether an underground belt is an entrance or an exit.
+  - `eot`: "This factory is finished" — a real action that ends the episode.
 
-- **Reward Signal**: After the agent has finished placing entities (or the
-  episode times out), the resulting factory is evaluated. A custom graph-based
-  algorithm simulates the flow of items through the constructed belts and
-  machines to calculate the factory's final **throughput** (items produced per
-  second). This throughput value serves as the primary reward signal. The agent
-  is thus incentivized to create designs that are not just connected, but
-  efficient.
+- **Reward Signal**: After the agent ends the episode (or it times out), the
+  resulting factory is evaluated. A custom graph-based algorithm simulates the
+  flow of items through the constructed belts and machines to calculate the
+  factory's final **throughput** (items produced per second). The reward is
+  that throughput, divided by an entity-cost penalty (so the agent cannot buy
+  throughput with unlimited entities) and then log-compressed — solved lessons
+  differ ~360× in achievable items/second, and without compression the belt
+  lessons would receive two orders of magnitude more gradient than the
+  assembler ones. The agent is thus incentivized to create designs that are not
+  just connected, but efficient and frugal.
 
 #### An example 5x5 environment with one transport-belt missing
 
@@ -129,18 +145,23 @@ of the Factorio game world.
 
 ### Training pipeline: SFT pretraining, then RL finetuning
 
-The project is moving toward an LLM-style two-stage training pipeline:
+The project uses an LLM-style pipeline — generate data, pretrain on it, then
+finetune with RL:
 
 **Stage 1 — Data generation via lessons.** Hand-written factory generators
-(`generate_lesson()` in `factorion.py`) produce known-correct factories and
-then blank out N entities from them. The result is a stream of
-*(partial-factory, correct-completion)* training pairs. Each **lesson type**
-covers a different entity/layout pattern:
+(`build_factory()`, implemented in `factorion_rs/src/factory_gen.rs`) produce
+known-correct factories and then blank out N entities from them. The result is
+a stream of *(partial-factory, correct-completion)* training pairs. Each
+**lesson type** covers a different entity/layout pattern:
 
-- `MOVE_ONE_ITEM`, `ALL_BELTS_ALREADY_IN_PLACE` — belt routing
+- `MOVE_ONE_ITEM`, `MOVE_ONE_ITEM_CHAOS` — belt routing
 - `SPLITTER_SPLIT`, `SPLITTER_MERGE_SIDELOADED` — flow splitting, and merging
   two side-load-limited (7.5 i/s) arms into one full belt via 2×1 splitters
-- (planned) underground belts, crossings, assembling machines
+- `MOVE_VIA_UG_BELT`, `CROSS_UNDER_BELT` — underground belts and crossings
+- `MEMORISE_1..4_INGREDIENT_RECIPES`, `FACTORY_1_INGREDIENT` — assembling
+  machines, recipe selection, and multi-assembler lanes
+- `TRIAL_RECIPE_TREE_DEPTH_1..3` — **trials**: only the source and sink markers
+  are placed, there is no reference solution, and they are trained by RL alone
 
 Each lesson also has an **internal difficulty knob**: `num_missing_entities`
 ranges from 0 (full solution shown) up to all placeable entities (only the
@@ -148,7 +169,8 @@ source/sink remain). Lesson *type* and difficulty are orthogonal — the agent
 sees diverse scenarios at every difficulty level.
 
 **Stage 2 — Supervised pre-training (SFT).** A multi-head classifier (tile +
-entity + direction) is trained on the lesson pairs via cross-entropy loss.
+entity + direction + item + misc, plus the end-of-turn head) is trained on the
+lesson pairs via cross-entropy loss.
 This gives the policy a strong prior: it already "knows" how inserters
 connect belt segments, how splitters divide flow, etc., before any RL
 happens.
@@ -158,43 +180,60 @@ refines the policy to maximise actual throughput — pushing beyond the
 lesson-generator's solutions when a better layout exists. Starting from a
 decent pretrained policy means the sparse-reward problem (most factories
 throughput=0) bites much less than in the original RL-from-scratch setup.
-Point `--start-from` at either a local `.pt` file or a W&B run id (e.g. an SFT
-run like `j0s5y2mc`, whose model artifact is fetched automatically), and use
-`--critic-warmup` to train the fresh value head before unfreezing the policy.
-The aim is for PPO to beat the SFT base's `val/thput`.
+Point `--start-from` at either a local `.pt` file or a W&B run id (e.g. the
+current SFT base `h76h80yb`, whose model artifact is fetched automatically),
+and use `--critic-warmup` to train the fresh value head before unfreezing the
+policy. The aim is for PPO to beat the SFT base's throughput on the same
+lesson mix — currently ≈0.67, which PPO takes to ≈0.78.
 
 Historically the project trained RL from scratch with an explicit curriculum
-that ramped `num_missing_entities` over time. That scaffolding still exists
-but its role is shifting: the curriculum axis becomes a data-sampling knob
-during SFT, and RL gets to skip early levels when loading an SFT checkpoint.
+that ramped `num_missing_entities` over time. That curriculum has been removed
+from PPO — every RL episode now builds from a fully blank grid. The
+`num_missing_entities` axis survives only as a data-sampling knob during SFT.
 
 ### The Agent: `AgentCNN`
 
-The agent's policy is represented by a Convolutional Neural Network (CNN). This
-architecture is well-suited for processing grid-based, spatial data like our
-environment.
+The agent's policy is a convolutional encoder followed by a self-attention
+stage. Convolutions capture local structure (which tiles touch which); the
+attention stage lets every cell see every other cell in one hop, which the
+architecture sweeps found to be the single biggest win — a belt in one corner
+has to be routed with respect to a sink in the other.
 
 - **Input**: The network takes the environment's `(Channels, Width, Height)`
   tensor as input.
-- **Architecture**: The agent uses a series of convolutional layers to extract
-  spatial features from the factory layout. The output of the convolutional
-  encoder is then fed into several separate linear heads.
+- **Architecture**: A stack of convolutional layers extracts spatial features,
+  a transformer encoder then mixes them globally (the 121 grid cells become
+  tokens, so full attention is cheap), and a pooled global-context vector is
+  concatenated onto the per-tile head inputs.
 - **Output**:
-  - **Actor Heads**: There are separate output heads for each component of the
-    action space (`x`, `y`, `entity`, `direction`), predicting a probability
-    distribution over the possible choices for each.
+  - **Actor Heads**: Separate heads for each component of the action space
+    (tile, entity, direction, item/recipe, misc), predicting a probability
+    distribution over the possible choices for each. Invalid combinations are
+    masked (only assemblers carry a recipe, only underground belts use misc).
+  - **End-of-turn Head**: A binary head that decides the factory is finished;
+    firing it ends the episode.
   - **Critic Head**: A single value head outputs an estimate of the expected
     future reward from the current state, which is used during training.
 
 ## Current Status and Future Goals
 
 The project is progressing by gradually increasing the complexity of the tasks
-the agent must solve. Currently, the focus is on training the agent to solve a
-fundamental logistics problem: placing transport belts on increasingly-sized
-grids to create an unbroken path from a source to a sink. The agent is
-successfully able to place transport belts on 7x7 grids. The grid size will
-increase until we reach an 11x11 grid, which is the smallest required to fit a
-basic green-circuits factory:
+the agent must solve. Training now runs at 11x11 — the smallest grid that fits
+a basic green-circuits factory — and belt routing is largely solved: the agent
+scores 0.9–1.0 of reference throughput on the belt, splitter and underground
+lessons, and picks the right recipe for a named output most of the time.
+
+What is *not* solved is building a factory from nothing but a source and a
+sink marker, with no reference layout to imitate. That is what the `TRIAL_*`
+kinds measure, and only the shallowest (one crafting step) scores above zero.
+[#339](https://github.com/beyarkay/factorion/issues/339) measures why: a random
+policy stumbles into a working belt route about 1 episode in 107, and into a
+working assembler setup 0 times in 1,200 — belt routing is disjunctive (any
+connected path pays) while crafting is conjunctive (right recipe *and* both
+ingredient arms *and* correctly oriented inserters, with zero reward until
+every piece is simultaneously right).
+
+Here is the intermediate goal:
 
 #### **Green circuit factory in factorio**
 
@@ -225,17 +264,27 @@ graph for the green-circuits factory is given below:
 ## Running the Code
 
 ```bash
+# Install deps, then build the Rust extension into the venv
 uv sync
+uv run maturin develop --release --manifest-path factorion_rs/Cargo.toml
+
+# RL finetuning, starting from the current SFT base
 uv run python ppo.py \
     --seed 1 \
     --env-id factorion/FactorioEnv-v0 \
+    --start-from h76h80yb \
     --track \
     --wandb-project-name factorion \
     --total-timesteps 500000
 ```
 
+`--start-from` accepts a local `.pt` path or a W&B run id (the run's model
+artifact is downloaded automatically). Omit it to train from scratch, which is
+much weaker — see [#339](https://github.com/beyarkay/factorion/issues/339).
+
 Most runs that get to any level of ability take at least 1 hour on my M1
-macbook pro.
+macbook pro. GPU training runs on self-terminating RunPod pods, triggered by
+`/ci ...` comments on a pull request; see `ci/README.md`.
 
 ## Out of scope
 


### PR DESCRIPTION
Docs only — no code changes.

The quoted PPO bar was `val/thput ≈ 0.11` for SFT run `j0s5y2mc`, which is obsolete: it predates the self-attention architecture (#314), the lesson-set changes (#325, #335, #344, #349) and the metric rename (#328). Nothing in the repo points at that run any more — `ci/sweep_ppo.yaml` and `scripts/factory_builder.py` both use `h76h80yb`. [#339](https://github.com/beyarkay/factorion/issues/339) already flagged it as stale.

## Two traps that make the older W&B numbers unreadable

Both are now documented in CLAUDE.md, because without them the run history is easy to misread:

- **#328 swapped which key holds the metric.** Before `dc2f435`, `val/thput` meant "run to env-done, ignore the EOT head" and the EOT-respecting number lived in `val/thput_eot`. After it, `val/thput` *is* the EOT-respecting number. So `h76h80yb`'s comparable score is its logged `val/thput_eot` (0.954), not its logged `val/thput` (0.319). #350 then made the rollout actually stop at the fire, which by construction preserved the values.
- **Lesson generation moved underneath the metric.** #335 (recipe rebalance) and #349 (sample one belt route) both changed the data distribution. Every SFT run on record predates both, so no SFT run's own `val/thput` is comparable to today's.

Because of the second point the baseline quoted is `h76h80yb` **re-measured inside a PPO run** on main@`94ef25e` — `eval/thput ≈ 0.67` — rather than taken from its own SFT-time log.

## Headline results now recorded

From the 3-seeds-per-side compare on #346 (2026-07-30, 2.5M timesteps, ~2.5 h/seed). Neither side moved significantly, so both read as "what PPO currently gets to":

| metric | main@`94ef25e` | PR@`b8042d4` | p |
|---|---|---|---|
| `eval/thput` | 0.776 | 0.784 | 0.38 |
| `eval/trial_thput` | 0.037 | 0.041 | 0.42 |
| `rollout/thput` | 0.788 | 0.793 | 0.29 |

Also recorded:

- **`eval/trial_thput` is no longer zero** — CLAUDE.md said to expect 0 for a long time. It sits at 0.00–0.05 across seeds, entirely from `TRIAL_RECIPE_TREE_DEPTH_1` (≈0.11 on its own curve). Depths 2 and 3 are still exactly 0.
- **Long runs are not reliably better.** `gs1nqoni` (21.7 h, 40M steps) *degraded* 0.68 → 0.42; #339 traces why. Others improved (`i3vzy230` 0.50 → 0.76 over 44M).
- **Caveats on the top SFT scores.** `84glrv0x`/`w1ci81b7` (0.83/0.82) came from a sweep over `missing_fraction_alpha`, a blanking-difficulty knob no longer in `SftArgs` — their distribution is not reproducible today. The largest SFT run, `rqsl66jw` (40.3 h, killed at 150M of 250M samples, 0.75), uploaded **no model artifact**, so it cannot be a `--start-from` base.
- **No run on record was trained at the current main tip** — the newest sit at `94ef25e`/`b8042d4`, predating #350, #347, #351, #349, #354.

## Other out-of-date info removed

- CLAUDE.md listed `ASSEMBLE_1IN_1OUT`/`ASSEMBLE_2IN_1OUT` as lessons. They are `#[deprecated]` in the Rust enum and absent from `py_lesson_kinds()`, so nothing generates or trains on them.
- README's "Recent additions" stopped at 2026-05-13; refreshed through 2026-07-30.
- README described the simulator as Python awaiting a Rust rewrite (it is Rust), pointed at `generate_lesson()` in `factorion.py` (generators live in `factory_gen.rs`), listed `ALL_BELTS_ALREADY_IN_PLACE` (gone) while omitting every underground/assembler/trial kind, called the policy a plain CNN (self-attention since #314), described the reward as bare throughput (it is cost-penalised and log-compressed), and said the agent was working up from 7x7 toward 11x11 (11x11 is the default).
- README's setup snippet ran `uv sync` without building the Rust extension, so following it left `factorion_rs` missing.

## Verification

`uv run ruff check .`, `uv run ty check .`, and the full pytest suite (3248 passed, 708 skipped) all pass. Two PPO runs launched today (`oexpfebw`, `a7jkpakt`) were still in flight and are deliberately not quoted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BAJan4PGCy3qnqX4B3iorN)_