### PR TITLE
E4a: exclude the deep trials from training episode sampling

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -537,6 +537,24 @@ def _resolve_start_from(
     return path
 
 
+def train_kinds_from_args(args) -> Optional[list[LessonKind]]:
+    """The LessonKind list training rollouts sample from: every kind minus
+    args.exclude_train_kinds (comma-separated names). None when nothing is
+    excluded, keeping the env default (= all kinds) in charge."""
+    names = {n.strip() for n in args.exclude_train_kinds.split(",") if n.strip()}
+    unknown = names - {k.name for k in LessonKind}
+    if unknown:
+        raise ValueError(
+            f"unknown LessonKind name(s) in --exclude-train-kinds: {sorted(unknown)}"
+        )
+    if not names:
+        return None
+    kinds = [k for k in LessonKind if k.name not in names]
+    if not kinds:
+        raise ValueError("--exclude-train-kinds excludes every kind")
+    return kinds
+
+
 def make_env(
     env_id,
     idx,
@@ -545,12 +563,14 @@ def make_env(
     run_name,
     entity_cost_scale=PpoArgs.entity_cost_scale,
     reward_symlog_r0=PpoArgs.reward_symlog_r0,
+    train_kinds=None,
 ):
     def thunk():
         kwargs: dict[str, Any] = {"render_mode": "rgb_array"} if capture_video else {}
         kwargs.update({'size': size, 'max_steps': size*size, 'idx': idx,
                        'entity_cost_scale': entity_cost_scale,
-                       'reward_symlog_r0': reward_symlog_r0})
+                       'reward_symlog_r0': reward_symlog_r0,
+                       'train_kinds': train_kinds})
         env = gym.make(env_id, **kwargs)
         if capture_video:
             env = gym.wrappers.RecordVideo(env, f"videos/{run_name}/env_{idx}", episode_trigger=lambda e: (e+1) % 10 == 0)
@@ -617,8 +637,15 @@ class FactorioEnv(gym.Env):
         options: Optional[dict] = None,
         entity_cost_scale: float = PpoArgs.entity_cost_scale,
         reward_symlog_r0: float = PpoArgs.reward_symlog_r0,
+        train_kinds: Optional[typing.Sequence[LessonKind]] = None,
     ):
         super().__init__()
+        if train_kinds is not None and len(train_kinds) == 0:
+            raise ValueError("train_kinds must be None (= all) or non-empty")
+        # Kinds the random-sampling reset path draws from (None = every
+        # LessonKind). Only training rollouts restrict this; eval passes an
+        # explicit kind per seed and is unaffected.
+        self._train_kinds = list(train_kinds) if train_kinds is not None else None
         if entity_cost_scale < 0:
             raise ValueError("entity_cost_scale must be non-negative")
         if reward_symlog_r0 < 0:
@@ -806,7 +833,7 @@ class FactorioEnv(gym.Env):
         kind_opt = self._reset_options.get('kind', None)
         factory = None
         if kind_opt is None:
-            kinds_list = list(LessonKind)
+            kinds_list = self._train_kinds or list(LessonKind)
             for _ in range(16):
                 kind = kinds_list[int(self.np_random.integers(0, len(kinds_list)))]
                 factory = build_factory(
@@ -1914,6 +1941,10 @@ if __name__ == "__main__":
         print("AMP: bf16 autocast enabled for forward passes")
 
     print(f"Setting up envs with {args}")
+    train_kinds = train_kinds_from_args(args)
+    if train_kinds is not None:
+        print(f"Training kinds: {[k.name for k in train_kinds]} "
+              f"(excluded: {args.exclude_train_kinds})")
     env_thunks = [
         make_env(
             args.env_id,
@@ -1923,6 +1954,7 @@ if __name__ == "__main__":
             run_name,
             args.entity_cost_scale,
             args.reward_symlog_r0,
+            train_kinds,
         )
         for i in range(args.num_envs)
     ]
@@ -2535,6 +2567,7 @@ if __name__ == "__main__":
                     run_name,
                     args.entity_cost_scale,
                     args.reward_symlog_r0,
+                    train_kinds,
                 )
                 for i in range(num_render_envs)
             ])

--- a/tests/test_train_kind_filter.py
+++ b/tests/test_train_kind_filter.py
@@ -1,0 +1,62 @@
+"""PpoArgs.exclude_train_kinds: the training-mix kind filter.
+
+Deep trials (depth 2/3) have delivered zero reward in every recorded run yet
+consume ~30% of env steps; the default excludes them from training sampling
+while the eval set still scores every kind.
+"""
+
+import os
+import sys
+
+import pytest
+
+os.environ["WANDB_MODE"] = "disabled"
+os.environ["WANDB_DISABLED"] = "true"
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from factorion import LessonKind  # noqa: E402
+from ppo import FactorioEnv, train_kinds_from_args  # noqa: E402
+from training_config import PpoArgs  # noqa: E402
+
+
+def test_default_excludes_only_the_deep_trials():
+    kinds = train_kinds_from_args(PpoArgs())
+    assert kinds is not None
+    names = {k.name for k in kinds}
+    assert "TRIAL_RECIPE_TREE_DEPTH_2" not in names
+    assert "TRIAL_RECIPE_TREE_DEPTH_3" not in names
+    assert names == {k.name for k in LessonKind} - {
+        "TRIAL_RECIPE_TREE_DEPTH_2", "TRIAL_RECIPE_TREE_DEPTH_3"
+    }
+    assert "TRIAL_RECIPE_TREE_DEPTH_1" in names, "depth-1 must stay trainable"
+
+
+def test_empty_exclusion_means_all_kinds():
+    assert train_kinds_from_args(PpoArgs(exclude_train_kinds="")) is None
+
+
+def test_unknown_name_is_rejected():
+    with pytest.raises(ValueError, match="unknown LessonKind"):
+        train_kinds_from_args(PpoArgs(exclude_train_kinds="NOT_A_KIND"))
+
+
+def test_env_only_samples_allowed_kinds():
+    """Across many episode resets the env draws exclusively from train_kinds;
+    an explicit per-reset kind still overrides the filter (the eval path)."""
+    allowed = [LessonKind.MOVE_ONE_ITEM, LessonKind.MOVE_ONE_ITEM_CHAOS]
+    env = FactorioEnv(size=11, max_steps=10, idx=0, train_kinds=allowed)
+    seen = set()
+    for seed in range(25):
+        env.reset(seed=seed)
+        seen.add(env._kind)
+    assert seen <= set(allowed)
+    assert len(seen) > 1, "sampling should reach more than one allowed kind"
+
+    env.reset(seed=0, options={"kind": LessonKind.TRIAL_RECIPE_TREE_DEPTH_2})
+    assert env._kind == LessonKind.TRIAL_RECIPE_TREE_DEPTH_2
+
+
+def test_env_rejects_empty_kind_list():
+    with pytest.raises(ValueError, match="non-empty"):
+        FactorioEnv(size=11, max_steps=10, idx=0, train_kinds=[])

--- a/training_config.py
+++ b/training_config.py
@@ -137,6 +137,15 @@ class PpoArgs(SharedArgs):
     clip_vloss: bool = True
     """Toggles whether or not to use a clipped loss for the value function, as per the paper."""
 
+    exclude_train_kinds: str = (
+        "TRIAL_RECIPE_TREE_DEPTH_2,TRIAL_RECIPE_TREE_DEPTH_3"
+    )
+    """comma-separated LessonKind names excluded from TRAINING episode sampling
+    (the eval set still covers every kind). Default drops the deep trials:
+    they have delivered exactly zero reward in every recorded run at every
+    scale (0 successes up to 40M steps), yet their ~80-step episodes consume
+    ~30% of all env steps — reallocating those steps to kinds with gradient
+    signal is free. Empty string = train on everything."""
     ent_coef_start: float = 0.008034
     """entropy coefficient at the start of training (high = more exploration)"""
     ent_coef_end: float = 0.0007372


### PR DESCRIPTION
## What

A `PpoArgs.exclude_train_kinds` filter on the env's random-kind reset sampler, defaulting to `TRIAL_RECIPE_TREE_DEPTH_2,TRIAL_RECIPE_TREE_DEPTH_3`. Training rollouts stop sampling the deep trials; the eval set is untouched and still scores every kind. Explicit per-reset kinds (the eval path) bypass the filter. ~60 lines including tests; empty string restores training-on-everything.

## Why (hypothesis)

Depth-2/3 trial episodes are a measured-zero-gradient compute sink:

- They have delivered **exactly 0 reward in every recorded run at every scale** — 0 in all four compares this week, 0 in the 10M run (`seug3e5t`), 0 at 40M (`gs1nqoni` era). Depth-1 delivers rarely but really (rollout 0.04–0.09, spikes 0.23).
- Trial episodes run ~80 steps vs ~13 for lessons, so 3 uniform trial kinds ≈ **60–65% of all env steps**; the two deep ones alone ≈ 30%. A third of the training budget produces no reward signal and (worse) fills the PPO batch with terminal-reward-0 transitions.

Dropping them from *training only* reallocates that ~30% to depth-1 + lessons. `eval/trial_thput` still pools depths 2–3 — at their unconditional 0 — so the pooled metric cannot lose from the exclusion itself and gains iff depth-1 improves with ~3× the exposure.

This is *not* giving up on deep trials: they stay in eval as the long-horizon scoreboard, and they re-enter training the moment something (staged credit #357, SIL #358) gives them a nonzero success rate to learn from. It's the RLVR-style difficulty filter: don't spend rollouts on problems the current policy solves 0% of.

## Predictions (before the compare)

1. `eval/TRIAL_RECIPE_TREE_DEPTH_1/thput` smoothed-final > main (≈3× the training exposure).
2. Pooled `eval/trial_thput` smoothed-final ≥ main (arithmetic consequence of 1; depths 2–3 contribute 0 on both sides).
3. `eval/thput` ≥ main (lessons also gain step share; batches carry a higher fraction of reward-bearing transitions).
4. `eval/TRIAL_RECIPE_TREE_DEPTH_2/thput` and `_3` stay 0 on both sides (nothing lost — if main's side ever shows >0 here, this PR's premise needs re-examination).
5. `rollout/trial_length`-driven batch composition shifts: mean `rollout/length` down, more episodes per iteration.

Analysis by smoothed final values (σ=12, last-quartile means); noise floor from the #370 post-mortem: ±0.02 `eval/thput` at 1 seed from hardware nondeterminism alone.

## Testing

`tests/test_train_kind_filter.py` (default excludes exactly the two deep trials; empty = all; unknown names rejected; env samples only allowed kinds over many resets while explicit eval kinds bypass; empty list rejected). `ruff`, `ty`, smoke test green locally; full suites in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYAAUaTkkMyHYZmkdwkEgB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYAAUaTkkMyHYZmkdwkEgB)_