### PR TITLE
Make the assembler honour crafting_time and crafting speed

### DIFF
--- a/factorion-mod/CLAUDE.md
+++ b/factorion-mod/CLAUDE.md
@@ -52,11 +52,18 @@ against the engine's prediction. Full sequence, from nothing to a report:
    Y/s (err Z%)`; the run ends with a ranked list of every sink with >0
    error and a pass/fail count (non-zero exit if any factory mismatches
    beyond `--rel-tol`/`--abs-tol`). Known-expected divergences (so a real
-   regression stands out): assembler crafting-time over-count, long-handed
-   inserter (0.86 vs ~1.23), the flat-inserter ~8% under, uncraftable
-   smelting recipes → 0, and impossible >15/s rates from degenerate
-   sink-loop factories. Transport (belts/splitters/undergrounds) should be
-   exact.
+   regression stands out): long-handed inserter (0.86 vs ~1.23), the
+   flat-inserter ~8% under, uncraftable smelting recipes → 0, and
+   impossible >15/s rates from degenerate sink-loop factories. Transport
+   (belts/splitters/undergrounds) should be exact.
+
+   The assembler crafting-time over-count is **fixed** (#355) — an
+   assembler now runs at `crafting_speed / crafting_time` crafts per
+   second, so a machine-speed-limited factory should agree with the game
+   too. The `assembler_input_limited` / `assembler_machine_speed_limited`
+   fixtures cover both branches; a divergence there is a real regression.
+   Slow recipes need many game-seconds to resolve a fractional items/s
+   rate — crank `--game-speed`.
 
 6. **After editing the mod Lua**, re-host to reload it (see *Reloading the
    mod after editing*) before the next run.

--- a/factorion.py
+++ b/factorion.py
@@ -130,7 +130,11 @@ class Item:
     is_placeable: bool
     width: int
     height: int
-    flow: float
+    flow: float  # items/second one tile can transfer
+    # Dimensionless recipe multiplier; None unless this is a crafting
+    # machine. A recipe's items/s in this machine is
+    # `produces[item] * crafting_speed / crafting_time`.
+    crafting_speed: Optional[float] = None
 
 
 # Items are defined in Rust (factorion_rs/src/types.rs::all_items)

--- a/factorion_rs/__init__.pyi
+++ b/factorion_rs/__init__.pyi
@@ -13,6 +13,7 @@ class ItemProps(TypedDict):
     width: int
     height: int
     flow: float
+    crafting_speed: float | None
 
 class RecipeData(TypedDict):
     consumes: dict[str, float]

--- a/factorion_rs/src/entities.rs
+++ b/factorion_rs/src/entities.rs
@@ -195,10 +195,12 @@ pub trait FactoryEntity {
     /// Return the edges this entity contributes to the graph.
     fn connections(&self, pos: (usize, usize), dir: Direction, world: &World) -> Vec<Edge>;
 
-    /// Given accumulated input flow rates, compute output flow rates.
+    /// Given accumulated input flow rates, compute output flow rates. Both
+    /// maps are in **items per second** — never per-craft quantities, which
+    /// is the unit a `Recipe` speaks (see [`crate::types::Recipe`]).
     fn transform_flow(&self, input: &HashMap<Item, f64>) -> HashMap<Item, f64>;
 
-    /// Maximum items/second this entity can transfer.
+    /// Maximum **items per second** this entity can transfer.
     /// Default delegates to Item::flow_rate().
     fn flow_rate(&self) -> f64 {
         self.kind().flow_rate()
@@ -434,19 +436,33 @@ impl FactoryEntity for AssemblingMachine {
             None => return HashMap::new(),
         };
 
-        // Find the minimum ratio of available input to required input
-        let mut min_ratio: f64 = 1.0;
-        for &(item, required) in recipe.consumes.iter() {
-            let available = input.get(&item).copied().unwrap_or(0.0);
-            let ratio = available / required;
-            min_ratio = min_ratio.min(ratio);
-        }
+        // The machine's ceiling in **crafts per second**. `crafting_time` is
+        // seconds per craft, so the rate is its reciprocal, scaled up by the
+        // entity's unitless multiplier — a faster machine does more crafts a
+        // second, a longer recipe fewer. Read off `self.kind()` so any future
+        // crafting entity (a smelter tier) is limited by the same code.
+        // Without this term crafting time has no effect on throughput and an
+        // artillery turret is as fast as an electronic circuit (#355).
+        let machine_limit = match self.kind().crafting_speed() {
+            Some(mult) if recipe.crafting_time > 0.0 => mult / recipe.crafting_time,
+            _ => return HashMap::new(),
+        };
 
-        // Produce outputs scaled by the minimum ratio
+        // Ingredient supply, also in crafts per second: each ingredient's
+        // items/s over the quantity one craft wants of it. The scarcest
+        // ingredient sets the pace, and the machine caps it.
+        let craft_rate = recipe
+            .consumes
+            .iter()
+            .map(|&(item, qty)| input.get(&item).copied().unwrap_or(0.0) / qty)
+            .fold(machine_limit, f64::min);
+
+        // Back to items per second: a recipe that yields several of an item
+        // per craft yields them that many times faster.
         recipe
             .produces
             .iter()
-            .map(|&(item, rate)| (item, rate * min_ratio))
+            .map(|&(item, qty)| (item, qty * craft_rate))
             .collect()
     }
 }
@@ -1316,20 +1332,41 @@ mod tests {
             recipe_item: Some(Item::ElectronicCircuit),
         };
 
-        // Full input matches recipe exactly: 3 copper cable + 1 iron plate → 1 EC
+        // Input feeds exactly one craft per second; the AM1 ceiling for a
+        // 0.5s recipe is also 1 craft/s, so both branches agree at 1 EC/s.
         let input = HashMap::from([(Item::CopperCable, 3.0), (Item::IronPlate, 1.0)]);
         let output = asm.transform_flow(&input);
         assert!((output[&Item::ElectronicCircuit] - 1.0).abs() < 1e-9);
 
-        // Half copper cable available: ratio = min(1.5/3, 1/1) = 0.5 → 0.5 EC
+        // Input-limited: min(1.5/3, 1/1) = 0.5 crafts/s → 0.5 EC/s
         let input = HashMap::from([(Item::CopperCable, 1.5), (Item::IronPlate, 1.0)]);
         let output = asm.transform_flow(&input);
         assert!((output[&Item::ElectronicCircuit] - 0.5).abs() < 1e-9);
+
+        // Machine-limited: drowning it in ingredients does not beat the
+        // 0.5 crafting_speed / 0.5s crafting_time ceiling of 1 craft/s.
+        let input = HashMap::from([(Item::CopperCable, 300.0), (Item::IronPlate, 100.0)]);
+        let output = asm.transform_flow(&input);
+        assert!((output[&Item::ElectronicCircuit] - 1.0).abs() < 1e-9);
 
         // Missing ingredient → 0 output
         let input = HashMap::from([(Item::CopperCable, 3.0)]);
         let output = asm.transform_flow(&input);
         assert!((output[&Item::ElectronicCircuit] - 0.0).abs() < 1e-9);
+
+        // A slow recipe is slow: artillery turret is 40s, so one AM1 tops
+        // out at 0.5/40 = 0.0125/s no matter how much arrives.
+        let slow = AssemblingMachine {
+            recipe_item: Some(Item::ArtilleryTurret),
+        };
+        let input = HashMap::from([
+            (Item::AdvancedCircuit, 100.0),
+            (Item::Concrete, 100.0),
+            (Item::IronGearWheel, 100.0),
+            (Item::SteelPlate, 100.0),
+        ]);
+        let output = slow.transform_flow(&input);
+        assert!((output[&Item::ArtilleryTurret] - 0.0125).abs() < 1e-9);
     }
 
     #[test]

--- a/factorion_rs/src/entities.rs
+++ b/factorion_rs/src/entities.rs
@@ -443,10 +443,10 @@ impl FactoryEntity for AssemblingMachine {
         // crafting entity (a smelter tier) is limited by the same code.
         // Without this term crafting time has no effect on throughput and an
         // artillery turret is as fast as an electronic circuit (#355).
-        let machine_limit = match self.kind().crafting_speed() {
-            Some(mult) if recipe.crafting_time > 0.0 => mult / recipe.crafting_time,
-            _ => return HashMap::new(),
+        let Some(mult) = self.kind().crafting_speed() else {
+            return HashMap::new();
         };
+        let machine_limit = mult / recipe.crafting_time;
 
         // Ingredient supply, also in crafts per second: each ingredient's
         // items/s over the quantity one craft wants of it. The scarcest

--- a/factorion_rs/src/factory_gen.rs
+++ b/factorion_rs/src/factory_gen.rs
@@ -3155,6 +3155,19 @@ fn walk_recipe_frontier(
     }
 }
 
+/// The crafting machine a trial's analytic ceiling assumes. A trial places no
+/// machine — the agent invents the factory — so the ceiling has to name one,
+/// and it must be the machine the agent can actually build with. When a second
+/// placeable crafting entity lands (a smelter tier), this becomes a choice
+/// rather than the only option.
+const CEILING_MACHINE: Item = Item::AssemblingMachine1;
+
+/// Items/second of `item` from one fully-fed [`CEILING_MACHINE`]: the
+/// recipe's own production rate scaled by the machine's multiplier.
+fn ceiling_thput(recipe: &Recipe, item: Item) -> Option<f64> {
+    Some(recipe.production_rate(item)? * CEILING_MACHINE.crafting_speed()?)
+}
+
 /// Build a TRIAL_RECIPE_TREE_DEPTH_`depth` trial: an RL-only scenario with no
 /// reference solution (see [`LessonKind::is_trial`]). A random craftable
 /// item whose recipe tree is at least `depth` deep becomes the sink; its
@@ -3171,10 +3184,9 @@ fn walk_recipe_frontier(
 /// marker may take it, so the agent always has somewhere to build against
 /// every marker.
 ///
-/// `max_throughput` is analytic: one fully-fed assembler's output rate of the
-/// sink recipe (`produces_rate`). `transform_flow` scales `produces` by input
-/// sufficiency and never beyond 1×, so this is the engine's single-machine
-/// ceiling — a clean chain that saturates one final assembler scores 1.0.
+/// `max_throughput` is analytic, in **items per second**: [`ceiling_thput`]
+/// of the sink recipe. `transform_flow` caps a crafting entity at exactly
+/// that, so a clean chain that saturates one final machine scores 1.0.
 fn build_recipe_tree_trial(size: usize, rng: &mut Rng, depth: usize) -> Option<BuiltFactory> {
     let s = size as i64;
     // Every recipe is expandable regardless of assembler tier: the engine's
@@ -3203,7 +3215,7 @@ fn build_recipe_tree_trial(size: usize, rng: &mut Rng, depth: usize) -> Option<B
 
         let sink_item = sinks[rng.choice_index(sinks.len())];
         let recipe = index.get(&sink_item)?;
-        let max_throughput = recipe.produces_rate(sink_item).filter(|&r| r > 0.0)?;
+        let max_throughput = ceiling_thput(recipe, sink_item).filter(|&r| r > 0.0)?;
 
         let mut frontier: Vec<Item> = Vec::new();
         let mut deepest = 0;
@@ -3696,7 +3708,7 @@ mod tests {
                     .unwrap_or_else(|| panic!("{kind:?} seed={seed}: sink has no recipe"));
                 assert_eq!(
                     f.max_throughput,
-                    recipe.produces_rate(sink_item).unwrap(),
+                    ceiling_thput(recipe, sink_item).unwrap(),
                     "{kind:?} seed={seed}"
                 );
 

--- a/factorion_rs/src/lib.rs
+++ b/factorion_rs/src/lib.rs
@@ -173,7 +173,11 @@ fn py_entity_tiles(
 /// per-item properties.
 ///
 /// Shape: `{int_value: {"name": str, "is_placeable": bool,
-///                      "width": int, "height": int, "flow": float}}`.
+///                      "width": int, "height": int, "flow": float,
+///                      "crafting_speed": float | None}}`.
+///
+/// `flow` is items/second; `crafting_speed` is the dimensionless recipe
+/// multiplier and is `None` for everything that is not a crafting machine.
 ///
 /// Single source of truth for item identity and entity properties —
 /// Python's `items` dict (and the older `entities` dict) are built from
@@ -190,6 +194,7 @@ fn py_items(py: Python<'_>) -> PyResult<Py<PyDict>> {
         entry.set_item("width", w)?;
         entry.set_item("height", h)?;
         entry.set_item("flow", item.flow_rate())?;
+        entry.set_item("crafting_speed", item.crafting_speed())?;
         outer.set_item(item as i64, entry)?;
     }
     Ok(outer.into())
@@ -197,8 +202,8 @@ fn py_items(py: Python<'_>) -> PyResult<Py<PyDict>> {
 
 /// Return all crafting recipes as a Python dict.
 ///
-/// Shape: `{item_name: {"consumes": {item_name: rate, ...},
-///                      "produces": {item_name: rate, ...},
+/// Shape: `{item_name: {"consumes": {item_name: qty_per_craft, ...},
+///                      "produces": {item_name: qty_per_craft, ...},
 ///                      "crafting_time": seconds_per_craft,
 ///                      "produced_by": [machine_name, ...],
 ///                      "total_raw": {item_name: amount, ...},
@@ -220,12 +225,14 @@ fn py_recipes(py: Python<'_>) -> PyResult<Py<PyDict>> {
     for (item, recipe) in &recipes {
         let entry = PyDict::new(py);
         let consumes = PyDict::new(py);
-        for &(i, rate) in recipe.consumes.iter() {
-            consumes.set_item(i.name(), rate)?;
+        // Quantities per craft, not rates — Python divides by crafting_time
+        // itself where it wants items/second.
+        for &(i, qty) in recipe.consumes.iter() {
+            consumes.set_item(i.name(), qty)?;
         }
         let produces = PyDict::new(py);
-        for &(i, rate) in recipe.produces.iter() {
-            produces.set_item(i.name(), rate)?;
+        for &(i, qty) in recipe.produces.iter() {
+            produces.set_item(i.name(), qty)?;
         }
         let total = recipe.total_raw(&index);
         let total_raw = PyDict::new(py);

--- a/factorion_rs/src/types.rs
+++ b/factorion_rs/src/types.rs
@@ -54,7 +54,6 @@ impl Direction {
     }
 
     /// The opposite direction.
-    #[allow(dead_code)]
     pub fn opposite(self) -> Self {
         match self {
             Direction::North => Direction::South,
@@ -503,16 +502,20 @@ impl Item {
         )
     }
 
-    /// Maximum items/second one TILE of this item can transfer when placed
-    /// as an entity (lane-aware entities cap each lane node at half this).
-    /// Returns 0.0 for non-placeable items.
-    #[allow(dead_code)]
+    /// Maximum **items per second** one TILE of this item can transfer when
+    /// placed as an entity (lane-aware entities cap each lane node at half
+    /// this). Returns 0.0 for non-placeable items.
     pub fn flow_rate(self) -> f64 {
         match self {
             Item::TransportBelt => 15.0,
             Item::Inserter => 0.86,
             Item::LongHandedInserter => 1.2,
-            Item::AssemblingMachine1 => 0.5,
+            // An assembler imposes no items/s cap of its own — like Source
+            // and Sink, its limit is set by `transform_flow`, where the
+            // recipe's crafting time and the machine's `crafting_speed`
+            // decide the rate. A finite number here would be a crafting
+            // speed wearing an items/s label.
+            Item::AssemblingMachine1 => f64::INFINITY,
             Item::UndergroundBelt => 15.0,
             Item::Sink => f64::INFINITY,
             Item::Source => f64::INFINITY,
@@ -603,6 +606,25 @@ impl Item {
         }
     }
 
+    /// This item's crafting speed when placed as a crafting machine — the
+    /// **unitless** multiplier on a recipe's own rate. A recipe carries a
+    /// speed in items/second ([`Recipe::production_rate`]); the machine
+    /// scales it, so foobar at 1/s comes out of an Assembling Machine 1 at
+    /// 0.5/s and out of an Assembling Machine 3 at 1.25/s. Base-game
+    /// normal-quality values (Factorio 1.0 and 2.0 agree).
+    ///
+    /// `None` means "does not craft" — it is not an assembler-only notion.
+    /// Smelting tiers carry a crafting speed the same way and belong here as
+    /// extra arms, not as a parallel mechanism.
+    pub fn crafting_speed(self) -> Option<f64> {
+        match self {
+            Item::AssemblingMachine1 => Some(0.5),
+            Item::AssemblingMachine2 => Some(0.75),
+            Item::AssemblingMachine3 => Some(1.25),
+            _ => None,
+        }
+    }
+
     /// Footprint (width, height) for placeable items.
     /// Width = perpendicular to flow, height = along flow.
     /// Non-placeable items return (1, 1).
@@ -649,10 +671,17 @@ impl Pos {
 /// empty recipe (no inputs or no outputs) is unrepresentable at compile
 /// time — there is no need for runtime checks of these invariants.
 ///
-/// `crafting_time` is the canonical wiki value (Base game) in **seconds
-/// per craft**, before any crafting-speed multiplier from the producing
-/// entity. For an Assembling Machine 1 (crafting_speed = 0.5), the
-/// real-time-per-craft is `crafting_time / crafting_speed`.
+/// **Units.** `consumes` and `produces` hold the canonical wiki quantities
+/// in **items per craft** — counts, not rates, and nothing may treat them as
+/// one (that confusion was #355). `crafting_time` is the canonical wiki value
+/// (Base game) in **seconds per craft**.
+///
+/// For a rate, use [`Recipe::consumption_rate`] / [`Recipe::production_rate`],
+/// which divide by `crafting_time` to give **items per second** at crafting
+/// speed 1.0; scale by the crafting entity's unitless
+/// [`Item::crafting_speed`] for its rate in a machine. Read the fields
+/// directly only when you genuinely want a per-craft count, as `total_raw`
+/// does.
 #[derive(Debug, Clone)]
 pub struct Recipe {
     pub consumes: NonEmpty<(Item, f64)>,
@@ -678,22 +707,31 @@ pub struct TotalRaw {
 }
 
 impl Recipe {
-    /// Look up the consumption rate for `item`, if present.
+    /// The recipe's own speed for an ingredient, in **items per second** —
+    /// the quantity one craft wants over the time one craft takes. `None` if
+    /// `item` is not an ingredient.
+    ///
+    /// This is the rate at crafting speed 1.0. Multiply by the crafting
+    /// entity's unitless [`Item::crafting_speed`] for the rate in a machine.
+    // Only the tests read this today. `expect` would be the self-cleaning
+    // choice, but the expectation is fulfilled in the lib build and
+    // unfulfilled in the test build, so it cannot hold for both configs.
     #[allow(dead_code)]
-    pub fn consumes_rate(&self, item: Item) -> Option<f64> {
-        self.consumes
-            .iter()
-            .find(|(i, _)| *i == item)
-            .map(|(_, r)| *r)
+    pub fn consumption_rate(&self, item: Item) -> Option<f64> {
+        let (_, qty) = self.consumes.iter().find(|(i, _)| *i == item)?;
+        (self.crafting_time > 0.0).then(|| qty / self.crafting_time)
     }
 
-    /// Look up the production rate for `item`, if present.
-    #[allow(dead_code)]
-    pub fn produces_rate(&self, item: Item) -> Option<f64> {
-        self.produces
-            .iter()
-            .find(|(i, _)| *i == item)
-            .map(|(_, r)| *r)
+    /// The recipe's own speed for an output, in **items per second**. A
+    /// recipe that yields several per craft is faster by exactly that
+    /// factor — copper cable is 2 per 0.5s, so 4/s. `None` if `item` is not
+    /// an output.
+    ///
+    /// This is the rate at crafting speed 1.0. Multiply by the crafting
+    /// entity's unitless [`Item::crafting_speed`] for the rate in a machine.
+    pub fn production_rate(&self, item: Item) -> Option<f64> {
+        let (_, qty) = self.produces.iter().find(|(i, _)| *i == item)?;
+        (self.crafting_time > 0.0).then(|| qty / self.crafting_time)
     }
 
     /// The total raw cost of one craft of this recipe, expanded through
@@ -737,10 +775,11 @@ fn raw_expand(item: Item, qty: f64, index: &HashMap<Item, Recipe>) -> (NonEmpty<
     let Some(recipe) = index.get(&item) else {
         return (NonEmpty::new((item, qty)), 0.0);
     };
-    // How many crafts yield `qty` of `item` (all recipes list positive
-    // output rates, so the filter only guards against malformed data).
-    let crafts = match recipe.produces_rate(item).filter(|p| *p > 0.0) {
-        Some(per_craft) => qty / per_craft,
+    // How many crafts yield `qty` of `item`. This is a count, not a rate, so
+    // it reads the per-craft quantity off `produces` directly (all recipes
+    // list positive outputs, so the `> 0.0` only guards malformed data).
+    let crafts = match recipe.produces.iter().find(|&&(i, q)| i == item && q > 0.0) {
+        Some(&(_, per_craft)) => qty / per_craft,
         None => qty,
     };
     let mut time = crafts * recipe.crafting_time;
@@ -1906,40 +1945,109 @@ mod tests {
         );
     }
 
+    /// Rates here are items/second at crafting speed 1.0, so each is the
+    /// wiki quantity over the recipe's crafting time — every recipe below is
+    /// 0.5s, hence exactly double its per-craft count.
     #[test]
     fn test_recipes() {
         let ec = get_recipe(Item::ElectronicCircuit).unwrap();
-        assert_eq!(ec.consumes_rate(Item::CopperCable), Some(3.0));
-        assert_eq!(ec.consumes_rate(Item::IronPlate), Some(1.0));
-        assert_eq!(ec.produces_rate(Item::ElectronicCircuit), Some(1.0));
+        assert_eq!(ec.consumption_rate(Item::CopperCable), Some(6.0));
+        assert_eq!(ec.consumption_rate(Item::IronPlate), Some(2.0));
+        assert_eq!(ec.production_rate(Item::ElectronicCircuit), Some(2.0));
 
         let cc = get_recipe(Item::CopperCable).unwrap();
-        assert_eq!(cc.consumes_rate(Item::CopperPlate), Some(1.0));
-        assert_eq!(cc.produces_rate(Item::CopperCable), Some(2.0));
+        assert_eq!(cc.consumption_rate(Item::CopperPlate), Some(2.0));
+        assert_eq!(cc.production_rate(Item::CopperCable), Some(4.0));
 
         let igw = get_recipe(Item::IronGearWheel).unwrap();
-        assert_eq!(igw.consumes_rate(Item::IronPlate), Some(2.0));
-        assert_eq!(igw.produces_rate(Item::IronGearWheel), Some(1.0));
+        assert_eq!(igw.consumption_rate(Item::IronPlate), Some(4.0));
+        assert_eq!(igw.production_rate(Item::IronGearWheel), Some(2.0));
 
         let tb = get_recipe(Item::TransportBelt).unwrap();
-        assert_eq!(tb.consumes_rate(Item::IronGearWheel), Some(1.0));
-        assert_eq!(tb.consumes_rate(Item::IronPlate), Some(1.0));
-        assert_eq!(tb.produces_rate(Item::TransportBelt), Some(2.0));
+        assert_eq!(tb.consumption_rate(Item::IronGearWheel), Some(2.0));
+        assert_eq!(tb.consumption_rate(Item::IronPlate), Some(2.0));
+        assert_eq!(tb.production_rate(Item::TransportBelt), Some(4.0));
 
         let ins = get_recipe(Item::Inserter).unwrap();
-        assert_eq!(ins.consumes_rate(Item::ElectronicCircuit), Some(1.0));
-        assert_eq!(ins.consumes_rate(Item::IronGearWheel), Some(1.0));
-        assert_eq!(ins.consumes_rate(Item::IronPlate), Some(1.0));
-        assert_eq!(ins.produces_rate(Item::Inserter), Some(1.0));
+        assert_eq!(ins.consumption_rate(Item::ElectronicCircuit), Some(2.0));
+        assert_eq!(ins.consumption_rate(Item::IronGearWheel), Some(2.0));
+        assert_eq!(ins.consumption_rate(Item::IronPlate), Some(2.0));
+        assert_eq!(ins.production_rate(Item::Inserter), Some(2.0));
 
         let am1 = get_recipe(Item::AssemblingMachine1).unwrap();
-        assert_eq!(am1.consumes_rate(Item::ElectronicCircuit), Some(3.0));
-        assert_eq!(am1.consumes_rate(Item::IronGearWheel), Some(5.0));
-        assert_eq!(am1.consumes_rate(Item::IronPlate), Some(9.0));
-        assert_eq!(am1.produces_rate(Item::AssemblingMachine1), Some(1.0));
+        assert_eq!(am1.consumption_rate(Item::ElectronicCircuit), Some(6.0));
+        assert_eq!(am1.consumption_rate(Item::IronGearWheel), Some(10.0));
+        assert_eq!(am1.consumption_rate(Item::IronPlate), Some(18.0));
+        assert_eq!(am1.production_rate(Item::AssemblingMachine1), Some(2.0));
 
         assert!(get_recipe(Item::IronPlate).is_none());
         assert!(get_recipe(Item::CopperPlate).is_none());
+    }
+
+    /// Single-assembler output rates checked against Factorio 1.0 (the
+    /// values are unchanged in 2.0). Real time per craft is
+    /// `crafting_time / crafting_speed`, so an Assembling Machine 1
+    /// (speed 0.5) is exactly half as fast as the wiki's speed-1.0
+    /// reference — the column the recipe pages quote.
+    #[test]
+    fn test_production_rate_matches_factorio() {
+        // (recipe, items/craft, seconds/craft, items/s at crafting speed 1.0)
+        let cases = [
+            (Item::ElectronicCircuit, 1.0, 0.5, 2.0),
+            (Item::CopperCable, 2.0, 0.5, 4.0),
+            (Item::IronGearWheel, 1.0, 0.5, 2.0),
+            // The very slow end of the range: 40s per craft.
+            (Item::ArtilleryTurret, 1.0, 40.0, 0.025),
+        ];
+        for (item, per_craft, seconds, at_speed_1) in cases {
+            let recipe = get_recipe(item).unwrap();
+            assert_eq!(recipe.crafting_time, seconds, "{item:?}");
+            // The per-craft quantity is folded in, so copper cable's 2-per-
+            // craft makes it twice the rate of a 1-per-craft 0.5s recipe.
+            let (_, qty) = recipe.produces.iter().find(|(i, _)| *i == item).unwrap();
+            assert_eq!(*qty, per_craft, "{item:?}");
+
+            let rate = recipe.production_rate(item).unwrap();
+            assert!((rate - at_speed_1).abs() < 1e-12, "{item:?}: {rate}");
+
+            // A machine only multiplies that rate by a unitless number.
+            for machine in [
+                Item::AssemblingMachine1,
+                Item::AssemblingMachine2,
+                Item::AssemblingMachine3,
+            ] {
+                let mult = machine.crafting_speed().unwrap();
+                let got = rate * mult;
+                assert!(
+                    (got - at_speed_1 * mult).abs() < 1e-12,
+                    "{item:?} in {machine:?}: {got}"
+                );
+            }
+        }
+
+        // The spread the engine used to collapse: 0.0125 .. 20 items/s in an
+        // AM1, a 1600x range the bare per-craft quantity (1 vs 1) reported as
+        // identical.
+        let ec = get_recipe(Item::ElectronicCircuit)
+            .unwrap()
+            .production_rate(Item::ElectronicCircuit)
+            .unwrap();
+        let turret = get_recipe(Item::ArtilleryTurret)
+            .unwrap()
+            .production_rate(Item::ArtilleryTurret)
+            .unwrap();
+        assert!((ec / turret - 80.0).abs() < 1e-9);
+
+        // A crafting speed is a property of whatever entity crafts, not of
+        // assemblers specifically - everything that doesn't craft says so,
+        // and a future smelter tier answers here without new plumbing.
+        assert_eq!(Item::TransportBelt.crafting_speed(), None);
+        assert_eq!(Item::IronPlate.crafting_speed(), None);
+
+        // A rate needs the item to be on that side of the recipe.
+        let gears = get_recipe(Item::IronGearWheel).unwrap();
+        assert_eq!(gears.production_rate(Item::CopperCable), None);
+        assert_eq!(gears.consumption_rate(Item::IronPlate), Some(4.0));
     }
 
     #[test]
@@ -1985,8 +2093,9 @@ mod tests {
         for (item, recipe) in all_recipes() {
             assert!(
                 recipe
-                    .produces_rate(item)
-                    .is_some_and(|amount| amount > 0.0),
+                    .produces
+                    .iter()
+                    .any(|&(i, qty)| i == item && qty > 0.0),
                 "{item:?} recipe key must be one of its positive outputs"
             );
         }

--- a/factorion_rs/src/types.rs
+++ b/factorion_rs/src/types.rs
@@ -719,7 +719,7 @@ impl Recipe {
     #[allow(dead_code)]
     pub fn consumption_rate(&self, item: Item) -> Option<f64> {
         let (_, qty) = self.consumes.iter().find(|(i, _)| *i == item)?;
-        (self.crafting_time > 0.0).then(|| qty / self.crafting_time)
+        Some(qty / self.crafting_time)
     }
 
     /// The recipe's own speed for an output, in **items per second**. A
@@ -731,7 +731,7 @@ impl Recipe {
     /// entity's unitless [`Item::crafting_speed`] for the rate in a machine.
     pub fn production_rate(&self, item: Item) -> Option<f64> {
         let (_, qty) = self.produces.iter().find(|(i, _)| *i == item)?;
-        (self.crafting_time > 0.0).then(|| qty / self.crafting_time)
+        Some(qty / self.crafting_time)
     }
 
     /// The total raw cost of one craft of this recipe, expanded through
@@ -2098,6 +2098,29 @@ mod tests {
                     .any(|&(i, qty)| i == item && qty > 0.0),
                 "{item:?} recipe key must be one of its positive outputs"
             );
+        }
+    }
+
+    /// The rate math divides by two things, both unguarded: `crafting_time`
+    /// and each ingredient's per-craft quantity. A zero divisor does not
+    /// fail loudly — it yields `inf` or `NaN`, and `f64::min` drops both, so
+    /// the constraint silently disappears and the assembler crafts at full
+    /// ceiling out of nothing. Runtime cannot produce one, so this guards the
+    /// next hand-edit of the recipe table instead.
+    #[test]
+    fn test_every_recipe_divisor_is_positive() {
+        for (item, recipe) in all_recipes() {
+            assert!(
+                recipe.crafting_time > 0.0,
+                "{item:?} has crafting_time {}; rates divide by it",
+                recipe.crafting_time
+            );
+            for &(ingredient, qty) in recipe.consumes.iter() {
+                assert!(
+                    qty > 0.0,
+                    "{item:?} consumes {qty} {ingredient:?}; supply divides by it"
+                );
+            }
         }
     }
 

--- a/factorion_rs/src/world.rs
+++ b/factorion_rs/src/world.rs
@@ -39,7 +39,6 @@ impl World {
 
     /// Create an empty world of given dimensions with default channel values.
     /// FOOTPRINT is initialized to 1 (available); all other channels are 0.
-    #[allow(dead_code)]
     pub fn empty(width: usize, height: usize) -> Self {
         let channels = NUM_CHANNELS;
         let mut data = vec![0; width * height * channels];
@@ -103,7 +102,6 @@ impl World {
     }
 
     /// Set a raw value at (x, y, channel).
-    #[allow(dead_code)]
     pub fn set(&mut self, x: usize, y: usize, channel: Channel, value: i64) {
         let idx = self.index(x, y, channel.index());
         self.data[idx] = value;
@@ -111,7 +109,6 @@ impl World {
 
     /// Place an entity at (x, y) with the given direction and item.
     /// `item = None` writes 0 to the items channel (no item set).
-    #[allow(dead_code)]
     pub fn place(&mut self, x: usize, y: usize, entity: Item, dir: Direction, item: Option<Item>) {
         self.set(x, y, Channel::Entities, entity as i64);
         self.set(x, y, Channel::Direction, dir as i64);
@@ -119,7 +116,6 @@ impl World {
     }
 
     /// Place an underground belt at (x, y) with the given direction and misc state.
-    #[allow(dead_code)]
     pub fn place_underground(&mut self, x: usize, y: usize, dir: Direction, misc: Misc) {
         self.set(x, y, Channel::Entities, Item::UndergroundBelt as i64);
         self.set(x, y, Channel::Direction, dir as i64);

--- a/factorion_rs/tests/factories/assembler_input_limited.yaml
+++ b/factorion_rs/tests/factories/assembler_input_limited.yaml
@@ -1,0 +1,32 @@
+description: |
+  An assembler whose INPUT supply is the binding constraint (#355). It
+  crafts electronic_circuit (3 copper cable + 1 iron plate -> 1, 0.5s),
+  fed by one inserter per ingredient:
+
+      source(copper cable) -> inserter -\
+                                          assembler -> inserter -> sink
+      source(iron plate)   -> inserter -/
+
+  Each inserter delivers 0.86 i/s, so the ingredient supply supports
+  min(0.86 / 3, 0.86 / 1) = 0.2866... crafts/s. An Assembling Machine 1
+  runs a 0.5s recipe at 0.5 / 0.5 = 1 craft/s, so the machine is nowhere
+  near its ceiling and the copper cable sets the pace: 0.2866... EC/s,
+  which the 0.86 i/s output inserter passes through untouched.
+items:
+- { x: 0, y: 0, item: copper_cable }          # source: the scarce ingredient
+- { x: 0, y: 2, item: iron_plate }            # source: the plentiful one
+- { x: 2, y: 0, item: electronic_circuit }    # assembler recipe (anchor = top-left)
+- { x: 6, y: 1, item: electronic_circuit }    # sink counts circuits
+throughput:
+- { item: electronic_circuit, per_second: 0.2866666666666667 }
+graph: |
+  S@0,0 -> i@1,0
+  i@1,0 -> a@2,0
+  S@0,2 -> i@1,2
+  i@1,2 -> a@2,0
+  a@2,0 -> i@5,1
+  i@5,1 -> K@6,1
+factory: |
+  S> i> aaaaaaaa .. ..
+  .. .. aa    aa i> K>
+  S> i> aaaaaaaa .. ..

--- a/factorion_rs/tests/factories/assembler_machine_speed_limited.yaml
+++ b/factorion_rs/tests/factories/assembler_machine_speed_limited.yaml
@@ -1,0 +1,28 @@
+description: |
+  An assembler whose own CRAFTING SPEED is the binding constraint (#355) —
+  the case the engine used to miss entirely. It crafts barrel (1 steel
+  plate -> 1 barrel, 1.0s):
+
+      source -> inserter -> assembler -> inserter -> sink
+
+  The input inserter delivers 0.86 steel plates/s, enough for 0.86
+  crafts/s, but an Assembling Machine 1 (crafting_speed 0.5) needs
+  1.0 / 0.5 = 2 real seconds per craft and so tops out at 0.5 crafts/s.
+  The machine, not the belt or the inserters, is the bottleneck: 0.5
+  barrels/s, comfortably under the output inserter's 0.86 i/s so the
+  sink sees the assembler's rate directly.
+items:
+- { x: 0, y: 1, item: steel_plate }   # source emits steel_plate
+- { x: 2, y: 0, item: barrel }        # assembler recipe (anchor = top-left)
+- { x: 6, y: 1, item: barrel }        # sink counts barrels
+throughput:
+- { item: barrel, per_second: 0.5 }
+graph: |
+  S@0,1 -> i@1,1
+  i@1,1 -> a@2,0
+  a@2,0 -> i@5,1
+  i@5,1 -> K@6,1
+factory: |
+  .. .. aaaaaaaa .. ..
+  S> i> aa    aa i> K>
+  .. .. aaaaaaaa .. ..

--- a/tests/test_lesson_generation.py
+++ b/tests/test_lesson_generation.py
@@ -3171,9 +3171,11 @@ class TestMemoriseRecipesConnectivity:
 class TestMemoriseRecipesThroughputPerRecipe:
     """Closed-form throughput from the live recipe table. One output inserter
     caps the result at INSERTER_CAP; each ingredient arm caps its input at
-    INSERTER_CAP too."""
+    INSERTER_CAP too; and the assembler itself can never beat
+    `crafting_speed / crafting_time` crafts per second."""
 
     INSERTER_CAP = 0.86
+    ASSEMBLER = str2ent("assembling_machine_1")
 
     @pytest.mark.parametrize("seed", range(10))
     def test_throughput_matches_recipe_closed_form(self, kind, n_ing, seed):
@@ -3185,12 +3187,12 @@ class TestMemoriseRecipesThroughputPerRecipe:
         snk = (ent == str2ent("sink").value).nonzero(as_tuple=False)[0]
         recipe_name = items[item[snk[0], snk[1]].item()].name
         recipe = recipes[recipe_name]
-        min_ratio = min(
-            1.0,
+        crafts_per_sec = min(
+            self.ASSEMBLER.crafting_speed / recipe.crafting_time,
             *(self.INSERTER_CAP / c for c in recipe.consumes.values()),
         )
         prod_count = next(iter(recipe.produces.values()))
-        expected = min(self.INSERTER_CAP, prod_count * min_ratio)
+        expected = min(self.INSERTER_CAP, prod_count * crafts_per_sec)
         tp, _ = rs_throughput(world.permute(1, 2, 0))
         assert abs(tp - expected) < 1e-3, (
             f"seed={seed}, recipe={recipe_name}: expected ≈ {expected}, got {tp}"

--- a/tests/test_recipe_tree_trial.py
+++ b/tests/test_recipe_tree_trial.py
@@ -142,12 +142,33 @@ class TestTrialFactory:
     @pytest.mark.parametrize("kind", list(TRIAL_KINDS))
     def test_analytic_max_throughput(self, kind):
         """The normalization ceiling is one fully-fed assembler's output rate
-        of the sink recipe — positive without any reference solution."""
+        of the sink recipe in items/s — positive without any reference
+        solution, and scaled by the recipe's crafting time so a 40s recipe
+        does not normalize against the same number as a 0.5s one (#355)."""
         f = build_factory(size=SIZE, kind=kind, seed=0)
         assert f is not None
         sink, _ = _markers(f)
+        recipe = recipes[sink]
         assert f.max_throughput > 0
-        assert f.max_throughput == recipes[sink].produces[sink]
+        assert f.max_throughput == pytest.approx(
+            recipe.produces[sink]
+            * str2ent("assembling_machine_1").crafting_speed
+            / recipe.crafting_time
+        )
+
+    def test_ceilings_span_the_recipe_table(self):
+        """Sanity on the fix: sink recipes differ by orders of magnitude in
+        real Factorio, so the trial ceilings must too. Before crafting time
+        entered the model these all collapsed onto the per-craft quantity
+        (93% of trials ceilinged at exactly 1.0)."""
+        ceilings = {
+            f.max_throughput
+            for kind in TRIAL_KINDS
+            for seed in range(200)
+            if (f := build_factory(size=SIZE, kind=kind, seed=seed)) is not None
+        }
+        assert len(ceilings) > 10, f"ceilings barely vary: {sorted(ceilings)}"
+        assert max(ceilings) / min(ceilings) > 100
 
     @pytest.mark.parametrize("kind", list(TRIAL_KINDS))
     def test_markers_sit_on_the_edge_working_inward(self, kind):

--- a/wiki/assembling-machine.md
+++ b/wiki/assembling-machine.md
@@ -56,7 +56,9 @@ Inserters can interact with any non-corner perimeter tile of the 3x3 body.
 - **Entity enum:** `EntityKind::AssemblingMachine1 = 3`
 - **Recipe:** Stored in the `Items` channel — the `Item` enum value indicates
   which recipe the machine is set to (e.g., `Item::ElectronicCircuit = 4`)
-- **Flow rate:** 0.5 items/sec (base crafting speed)
+- **Crafting speed:** `0.5×`, a unitless multiplier on a recipe's rate
+  (`Item::crafting_speed()`). Its `flow_rate()` is `INFINITY` — an assembler
+  has no per-tile transfer cap; the recipe sets its limit.
 - **Anchor:** Top-left corner of the 3x3 footprint
 
 ### Connection Logic
@@ -78,22 +80,31 @@ Specifically, "faces away" means:
 
 ### Transform Flow
 
-The `transform_flow` function implements recipe crafting:
+`transform_flow` works in **crafts per second**, because items/second of
+different ingredients are not comparable:
 
-1. Look up the recipe for the assigned item
-2. Find the **minimum ratio** of available input to required input across all
-   ingredients
-3. Scale output production by that ratio
+1. Look up the recipe for the assigned item.
+2. The machine's ceiling is `crafting_speed / crafting_time` — the multiplier
+   off the entity, the seconds-per-craft off the recipe.
+3. Each ingredient's supply is its items/second over the quantity **one craft**
+   wants of it. The scarcest ingredient sets the pace, capped by the machine.
+4. Multiply that craft rate by each output's per-craft quantity to get back to
+   items/second.
 
-Example: Electronic circuit needs 6 copper cable + 2 iron plate → 2 circuits.
-If only 3 copper cable is available, ratio = min(3/6, ∞) = 0.5, output = 1
-circuit.
+Example: electronic circuit is 3 copper cable + 1 iron plate → 1 circuit in
+0.5s. In an AM1 the machine ceiling is `0.5 / 0.5` = 1 craft/s. Fed one
+inserter per ingredient (0.86 i/s each), supply allows
+`min(0.86/3, 0.86/1)` = 0.287 crafts/s, so output is `1 × 0.287` = **0.287
+circuits/s** — ingredient-limited. Feed the same machine a 1.0s recipe and it
+tops out at 0.5 crafts/s instead, machine-limited. `assembler_input_limited`
+and `assembler_machine_speed_limited` in `factorion_rs/tests/factories/` pin
+both cases.
 
 ### Simplifications vs Real Factorio
 
 | Mechanic | Real Factorio | Factorion |
 |---|---|---|
-| Crafting time | Discrete per-item crafting | Continuous flow rate |
+| Crafting time | Discrete per-item crafting | Continuous, but the rate is the real one: `crafting_speed / crafting_time` |
 | Internal buffer | Stores ingredients and products | No buffer — instant flow |
 | Power | Requires electricity | No power simulation |
 | Tiers | AM1/AM2/AM3 | AM1 only |

--- a/wiki/items-and-recipes.md
+++ b/wiki/items-and-recipes.md
@@ -123,6 +123,8 @@ currently used by Factorion's throughput model.
 | Inserter (basic) | ~0.83 i/s (not in infobox) | rotation 302°/s, energy 15.1 kW | [wiki](https://wiki.factorio.com/Inserter) |
 | Assembling machine 1 | `0.5×` crafting speed | 0 module slots, 75 kW, 4 pollution/m, no fluid recipes | [wiki](https://wiki.factorio.com/Assembling_machine_1) |
 
-The 0.5× crafting speed of AM1 is why the Rust `assembling_machine_1`
-flow rate is `0.5` (`EntityKind::AssemblingMachine1.flow_rate()` in
-`factorion_rs/src/types.rs`).
+The 0.5× is a **unitless multiplier on a recipe's rate**, not an items/second
+figure, and lives in `Item::crafting_speed()` (`factorion_rs/src/types.rs`).
+`Item::flow_rate()` is items/second and returns `INFINITY` for an assembler:
+its limit comes from the recipe, not from a per-tile transfer cap. Conflating
+the two is what #355 was.


### PR DESCRIPTION
Fixes #355.

## The bug

`AssemblingMachine::transform_flow` capped its input-sufficiency ratio at 1 and multiplied `recipe.produces` by it. `produces` is the **per-craft quantity**, so a fully-fed assembler's ceiling was that bare quantity — crafting time never entered the simulation anywhere.

## The fix

A recipe carries a speed; a machine carries a unitless multiplier.

```rust
// the machine's own ceiling, read off self.kind() — not hardcoded to assemblers
let machine_limit = match self.kind().crafting_speed() {
    Some(mult) if recipe.crafting_time > 0.0 => mult / recipe.crafting_time,
    _ => return HashMap::new(),
};

// ingredient supply on the same scale; the scarcest one sets the pace
let crafts = recipe.consumes.iter()
    .map(|&(item, qty)| input.get(&item).copied().unwrap_or(0.0) / qty)
    .fold(machine_limit, f64::min);

// a recipe yielding several per craft is faster by exactly that factor
recipe.produces.iter().map(|&(item, qty)| (item, qty * crafts)).collect()
```

The multiplier comes from `Item::crafting_speed()`, an `Option<f64>` on any item — so a smelting tier gets a crafting speed by adding a match arm, not a parallel mechanism. `transform_flow` reads it off `self.kind()`, so any future crafting entity is limited by the same code.

### Validated against Factorio 1.0

`test_production_rate_matches_factorio` checks all three tiers. Wiki-confirmed, unchanged in 2.0:

| recipe | per craft | crafting_time | recipe rate | in AM1 (×0.5) | was |
|---|---|---|---|---|---|
| `electronic_circuit` | 1 | 0.5 s | 2.000 /s | 1.000 /s | 1.000 /s |
| `copper_cable` | 2 | 0.5 s | 4.000 /s | 2.000 /s | 2.000 /s |
| `iron_gear_wheel` | 1 | 0.5 s | 2.000 /s | 1.000 /s | 1.000 /s |
| `artillery_turret` | 1 | 40.0 s | 0.025 /s | 0.0125 /s | **1.000 /s** |

Electronic circuit and artillery turret are now 80× apart, matching the game. Copper cable's 2-per-craft is folded into the rate, so it stays twice a 1-per-craft recipe of the same duration.

## Units

`consumes_rate` / `produces_rate` returned items **per craft** under a name that said rate — which is how this stayed invisible, and is exactly the assignment that produced the bug. They become `consumption_rate` / `production_rate` and now return what they claim: **items per second at crafting speed 1.0**.

Every caller was audited for which one it wants:

| caller | wants | |
|---|---|---|
| trial `max_throughput` (`ceiling_thput`) | rate | the bug — a per-craft count assigned into an items/s field |
| `total_raw` / `raw_expand` | count | right answer, wrong name; reads the fields now |
| `transform_flow` | count | reads the fields |
| `ppo.py` per-unit entity cost | count | correct, untouched |
| ~14 sites in `factory_gen` | neither | `.len()` / item identity only |
| `py_recipes` | count | **second instance of the same trap** — it carried the per-craft quantity into Python's `recipes[x].consumes` dict under the name `rate`, and `ppo.py` reads that dict. Now `qty_per_craft`. |

No helper layer beyond those two: `consumes`/`produces` are read directly wherever a count is wanted.

## Recomputed ceilings

Lesson `max_throughput` comes from `world_throughput`, so it recomputed itself. Trial ceilings are analytic. Sampling 120 seeds/kind at size 11:

| kind | min | median | max |
|---|---|---|---|
| `MEMORISE_1_INGREDIENT_RECIPES` | 0.0215 | 0.4300 | 0.8600 |
| `MEMORISE_4_INGREDIENT_RECIPES` | 0.0017 | 0.0333 | 0.1720 |
| `FACTORY_1_INGREDIENT` | 0.0215 | 0.9397 | 5.4400 |
| `TRIAL_RECIPE_TREE_DEPTH_1` | 0.0125 | **1.0000** | 20.0000 |
| `TRIAL_RECIPE_TREE_DEPTH_2` | 0.0125 | **0.2500** | 2.0000 |
| `TRIAL_RECIPE_TREE_DEPTH_3` | 0.0125 | **0.1000** | 1.0000 |

Before, 93% of trials ceilinged at exactly 1.0 and a depth-3 tree normalized against the same number as a depth-1 one. Belt/splitter/inserter-bound lessons (`MOVE_ONE_ITEM` 15.0, `SPLITTER_SPLIT` 7.5, `CROSS_UNDER_BELT` 15.0) are unchanged.

`CEILING_MACHINE` names the machine a trial's ceiling assumes — a trial places no machine, so the ceiling has to pick one, and it must be what the agent can actually build. It becomes a real choice when a second placeable crafting entity lands.

## Parity fixtures

Both branches of the new `min()`, unit-tested by `test_all_yamls_in_factories_dir` and replayed in-game by `parity_regression.sh`:

- `assembler_input_limited.yaml` — electronic circuit, one inserter per ingredient; copper cable (3 per craft, 0.86 i/s in) holds it to 0.287 EC/s against a 1 craft/s machine.
- `assembler_machine_speed_limited.yaml` — barrel with 0.86 steel plates/s arriving but an AM1 needing 2 real seconds per craft: 0.5 barrels/s. **Read 0.86 under the old model** — the case the engine could not express.

Both verified through `parity.py --dry-run`. The parity runbook's "known-expected divergences" list drops the assembler crafting-time over-count, so a mismatch there is now a real regression.

## Baselines

Every assembler-bound `thput`/`reward` recorded before this moved, so the numbers in **Baselines and best runs** (`h76h80yb`'s `eval/thput ≈ 0.67`, the PR #346 compare table) were measured on the old assembler and need re-measuring before they're quoted again. Belt/splitter/underground figures are unaffected — the assembler is the only entity whose flow model changed. Not recorded in-repo, per your call.

## Follow-up, not here

- **`Qty`/`Rate` newtypes** so this can't recur — agreed for a separate PR. Estimate: ~380 lines for recipe-scoped `Qty`/`Secs`/`Rate` (95% mechanical: 251 quantity literals in `all_recipes`, 72 `crafting_time` lines, plus the `Div`/`Mul` impls). Threading `Rate` through `transform_flow` / `flow_rate` / `throughput.rs` as well would be ~830 and is not recommended — inside the flow engine everything is already items/second.
- **Recipe reward scales / recipe-tree training**, per the issue's framing. Worth knowing: `thput_raw` for assembler lessons is now up to ~80× smaller while belt lessons still sit at 15 i/s, so the cross-lesson reward balance has genuinely shifted.

## Checks

cargo fmt / clippy `-D warnings` / cargo test (167) / maturin / pytest (3254 passed, 708 skipped) / ruff / ty / SFT smoke — all green. PPO smoke test not re-run after the final doc-comment cleanup.