### PR TITLE
E2: exclude the EOT head from PPO's entropy bonus (minimal #364)

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -1513,6 +1513,17 @@ class AgentCNN(nn.Module):
                 head.bias.fill_(0.0)
                 head.bias.data[0] = 1.0
 
+        # Weight of the EOT head's entropy inside the summed `entropy` that
+        # sample_action returns. Bernoulli entropy peaks at p=0.5, so a plain
+        # sum lets PPO's entropy bonus drag the EOT head toward a coin flip —
+        # expected episode length ~2 — on the one bit with the most leverage
+        # over the return (#235). Defaults to the plain sum so SFT and every
+        # non-PPO consumer are untouched; PPO overrides it from
+        # PpoArgs.ent_mult_eot before compiling its handles. The per-head
+        # entropies stashed in _last_head_entropy stay unweighted, so the
+        # policy/* metrics remain comparable across weightings.
+        self.ent_mult_eot = 1.0
+
     def _encode_input(self, x_BCWH):
         """Expand the raw (B, len(Channel), W, H) observation into the conv's
         input by encoding the nominal channels categorically: learned
@@ -1742,7 +1753,10 @@ class AgentCNN(nn.Module):
             p_eot_B * F.logsigmoid(eot_logit_B)
             + (1.0 - p_eot_B) * F.logsigmoid(-eot_logit_B)
         )
-        entropy_B = ent_tile + ent_e + ent_d + ent_i + ent_m + ent_eot
+        entropy_B = (
+            ent_tile + ent_e + ent_d + ent_i + ent_m
+            + self.ent_mult_eot * ent_eot
+        )
         self._last_head_entropy = {
             "tile": ent_tile.mean().detach(),
             "entity": ent_e.mean().detach(),
@@ -1963,6 +1977,8 @@ if __name__ == "__main__":
         attn_pos_embed=args.attn_pos_embed,
         global_feat_dim=args.global_feat_dim,
     )
+
+    agent.ent_mult_eot = args.ent_mult_eot
 
     if args.start_from is not None:
         if args.track:

--- a/tests/test_eot_entropy_weight.py
+++ b/tests/test_eot_entropy_weight.py
@@ -1,0 +1,72 @@
+"""The EOT head's weight in the entropy bonus (PpoArgs.ent_mult_eot, #235).
+
+Bernoulli entropy peaks at p(eot)=0.5 — expected episode length ~2 — so PPO
+excludes the EOT head from the entropy bonus by default; every other consumer
+keeps the plain six-head sum.
+"""
+
+import os
+import sys
+
+import gymnasium as gym
+import pytest
+import torch
+
+os.environ["WANDB_MODE"] = "disabled"
+os.environ["WANDB_DISABLED"] = "true"
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from ppo import AgentCNN, make_env  # noqa: E402
+from training_config import PpoArgs  # noqa: E402
+from factorion import Channel  # noqa: E402
+
+ENV_ID = "factorion/FactorioEnv-v0-eot-entropy-test"
+
+
+@pytest.fixture(scope="module")
+def envs():
+    gym.register(id=ENV_ID, entry_point="ppo:FactorioEnv")
+    return gym.vector.SyncVectorEnv(
+        [make_env(ENV_ID, i, False, 5, "test") for i in range(2)]
+    )
+
+
+def _entropy_and_heads(agent, obs):
+    """The summed entropy the PPO loss consumes, next to the unweighted
+    per-head means the policy/* metrics log."""
+    torch.manual_seed(0)
+    out = agent.sample_action(obs)
+    return out["entropy"].mean(), dict(agent._last_head_entropy)
+
+
+def test_ppo_default_excludes_the_eot_head(envs):
+    """At the PpoArgs default the loss entropy is the sum of the five
+    placement heads — the EOT head contributes nothing to the bonus."""
+    assert PpoArgs.ent_mult_eot == 0.0
+    agent = AgentCNN(envs, layers=(16, 16, 16))
+    agent.ent_mult_eot = PpoArgs.ent_mult_eot
+    obs = torch.randn(4, len(Channel), 5, 5)
+    total, heads = _entropy_and_heads(agent, obs)
+    without_eot = sum(v for k, v in heads.items() if k != "eot")
+    assert total.item() == pytest.approx(without_eot.item(), abs=1e-5)
+
+
+def test_weight_one_recovers_the_plain_sum(envs):
+    """--ent-mult-eot 1.0 (and AgentCNN's own default, which SFT and the mod
+    server see) is exactly the previous behaviour."""
+    agent = AgentCNN(envs, layers=(16, 16, 16))
+    assert agent.ent_mult_eot == 1.0
+    obs = torch.randn(4, len(Channel), 5, 5)
+    total, heads = _entropy_and_heads(agent, obs)
+    assert total.item() == pytest.approx(sum(heads.values()).item(), abs=1e-5)
+
+
+def test_stashed_head_entropies_stay_unweighted(envs):
+    """policy/entropy_eot must stay comparable across weightings: zeroing the
+    bonus must not zero the logged EOT entropy."""
+    agent = AgentCNN(envs, layers=(16, 16, 16))
+    agent.ent_mult_eot = 0.0
+    obs = torch.randn(4, len(Channel), 5, 5)
+    _, heads = _entropy_and_heads(agent, obs)
+    assert heads["eot"].item() > 0.0

--- a/training_config.py
+++ b/training_config.py
@@ -141,6 +141,11 @@ class PpoArgs(SharedArgs):
     """entropy coefficient at the start of training (high = more exploration)"""
     ent_coef_end: float = 0.0007372
     """entropy coefficient at the end of training (low = more exploitation)"""
+    ent_mult_eot: float = 0.0
+    """weight of the EOT head's entropy inside the entropy bonus. The Bernoulli
+    entropy peaks at p(eot)=0.5, i.e. ~2-step episodes, so the default excludes
+    the EOT head from the bonus and lets reward pressure alone set the stopping
+    policy (#235). 1.0 recovers the previous plain sum over all six heads."""
     vf_coef: float = 0.794
     """coefficient of the value function"""
     entity_cost_scale: float = 0.001


### PR DESCRIPTION
## What

The minimal core of draft #364 (whose compare was killed before producing any runs, and whose branch has since drifted from main): a single `ent_mult_eot` weight on the EOT head's term in PPO's entropy bonus, **defaulting to 0**. `AgentCNN` keeps the plain six-head sum for SFT/mod-server/builder; PPO sets the weight from `PpoArgs` before compiling its handles. `--ent-mult-eot 1.0` recovers main exactly. +94/−1 including tests.

Independent of PR #370 (branches from main; one variable per experiment).

## Why (hypothesis)

PPO maximises the summed entropy of all six heads. Bernoulli entropy peaks at `p(eot)=0.5` — expected episode length ~2 — so the bonus drags the EOT head toward a coin flip on the one bit with the most leverage over the return (#235). This isn't hypothetical; it's the dominant *instability* in recent runs:

- `i7u8l0gw` (main-side seed 3, cmp-112228b): at ~1.7M steps trials collapse to instant-EOT — `rollout/trial_eot_rate` → 1.0, `rollout/trial_length` 58 → **1.7**, `policy/eot_prob` 0.06 → 0.21 — killing all trial exploration for the rest of the run.
- The #353 compare's main side ended the same way (`trial_length` 1.49, `trial_eot_rate` 1.0 at 1.5M).
- Other seeds (`gsgsp9wd`, `t0n1p1c5`) instead drift entropy *upward* (3.5–4.4) while `eval/thput` decays. End-state entropy across recent runs spans 0.88–6.2 — the run-to-run bimodality that makes every compare noisy.

A trial episode that ends at step 2 can never discover any reward, whatever the reward design — this failure mode gates every other trial-side improvement.

## Predictions (before the compare)

1. **No instant-EOT collapse**: `rollout/trial_length` never enters the ~2-step mode; `rollout/trial_eot_rate` stays well below 1.0 late in training.
2. `policy/eot_prob` stays near the SFT prior / reward-pressure level (~0.05–0.10) instead of climbing toward 0.2+.
3. Smoothed-final `eval/thput` ≥ main (removing the drag must not cost the imitation prior; mid-build premature EOT should if anything drop).
4. Smoothed-final `eval/trial_thput` ≥ main. (Any gain above noise is a win; the main claim is removing the collapse mode, so with 1 seed the trial-episode-shape metrics in (1)–(2) carry most of the evidence.)
5. `losses/entropy` lower by roughly the EOT term; the unweighted `policy/entropy_eot` still logged and nonzero.

Adoption gate (mirrors #364's): (3) and (4), judged on W&B-API smoothed final values, never `summary="max"` asserts.

## Testing

- `tests/test_eot_entropy_weight.py`: PPO default excludes the EOT head from the loss entropy; weight 1.0 (and AgentCNN's own default) reproduces the plain sum exactly; the stashed per-head entropies stay unweighted.
- `ruff`, `ty`, agent test file, and the PPO smoke test (critic-warmup KL invariant intact) green locally; full suites in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYAAUaTkkMyHYZmkdwkEgB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYAAUaTkkMyHYZmkdwkEgB)_