### PR TITLE
Drop the autoreset junk transition from the PPO update (#233)

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -415,6 +415,16 @@ def _critic_stats(values: np.ndarray, returns: np.ndarray, advantages: np.ndarra
     }
 
 
+def _masked_mean(x_B: torch.Tensor, valid_B: torch.Tensor) -> torch.Tensor:
+    """Mean of ``x_B`` over the entries ``valid_B`` marks 1, ignoring the rest.
+
+    The floor of 1 on the denominator keeps an all-masked minibatch at 0
+    instead of NaN — every term is zero-weighted there anyway, so it
+    contributes no gradient.
+    """
+    return (x_B * valid_B).sum() / valid_B.sum().clamp(min=1.0)
+
+
 def _critic_diagnostics(
     values: np.ndarray,
     returns: np.ndarray,
@@ -2300,6 +2310,15 @@ if __name__ == "__main__":
         advantages_B = advantages_SE.reshape(-1)
         returns_B = returns_SE.reshape(-1)
         values_B = values_SE.reshape(-1)
+        # Gymnasium's NEXT_STEP autoreset (#233): the call right after an
+        # episode ends ignores the action, resets the sub-env and forces
+        # reward=0. Its stored transition is therefore junk — the action was
+        # never executed and its "next state" is an unrelated fresh factory —
+        # and `dones_SE[step] = next_done` already flags exactly those steps.
+        # Zero-weight them everywhere the update reads the batch. GAE needs no
+        # such guard: the preceding real terminal step is already cut off by
+        # `nextnonterminal = 0`, so the junk is confined to the junk step.
+        valid_B = 1.0 - dones_SE.reshape(-1)
 
         # Optimizing the policy and value network
         update_start = time.time()
@@ -2326,23 +2345,29 @@ if __name__ == "__main__":
                 logratio_B = newlogprobs_B - logprobs_B[idxs].reshape(-1)
                 ratio_B = logratio_B.exp()
 
+                valid_mB = valid_B[idxs]  # autoreset junk weighs 0 (#233)
+
                 with torch.no_grad():
                     # calculate approx_kl http://joschu.net/blog/kl-approx.html
-                    approx_kl = ((ratio_B - 1) - logratio_B).mean()
+                    approx_kl = _masked_mean((ratio_B - 1) - logratio_B, valid_mB)
                     # Keep the per-minibatch clipfrac on-device and convert once
                     # after the loop (was `.item()` per minibatch = a CUDA sync
                     # that stalled the optimiser pipeline). Logging-only.
-                    clipfracs.append(((ratio_B - 1.0).abs() > args.clip_coef).float().mean())
+                    clipfracs.append(_masked_mean(
+                        ((ratio_B - 1.0).abs() > args.clip_coef).float(), valid_mB
+                    ))
 
                 assert not torch.isnan(advantages_B).any(), f"Some advantages are NaN: {advantages_B=}"
                 advantages_mB = advantages_B[idxs]
                 if args.norm_adv:
-                    advantages_mB = (advantages_mB - advantages_mB.mean()) / (advantages_mB.std() + 1e-8)
+                    adv_mean = _masked_mean(advantages_mB, valid_mB)
+                    adv_var = _masked_mean((advantages_mB - adv_mean) ** 2, valid_mB)
+                    advantages_mB = (advantages_mB - adv_mean) / (adv_var.sqrt() + 1e-8)
 
                 # Policy loss
                 pg_loss1 = -advantages_mB * ratio_B
                 pg_loss2 = -advantages_mB * torch.clamp(ratio_B, 1 - args.clip_coef, 1 + args.clip_coef)
-                pg_loss = torch.max(pg_loss1, pg_loss2).mean()
+                pg_loss = _masked_mean(torch.max(pg_loss1, pg_loss2), valid_mB)
 
                 # Value loss
                 newvalue = newvalue_B.view(-1)
@@ -2355,11 +2380,11 @@ if __name__ == "__main__":
                     )
                     v_loss_clipped = (v_clipped - returns_B[idxs]) ** 2
                     v_loss_max = torch.max(v_loss_unclipped, v_loss_clipped)
-                    v_loss = 0.5 * v_loss_max.mean()
+                    v_loss = 0.5 * _masked_mean(v_loss_max, valid_mB)
                 else:
-                    v_loss = 0.5 * ((newvalue - returns_B[idxs]) ** 2).mean()
+                    v_loss = 0.5 * _masked_mean((newvalue - returns_B[idxs]) ** 2, valid_mB)
 
-                entropy_loss = entropy_B.mean()
+                entropy_loss = _masked_mean(entropy_B, valid_mB)
                 assert not torch.isnan(pg_loss), "pg_loss is NaN, probably a bug"
                 assert not torch.isnan(v_loss), "v_loss is NaN, probably a bug"
                 if in_warmup:
@@ -2388,9 +2413,10 @@ if __name__ == "__main__":
             )
 
         # Value-head (critic) diagnostics, global + per-lesson.
+        keep_B = valid_B.cpu().numpy() > 0  # drop the autoreset junk (#233)
         critic_metrics = _critic_diagnostics(
-            values_B.cpu().numpy(), returns_B.cpu().numpy(),
-            advantages_B.cpu().numpy(), kinds_SE.reshape(-1),
+            values_B.cpu().numpy()[keep_B], returns_B.cpu().numpy()[keep_B],
+            advantages_B.cpu().numpy()[keep_B], kinds_SE.reshape(-1)[keep_B],
         )
         explained_var = critic_metrics["critic/explained_variance"]  # losses/* back-compat
 

--- a/tests/test_autoreset_masking.py
+++ b/tests/test_autoreset_masking.py
@@ -1,0 +1,117 @@
+"""The PPO update must not train on Gymnasium's NEXT_STEP autoreset step (#233).
+
+When a sub-env terminates at ``step()`` call N, call N+1 ignores the action,
+resets the env and returns ``reward=0, terminated=False``. The CleanRL-style
+rollout stores that call as an ordinary transition, so the batch carries one
+junk row per episode: an action the env never executed, paired with the
+previous episode's terminal observation.
+
+These tests pin (a) that the autoreset step really behaves that way for a
+vectorised ``FactorioEnv``, (b) that ``1 - dones`` — the flag the rollout
+already stores — marks exactly those rows, and (c) that ``_masked_mean``
+drops them from the loss reductions.
+"""
+
+import os
+import sys
+
+import gymnasium as gym
+import numpy as np
+import pytest
+import torch
+
+os.environ["WANDB_MODE"] = "disabled"
+os.environ["WANDB_DISABLED"] = "true"
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from ppo import FactorioEnv, _masked_mean  # noqa: E402
+
+NUM_ENVS = 2
+MAX_STEPS = 3
+
+
+def _eot_action(num_envs, eot):
+    """A batched no-op placement; ``eot`` declares end-of-turn per sub-env."""
+    return {
+        "xy": np.zeros((num_envs, 2), dtype=np.int64),
+        "entity": np.zeros(num_envs, dtype=np.int64),
+        "direction": np.zeros(num_envs, dtype=np.int64),
+        "item": np.zeros(num_envs, dtype=np.int64),
+        "misc": np.zeros(num_envs, dtype=np.int64),
+        "eot": np.asarray(eot, dtype=np.int64),
+    }
+
+
+def _make_vec_env():
+    return gym.vector.SyncVectorEnv([
+        lambda i=i: FactorioEnv(size=5, max_steps=MAX_STEPS, idx=i)
+        for i in range(NUM_ENVS)
+    ])
+
+
+def test_autoreset_step_ignores_the_action_and_pays_zero():
+    """The step after a termination is junk: action dropped, reward forced 0."""
+    envs = _make_vec_env()
+    envs.reset(seed=0)
+
+    # End both episodes via the eot action.
+    _, _, terminations, _, _ = envs.step(_eot_action(NUM_ENVS, [1, 1]))
+    assert terminations.all(), "eot should terminate every sub-env"
+
+    # Next call: place a belt somewhere. Autoreset must swallow it.
+    action = _eot_action(NUM_ENVS, [0, 0])
+    action["entity"][:] = 1  # a real, placeable entity
+    action["direction"][:] = 1
+    obs, reward, terminations, truncations, _ = envs.step(action)
+
+    assert np.all(reward == 0.0), f"autoreset step paid {reward}, expected 0"
+    assert not terminations.any() and not truncations.any()
+    # The action was never executed, so the fresh episode's world is untouched
+    # by it: every sub-env is back at step 0.
+    for env in envs.unwrapped.envs:
+        assert env.steps == 0
+
+
+def test_dones_flag_marks_exactly_the_junk_rows():
+    """`dones_SE[step] = next_done` (stored pre-step) flags the junk steps."""
+    envs = _make_vec_env()
+    next_obs, _ = envs.reset(seed=0)
+    next_done = np.zeros(NUM_ENVS, dtype=bool)
+
+    num_steps = 8
+    dones = np.zeros((num_steps, NUM_ENVS), dtype=bool)
+    rewards = np.zeros((num_steps, NUM_ENVS), dtype=np.float64)
+
+    rng = np.random.default_rng(0)
+    for step in range(num_steps):
+        dones[step] = next_done  # exactly what the PPO rollout stores
+        action = _eot_action(NUM_ENVS, rng.integers(0, 2, size=NUM_ENVS))
+        next_obs, reward, terminations, truncations, _ = envs.step(action)
+        rewards[step] = reward
+        next_done = np.logical_or(terminations, truncations)
+
+    assert dones.any(), "no episode ended; the test is not exercising autoreset"
+    # Every flagged row is a zero-reward junk row.
+    assert np.all(rewards[dones] == 0.0)
+
+
+def test_masked_mean_ignores_masked_rows():
+    x = torch.tensor([1.0, 100.0, 3.0])
+    valid = torch.tensor([1.0, 0.0, 1.0])
+    assert _masked_mean(x, valid).item() == pytest.approx(2.0)
+
+
+def test_masked_mean_of_all_masked_batch_is_zero_not_nan():
+    x = torch.tensor([1.0, 2.0])
+    valid = torch.zeros(2)
+    out = _masked_mean(x, valid)
+    assert torch.isfinite(out) and out.item() == pytest.approx(0.0)
+
+
+def test_masked_mean_gradient_does_not_reach_masked_rows():
+    """The junk row must contribute no gradient, not just no value."""
+    x = torch.tensor([1.0, 5.0], requires_grad=True)
+    _masked_mean(x, torch.tensor([1.0, 0.0])).backward()
+    assert x.grad is not None
+    assert x.grad[1].item() == pytest.approx(0.0)


### PR DESCRIPTION
Fixes #233. One commit, `ppo.py` + a new test file.

## The problem

Gymnasium's NEXT_STEP autoreset makes the `step()` call right after an episode ends ignore the action, reset the sub-env and force `reward=0`. The CleanRL-style rollout stored it like any other transition, so every episode contributed one row whose action was never executed and whose "next state" is an unrelated fresh factory. At the current mean episode length (~10.8) that's ~8-9% of every batch:

- the policy gradient reinforced or punished an action the env never ran, with an advantage that bootstraps **across the episode boundary** into a different factory;
- the value head was trained to predict `γ·V(next factory's blank state)` at terminal states, which look like ordinary mid-build states, so the error generalises;
- the junk advantages polluted per-minibatch advantage normalisation.

## The fix

`dones_SE[step] = next_done` is stored *before* the env step, so it already flags exactly those rows. They now carry zero weight in the policy, value and entropy losses, in the advantage normalisation, in the approx-KL/clipfrac diagnostics and in the `critic/*` report, via a new `_masked_mean` helper.

GAE is unchanged, as the issue notes: the preceding real terminal step is already cut off by `nextnonterminal = 0`, so the contamination was confined to the junk step itself.

## Tests

`tests/test_autoreset_masking.py`:

- the autoreset step really does drop the action and pay 0 (pinning the Gymnasium behaviour the fix depends on);
- the stored `dones` flag marks exactly the zero-reward junk rows;
- `_masked_mean` ignores masked rows, returns 0 rather than NaN for an all-masked minibatch, and propagates **no gradient** to a masked row.

Full checklist green: `cargo fmt`/`clippy`/`test` (166), `maturin develop --release`, pytest (3253 passed), `ruff`, `ty`, and both smoke tests.

## Not in this PR

The two compounding problems from the same report are left for follow-ups: the training rollout not legal-masking the tile head (#339 blocker 3) and CROSS_UNDER_BELT paying a free 0.25 at step 0 (#339 blocker 1, both the deletable-protected-tile landmine and the reward baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASW26Mqyqpq2hFEX4Pkh2y