### PR TITLE
Add a WSD anneal shape so runs of different budgets are comparable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Historically the project did RL-from-scratch with heavy scaffolding (curriculum 
 - **Dual-lane belts** (`wiki/two-lane-system.md`, #65): graph nodes are NOT 1:1 with entities — belt-ish tiles (belt, UG, each splitter tile) emit one node per `Lane` (`NodeId.lane`), each capped at half the tile's `Item::flow_rate()` (belt tile 15 → 7.5/lane; a splitter is two belt tiles, so `flow_rate(Splitter)` is 15 per tile, 4 lane pools × 7.5 = 30 total); inserter/assembler/source/sink stay single-node. Node references use ONE canonical format everywhere (engine labels, `py_build_graph`, and fixture `graph:` blocks): `<entity_char>@x,y` plus `:L`/`:R` for lane nodes (grid-registry chars: `b@1,0:L`, `i@0,1`, `d`/`u`, `S`, `K`); fixture graph blocks may elide lane markers per document (entity-level, lane-projected comparison). All connection logic funnels through `entities.rs::calc_lane_aware_edges`: straight/curve/tunnel/splitter flow is lane-preserving; a perpendicular feed onto a belt with any other belt-connectable input sideloads onto the near-side lane (`belt_feeders`/`is_curved_belt` — lone side feed = curve; UG mouths and splitters never curve; a side feed onto a UG tile connects only the feeder lane over its surface half — aft of an entrance, fore of an exit); inserters drop onto exactly one lane (far when perpendicular, belt's right when in-line) and pick up with lane priority (near when perpendicular, left when in-line/curved) via greedy fill in `throughput.rs::pickup_input`.
 - **Rendering factories to ASCII** — when asked to "render"/"show"/"draw" factories, use the real renderer, never hand-roll one: `from factorion import render_factory; print(render_factory(factory))` (accepts a `Factory` or a `(C, W, H)` world tensor; Rust binding `factorion_rs.render_factory(world_WHC)` lives in `factorion_rs/src/render.rs`). It returns the two-char grid format the textual fixtures use — `b`=belt, `i`=inserter, `l`=long-handed inserter, `a`=assembler box, `Y`=splitter, `d`/`u`=underground down/up, `S`=source, `K`=sink, each plus a facing marker `^>v<`; `..` is an empty tile. To also show each factory's recipe, read the assembler's tagged item from the `ITEMS` channel (or the sink's carried item).
 - **Placing entities in a generator** (`factory_gen.rs`) — mutate the `World` through the existing `place_*` helpers, never hand-write `world.set(Channel::Entities/Direction, …)` for a belt/marker/splitter (same rule as the renderer above: don't re-implement a helper that exists). `place_belts(world, &[(x, y, dir, Misc)])` lays plain belts **and** underground tunnel ends, one tuple per tile; `place_marker` for sources/sinks, `place_splitter` for the 2-tile splitter, `place_assembler` for the 3×3. Route belt runs with `find_belt_path`/`find_belt_paths` (the UG-aware Dijkstra) and feed the returned placements straight into `place_belts`. Raw `world.set` on the entity channel is only for post-hoc tweaks (e.g. neutralising a tile inside a validation check), not layout.
-- **`ppo.py`**: `PpoArgs` (all PPO hyperparams + `start_from`, `critic_warmup`, `eval_every`; defined in `training_config.py`), `FactorioEnv` (`reset`/`step`; terminal reward = `thput_raw / (1 + entity_cost_scale * entity_cost)`, where entity cost is per-output recursively-expanded raw-item quantity + craft time; normalized throughput remains a reference-based evaluation diagnostic and is not used by the reward; `eot` is a real action that ends the episode; `info['kind']` carries the lesson for per-lesson logging), `AgentCNN` (encoder + per-head outputs: tile/entity/direction/item/misc + `critic_head` + `eot_head`; stashes `_last_head_entropy`/`_last_eot_prob` for the policy/* metrics), `_resolve_start_from`/`_resolve_wandb_checkpoint` (checkpoint loading), `_run_signature` (run name), `_build_eval_set`/`_run_greedy_eval` (the eval/ section).
+- **`ppo.py`**: `PpoArgs` (all PPO hyperparams + `start_from`, `critic_warmup`, `eval_every`; defined in `training_config.py`), `FactorioEnv` (`reset`/`step`; terminal reward = `thput_raw / (1 + entity_cost_scale * entity_cost)`, where entity cost is per-output recursively-expanded raw-item quantity + craft time; normalized throughput remains a reference-based evaluation diagnostic and is not used by the reward; `eot` is a real action that ends the episode; `info['kind']` carries the lesson for per-lesson logging), `AgentCNN` (encoder + per-head outputs: tile/entity/direction/item/misc + `critic_head` + `eot_head`; stashes `_last_head_entropy`/`_last_eot_prob` for the policy/* metrics), `_resolve_start_from`/`_resolve_wandb_checkpoint` (checkpoint loading), `_run_signature` (run name), `_build_eval_set`/`_run_greedy_eval` (the eval/ section), `_iteration_schedule` (per-iteration LR + entropy coefficient; see "Comparing runs across budgets" below).
 - **`sft.py`**: `run_rollout_eval` returns `RolloutEval` with `overall` and per-`LessonKind` breakdowns; the rollout ends when the EOT head crosses `rollout_eot_threshold` (as it does in the web UI and the mod server, and as the sampled `eot` action ends a PPO episode), so the scored factory is the one the model declared finished. Checkpoint selection is on that `val/thput`. PPO reuses this for its `eval/` metrics (lazy import to avoid the ppo↔sft cycle).
 
 ## W&B dashboards
@@ -142,6 +142,30 @@ above to shift when the next run lands.
 ## SFT → PPO handoff
 
 `ppo.py --start-from <ckpt>` loads the full SFT `AgentCNN` state dict (encoder + every policy/eot head). The **critic head is the only part SFT never trained**, so `--critic-warmup N` freezes the actor (encoder + policy heads) for N iterations and trains the value head alone against the fixed SFT features before joint PPO begins; LR anneal + entropy schedule restart at the unfreeze. For finetuning an SFT policy, set `--ent-coef-start/--ent-coef-end 0` and a small `--learning-rate` (e.g. 5e-5). Every episode builds from a full blank (the legacy `num_missing_entities` curriculum was removed).
+
+## Comparing runs across budgets
+
+`--anneal-shape` (`ppo.py:_iteration_schedule`) selects how the LR *and* the
+entropy coefficient decay; both ride one multiplier, so they always move
+together.
+
+- **`linear`** (default) decays across the whole post-critic-warmup window. Every
+  step's LR and `ent_coef` therefore depend on `total_timesteps`, so **two runs
+  with different budgets are only comparable at matched *fraction* of the run,
+  never at matched `global_step`.** This bit real comparisons: `seug3e5t` (10M)
+  vs `ot3lw16n` (2M) sat at 2x the LR and 1.8x the `ent_coef` at the same step,
+  and the longer run's `policy/entropy` climbed 1.77 -> 4.57 while the short
+  one's fell to 1.30.
+- **`wsd`** (warmup-stable-decay) holds the peak through a stable phase and
+  decays only over the final `--cooldown-frac` (default 0.2), with an optional
+  `--lr-warmup-steps` ramp measured in env steps. The stable phase is then
+  identical at any budget, so a short tuning run and the prefix of a long
+  production run are the same trajectory and compare directly at matched
+  `global_step`. Cooldown shape is 1-sqrt (Hägele et al. 2024).
+
+Use `wsd` for anything that will be compared against a differently-sized run, or
+when tuning at one budget to spend at another. `linear` is kept as the default so
+the baselines in "Baselines and best runs" stay reproducible.
 
 ## Python Environment
 

--- a/ppo.py
+++ b/ppo.py
@@ -242,6 +242,8 @@ def _run_signature(args) -> str:
         sig += f"_{args.ent_coef_end:g}"
     if args.target_kl is not None:
         sig += f"-kl{args.target_kl:g}"
+    if args.anneal_shape != "linear":
+        sig += f"-{args.anneal_shape}{args.cooldown_frac:g}"
     if args.critic_warmup:
         sig += f"-cw{args.critic_warmup}"
     if args.start_from:
@@ -378,6 +380,61 @@ def _rollout_episode_metrics(
         f"rollout/{lesson}/entity_cost": float(entity_cost),
         f"rollout/{lesson}/cost_efficiency": float(cost_efficiency),
     }
+
+
+def _decay_multiplier(shape: str, done: int, total: int, cooldown_frac: float) -> float:
+    """Fraction of the start->end anneal span still remaining, in [0, 1]:
+    1.0 holds the start value (peak LR, `ent_coef_start`), 0.0 lands on the end
+    value. `done`/`total` are env steps into / spanning the anneal window.
+
+    `linear` decays across the whole window, so a run's value at a given step
+    depends on its total budget. `wsd` holds 1.0 until the final
+    `cooldown_frac`, making the stable phase budget-independent so runs of
+    different lengths are directly comparable at matched step (see
+    `PpoArgs.anneal_shape`). The 1-sqrt cooldown shape is from Hägele et al.
+    2024, which found it beats linear and cosine cooldowns."""
+    if total <= 0:
+        return 1.0
+    progress = min(1.0, max(0.0, done / total))
+    if shape != "wsd":
+        return 1.0 - progress
+    stable_end = 1.0 - cooldown_frac
+    if cooldown_frac <= 0.0 or progress <= stable_end:
+        return 1.0
+    return 1.0 - math.sqrt((progress - stable_end) / cooldown_frac)
+
+
+def _lr_warmup_multiplier(done: int, batch_size: int, warmup_steps: int) -> float:
+    """Linear 0->1 LR ramp over the anneal window's first `warmup_steps` env
+    steps. `done + batch_size` (steps completed by the *end* of this iteration)
+    keeps the first iteration off zero."""
+    if warmup_steps <= 0:
+        return 1.0
+    return min(1.0, (done + batch_size) / warmup_steps)
+
+
+def _iteration_schedule(args, iteration: int) -> tuple[float, float]:
+    """(actor LR, entropy coef) for a 1-based PPO iteration.
+
+    Both ride one progress multiplier, so `anneal_shape` moves them together —
+    making only one budget-independent would still leave runs of different
+    lengths incomparable. The window opens at the critic-warmup unfreeze: the
+    actor is frozen before that, so schedule spent there is spent on nothing.
+    Progress is tracked in env steps rather than iterations so `lr_warmup_steps`
+    means the same thing across batch sizes."""
+    in_warmup = iteration <= args.critic_warmup
+    anneal_total = max(1, args.num_iterations - args.critic_warmup)
+    anneal_iter = max(0, iteration - args.critic_warmup)
+    anneal_done = max(0, anneal_iter - 1) * args.batch_size
+    decay = 1.0 if in_warmup else _decay_multiplier(
+        args.anneal_shape, anneal_done, anneal_total * args.batch_size,
+        args.cooldown_frac)
+    frac = decay
+    if args.anneal_shape == "wsd" and not in_warmup:
+        frac *= _lr_warmup_multiplier(
+            anneal_done, args.batch_size, args.lr_warmup_steps)
+    ent_coef = args.ent_coef_end + decay * (args.ent_coef_start - args.ent_coef_end)
+    return frac * args.learning_rate, ent_coef
 
 
 def _explained_variance(y_true: np.ndarray, y_pred: np.ndarray) -> float:
@@ -2133,24 +2190,13 @@ if __name__ == "__main__":
             set_actor_requires_grad(True)
             print(f"\nCritic warm-up complete; unfreezing actor at iteration {iteration}")
 
-        # Annealing schedules run over the post-warm-up window, so the actor
-        # gets its full LR/entropy schedule starting from the unfreeze point
-        # rather than burning it while frozen. During warm-up the critic
-        # trains at the un-annealed peak LR.
-        anneal_total = max(1, args.num_iterations - args.critic_warmup)
-        anneal_iter = max(0, iteration - args.critic_warmup)
+        lrnow, ent_coef = _iteration_schedule(args, iteration)
         # Annealing the rate if instructed to do so.
         if args.anneal_lr:
-            frac = 1.0 if in_warmup else 1.0 - (anneal_iter - 1.0) / anneal_total
-            lrnow = frac * args.learning_rate
             # param_groups[0]=actor, [1]=critic. The critic can run at a higher LR
             # (critic_lr_mult) to warm the value head faster; 1.0 = unchanged.
             optimizer.param_groups[0]["lr"] = lrnow
             optimizer.param_groups[1]["lr"] = lrnow * args.critic_lr_mult
-
-        # Entropy coefficient annealing: linear from ent_coef_start to ent_coef_end
-        ent_frac = 1.0 if in_warmup else 1.0 - (anneal_iter - 1.0) / anneal_total
-        ent_coef = args.ent_coef_end + ent_frac * (args.ent_coef_start - args.ent_coef_end)
 
         # Per-iteration accumulators for the acting policy's distribution shape
         # (the policy/* metrics): summed over rollout steps, meaned at log time.

--- a/tests/test_lr_schedule.py
+++ b/tests/test_lr_schedule.py
@@ -1,0 +1,234 @@
+"""Tests for the LR/entropy anneal shapes (`PpoArgs.anneal_shape`).
+
+The point of `wsd` is that the stable phase does not depend on the total
+budget, so a short tuning run and the prefix of a long production run are the
+same trajectory and can be compared at matched `global_step`. `linear` (the
+default) keeps the pre-existing whole-run decay, where every step's value
+depends on `total_timesteps`.
+"""
+
+import os
+import sys
+
+import pytest
+import tyro
+
+os.environ["WANDB_MODE"] = "disabled"
+os.environ["WANDB_DISABLED"] = "true"
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from ppo import (  # noqa: E402
+    PpoArgs,
+    _decay_multiplier,
+    _iteration_schedule,
+    _lr_warmup_multiplier,
+    _run_signature,
+)
+
+BATCH = 4096
+
+
+def make_args(total_timesteps: int, **overrides) -> PpoArgs:
+    """PpoArgs with the derived fields `__main__` computes before the loop."""
+    args = PpoArgs(total_timesteps=total_timesteps, **overrides)
+    args.batch_size = int(args.num_envs * args.num_steps)
+    args.minibatch_size = int(args.batch_size // args.num_minibatches)
+    args.num_iterations = args.total_timesteps // args.batch_size
+    return args
+
+
+def lrs(args) -> list[float]:
+    return [_iteration_schedule(args, i)[0] for i in range(1, args.num_iterations + 1)]
+
+
+def ents(args) -> list[float]:
+    return [_iteration_schedule(args, i)[1] for i in range(1, args.num_iterations + 1)]
+
+
+class TestDefaultsUnchanged:
+    """`linear` must reproduce the pre-WSD formula exactly, so existing
+    baselines stay reproducible."""
+
+    def test_default_shape_is_linear(self):
+        assert PpoArgs().anneal_shape == "linear"
+
+    def test_matches_the_original_inline_formula(self):
+        args = make_args(2_000_000)
+        anneal_total = max(1, args.num_iterations - args.critic_warmup)
+        for iteration in range(1, args.num_iterations + 1):
+            in_warmup = iteration <= args.critic_warmup
+            anneal_iter = max(0, iteration - args.critic_warmup)
+            frac = 1.0 if in_warmup else 1.0 - (anneal_iter - 1.0) / anneal_total
+            want_lr = frac * args.learning_rate
+            want_ent = args.ent_coef_end + frac * (
+                args.ent_coef_start - args.ent_coef_end
+            )
+            got_lr, got_ent = _iteration_schedule(args, iteration)
+            assert got_lr == pytest.approx(want_lr, rel=1e-12)
+            assert got_ent == pytest.approx(want_ent, rel=1e-12)
+
+    def test_linear_is_budget_dependent(self):
+        """The behaviour WSD exists to fix: same step, different value."""
+        short, long = make_args(2_000_000), make_args(10_000_000)
+        i = 100  # past critic_warmup, so both are annealing
+        assert _iteration_schedule(short, i)[0] != pytest.approx(
+            _iteration_schedule(long, i)[0], rel=1e-6
+        )
+
+
+class TestWsdIsBudgetIndependent:
+    def test_stable_phase_identical_across_budgets(self):
+        short = make_args(2_000_000, anneal_shape="wsd")
+        long = make_args(10_000_000, anneal_shape="wsd")
+        # Every iteration the *short* run still holds at peak must match the
+        # long run step for step — that is the whole property.
+        stable_iters = int(
+            (short.num_iterations - short.critic_warmup) * (1 - short.cooldown_frac)
+        )
+        assert stable_iters > 100, "test needs a meaningful stable phase"
+        for i in range(1, stable_iters + 1):
+            assert _iteration_schedule(short, i) == _iteration_schedule(long, i)
+
+    def test_stable_phase_holds_peak_values(self):
+        args = make_args(2_000_000, anneal_shape="wsd")
+        lr, ent = _iteration_schedule(args, args.critic_warmup + 5)
+        assert lr == pytest.approx(args.learning_rate)
+        assert ent == pytest.approx(args.ent_coef_start)
+
+    def test_cooldown_decays_to_the_end_values(self):
+        args = make_args(2_000_000, anneal_shape="wsd")
+        lr, ent = _iteration_schedule(args, args.num_iterations)
+        assert lr < 0.02 * args.learning_rate
+        assert ent == pytest.approx(args.ent_coef_end, abs=0.05 * args.ent_coef_start)
+
+    def test_schedule_is_monotonically_decreasing(self):
+        args = make_args(2_000_000, anneal_shape="wsd")
+        for series in (lrs(args), ents(args)):
+            for prev, cur in zip(series, series[1:]):
+                assert cur <= prev + 1e-15
+
+    def test_only_the_cooldown_tail_moves(self):
+        args = make_args(2_000_000, anneal_shape="wsd")
+        moved = [i for i, lr in enumerate(lrs(args), 1) if lr < args.learning_rate]
+        expected_start = args.critic_warmup + int(
+            (args.num_iterations - args.critic_warmup) * (1 - args.cooldown_frac)
+        )
+        assert moved[0] == pytest.approx(expected_start + 1, abs=1)
+
+    def test_zero_cooldown_is_a_constant_schedule(self):
+        args = make_args(2_000_000, anneal_shape="wsd", cooldown_frac=0.0)
+        assert lrs(args) == [args.learning_rate] * args.num_iterations
+        assert ents(args) == [args.ent_coef_start] * args.num_iterations
+
+
+class TestLrWarmup:
+    def test_off_by_default(self):
+        args = make_args(2_000_000, anneal_shape="wsd")
+        assert args.lr_warmup_steps == 0
+        assert _iteration_schedule(args, args.critic_warmup + 1)[0] == pytest.approx(
+            args.learning_rate
+        )
+
+    def test_ramps_from_near_zero_to_peak(self):
+        warmup = 20 * BATCH
+        args = make_args(2_000_000, anneal_shape="wsd", lr_warmup_steps=warmup)
+        first = _iteration_schedule(args, args.critic_warmup + 1)[0]
+        assert first == pytest.approx(args.learning_rate / 20)
+        at_peak = _iteration_schedule(args, args.critic_warmup + 20)[0]
+        assert at_peak == pytest.approx(args.learning_rate)
+
+    def test_ramp_is_invariant_to_batch_size(self):
+        """Warmup is in env steps, so halving the batch just doubles the number
+        of iterations covering the same ramp."""
+        big = make_args(
+            2_000_000,
+            anneal_shape="wsd",
+            lr_warmup_steps=50_000,
+            critic_warmup=0,
+            num_steps=256,
+        )
+        small = make_args(
+            2_000_000,
+            anneal_shape="wsd",
+            lr_warmup_steps=50_000,
+            critic_warmup=0,
+            num_steps=128,
+        )
+        assert big.batch_size == 2 * small.batch_size
+        for global_step in (big.batch_size, 5 * big.batch_size, 12 * big.batch_size):
+            lr_big = _iteration_schedule(big, global_step // big.batch_size)[0]
+            lr_small = _iteration_schedule(small, global_step // small.batch_size)[0]
+            assert lr_big == pytest.approx(lr_small)
+
+    def test_entropy_is_not_warmed_up(self):
+        """The entropy bonus should be at full strength immediately — ramping it
+        would mean the least-trained policy also explores least."""
+        args = make_args(2_000_000, anneal_shape="wsd", lr_warmup_steps=20 * BATCH)
+        assert _iteration_schedule(args, args.critic_warmup + 1)[1] == pytest.approx(
+            args.ent_coef_start
+        )
+
+
+class TestCriticWarmupWindow:
+    def test_peak_is_held_while_the_actor_is_frozen(self):
+        for shape in ("linear", "wsd"):
+            args = make_args(2_000_000, anneal_shape=shape, lr_warmup_steps=20 * BATCH)
+            for i in range(1, args.critic_warmup + 1):
+                lr, ent = _iteration_schedule(args, i)
+                assert lr == pytest.approx(args.learning_rate)
+                assert ent == pytest.approx(args.ent_coef_start)
+
+
+class TestDecayMultiplier:
+    def test_linear_spans_one_to_zero(self):
+        assert _decay_multiplier("linear", 0, 100, 0.2) == pytest.approx(1.0)
+        assert _decay_multiplier("linear", 50, 100, 0.2) == pytest.approx(0.5)
+        assert _decay_multiplier("linear", 100, 100, 0.2) == pytest.approx(0.0)
+
+    def test_wsd_cooldown_is_one_minus_sqrt(self):
+        # 20% cooldown: halfway through it, 1 - sqrt(0.5).
+        assert _decay_multiplier("wsd", 90, 100, 0.2) == pytest.approx(1 - 0.5**0.5)
+        assert _decay_multiplier("wsd", 80, 100, 0.2) == pytest.approx(1.0)
+        assert _decay_multiplier("wsd", 100, 100, 0.2) == pytest.approx(0.0)
+
+    def test_degenerate_windows_hold_the_start_value(self):
+        assert _decay_multiplier("wsd", 0, 0, 0.2) == 1.0
+        assert _decay_multiplier("linear", 0, 0, 0.2) == 1.0
+        assert _decay_multiplier("wsd", 99, 100, 0.0) == 1.0
+
+    def test_warmup_multiplier_clamps_at_one(self):
+        assert _lr_warmup_multiplier(0, 10, 0) == 1.0
+        assert _lr_warmup_multiplier(0, 10, 100) == pytest.approx(0.1)
+        assert _lr_warmup_multiplier(990, 10, 100) == 1.0
+
+
+class TestRunSignature:
+    def test_linear_signature_is_unchanged(self):
+        assert "wsd" not in _run_signature(make_args(2_000_000))
+
+    def test_wsd_is_named_so_runs_are_distinguishable(self):
+        sig = _run_signature(make_args(2_000_000, anneal_shape="wsd"))
+        assert "-wsd0.2" in sig
+
+
+class TestCli:
+    """`ppo.py` builds its args with `tyro.cli(PpoArgs)`, so the flags have to
+    round-trip through it for `/ci ppo` overrides to work."""
+
+    def test_flags_round_trip(self):
+        args = tyro.cli(
+            PpoArgs,
+            args=[
+                "--anneal-shape", "wsd",
+                "--lr-warmup-steps", "50000",
+                "--cooldown-frac", "0.15",
+            ],
+        )
+        assert args.anneal_shape == "wsd"
+        assert args.lr_warmup_steps == 50_000
+        assert args.cooldown_frac == 0.15
+
+    def test_shape_is_constrained_to_known_values(self):
+        with pytest.raises(SystemExit):
+            tyro.cli(PpoArgs, args=["--anneal-shape", "cosine"])

--- a/training_config.py
+++ b/training_config.py
@@ -18,7 +18,7 @@ independently — e.g. `learning_rate`/`lr`, `dropout`, `weight_decay`,
 
 import typing
 from dataclasses import dataclass
-from typing import Optional
+from typing import Literal, Optional
 
 # Number of CNN encoder width slots (layer1..layer{NUM_LAYER_SLOTS}); every slot
 # with positive width becomes one conv layer (see ppo.layers_from_args).
@@ -121,6 +121,23 @@ class PpoArgs(SharedArgs):
     """the number of steps to run in each environment per policy rollout"""
     anneal_lr: bool = True
     """Toggle learning rate annealing for policy and value networks"""
+    anneal_shape: Literal["linear", "wsd"] = "linear"
+    """Shape of the LR *and* entropy anneal (both ride the same progress
+    multiplier). `linear` decays across the whole post-critic-warmup window, so
+    every step's value depends on `total_timesteps` and two runs of different
+    length are only comparable at matched *fraction* of the run. `wsd`
+    (warmup-stable-decay) holds the peak through a stable phase and decays only
+    over the final `cooldown_frac`, so the stable phase is identical at any
+    budget: a short tuning run and the prefix of a long production run become
+    the same trajectory, comparable at matched `global_step`."""
+    lr_warmup_steps: int = 0
+    """Env steps of linear LR ramp from 0 to `learning_rate` at the start of the
+    anneal window (`wsd` only; 0 = start at peak). Measured in env steps rather
+    than iterations so it is unchanged by the total budget or the batch size."""
+    cooldown_frac: float = 0.2
+    """Fraction of the anneal window spent decaying to the end value (`wsd`
+    only). This is the one genuinely budget-dependent knob, which is why it is
+    expressed as a fraction — that form transfers across run lengths."""
     # gamma is fine for now, check sweep v3ohvfpl for details
     gamma: float = 0.9566
     """the discount factor gamma"""


### PR DESCRIPTION
## Why

The LR and entropy schedules were both `1.0 - (anneal_iter - 1) / anneal_total`, i.e. pure fraction-of-run. That makes every step's value a function of `total_timesteps`, so **two runs with different budgets are only comparable at matched *fraction* of the run, never at matched `global_step`.**

This isn't hypothetical — it bit a live comparison. `seug3e5t` (10M budget) vs `ot3lw16n` (2M budget), read at the same `global_step` of ~1.1M:

| | `ot3lw16n` (2M) | `seug3e5t` (10M) |
|---|---|---|
| `optim/lr` | 1.53e-5 | 3.01e-5 |
| `optim/ent_coef` | 0.0041 | 0.0073 |
| `policy/entropy` | 1.30 | 4.57 |
| `eval/thput` | 0.70 | 0.66 |

Both started at `policy/entropy = 1.77`. The longer run was simply still being pushed toward exploration while the shorter one had already cooled down, so the `eval/thput` gap says very little about the code change under test.

## What

`--anneal-shape` selects the shape of the LR **and** entropy anneal:

- **`linear`** (default, unchanged) — decays across the whole post-critic-warmup window.
- **`wsd`** — warmup → stable → decay. Holds the peak through a stable phase and decays only over the final `--cooldown-frac` (default 0.2). The stable phase no longer depends on the budget, so a short tuning run and the prefix of a long production run are the same trajectory and compare directly at matched `global_step`. Cooldown shape is `1 - sqrt(progress)`, from Hägele et al. 2024, which found it beats linear and cosine cooldowns.

`--lr-warmup-steps` adds an optional linear LR ramp, measured in **env steps** rather than iterations so it means the same thing across batch sizes.

Two deliberate design points:

- **LR and entropy share one multiplier.** Making only one of them budget-independent would still leave runs incomparable.
- **`linear` remains the default** and is asserted to reproduce the previous formula exactly, so the baselines in `CLAUDE.md` stay reproducible and no in-flight run changes behaviour.

The per-iteration schedule math moved into a pure `_iteration_schedule(args, iteration) -> (lr, ent_coef)` so the tests exercise the exact function the training loop calls rather than a re-implementation of it.

## Changes

- `training_config.py` — `PpoArgs.anneal_shape`, `lr_warmup_steps`, `cooldown_frac`.
- `ppo.py` — `_decay_multiplier`, `_lr_warmup_multiplier`, `_iteration_schedule`; loop wiring; `_run_signature` tags non-linear shapes so W&B run names stay distinguishable.
- `tests/test_lr_schedule.py` — 22 tests: the `linear` regression guard (exact equality with the old inline formula across a whole run), the budget-independence property (short vs long run identical step-for-step through the stable phase), the `linear` counter-example, cooldown monotonicity/endpoints, batch-size invariance of the warmup ramp, critic-warmup window behaviour, and tyro CLI round-trip.
- `CLAUDE.md` — new "Comparing runs across budgets" section.

## Testing

Full pre-completion checklist passes:

- `cargo fmt` / `cargo clippy -- -D warnings` / `cargo test` — 166 passed (no Rust changes)
- `maturin develop --release`
- `pytest tests/` — **3275 passed, 708 skipped**
- `ruff check .` — clean
- `ty check .` — clean
- PPO smoke test — passes on the default `linear` **and** with `--anneal-shape wsd --lr-warmup-steps 256`
- SFT smoke test — passes

## Follow-up

Not in this PR: replacing the entropy *schedule* with a target-entropy controller (a dual variable on `log ent_coef` driving `policy/entropy` to a target, as SAC does for temperature). That is scale-free in a stronger sense — you tune a target in nats instead of a coefficient, and it self-corrects when the advantage scale shifts, which is what actually happened here when the critic improved (`critic/adv_abs_mean` halved). Worth its own PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_0186jRicjq2UdSsxBh7Vg9s3)_