### PR TITLE
E4b: self-imitate archived successful trial episodes (SIL, #358)

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -380,6 +380,89 @@ def _rollout_episode_metrics(
     }
 
 
+class SilArchive:
+    """Ring buffer of transitions from successful episodes, replayed by the
+    self-imitation step (#358). Stores (obs, action, discounted-return)
+    triples; capacity in transitions, oldest overwritten first."""
+
+    def __init__(self, capacity: int, obs_shape: tuple):
+        if capacity <= 0:
+            raise ValueError("capacity must be positive")
+        self._obs = np.zeros((capacity,) + obs_shape, dtype=np.float32)
+        self._act = np.zeros((capacity, 7), dtype=np.int64)
+        self._ret = np.zeros(capacity, dtype=np.float32)
+        self._next = 0
+        self._size = 0
+
+    def __len__(self) -> int:
+        return self._size
+
+    def add_episode(self, obs_list, act_list, terminal_reward: float, gamma: float):
+        """Store one episode. The reward is terminal-only, so the return at
+        step t of a T-step episode is gamma^(T-1-t) * terminal_reward."""
+        T = len(obs_list)
+        for t, (o, a) in enumerate(zip(obs_list, act_list)):
+            i = self._next
+            self._obs[i] = o
+            self._act[i] = a
+            self._ret[i] = terminal_reward * gamma ** (T - 1 - t)
+            self._next = (self._next + 1) % self._obs.shape[0]
+            self._size = min(self._size + 1, self._obs.shape[0])
+
+    def sample(self, batch_size: int, rng: np.random.Generator):
+        idx = rng.integers(0, self._size, size=batch_size)
+        return self._obs[idx], self._act[idx], self._ret[idx]
+
+
+class SilEpisodeTracker:
+    """Assembles per-env episodes host-side during the rollout and archives
+    the successful trial ones.
+
+    Gymnasium's NEXT_STEP autoreset makes the step after a termination junk
+    (the action is swallowed, #233), so that step is skipped rather than
+    recorded as the new episode's first pair.
+    """
+
+    def __init__(self, num_envs: int, archive: SilArchive, gamma: float):
+        self._bufs: list[tuple[list, list]] = [([], []) for _ in range(num_envs)]
+        self._skip = [False] * num_envs
+        self.archive = archive
+        self.gamma = gamma
+        self.episodes_stored = 0
+
+    def step(self, obs_ECWH, action_EA, reward_E, done_E, kind_E):
+        """Record one vector-env step: the obs each env acted FROM, the action
+        taken, and the step's reward/done/kind. ``obs_ECWH`` must not be a
+        view of a buffer the caller will overwrite (slices of it are kept
+        until the episode ends)."""
+        for i in range(len(self._bufs)):
+            if self._skip[i]:
+                self._skip[i] = False
+                continue
+            obs_buf, act_buf = self._bufs[i]
+            obs_buf.append(obs_ECWH[i])
+            act_buf.append(np.array(action_EA[i], copy=True))
+            if done_E[i]:
+                reward = float(reward_E[i])
+                if LESSON_IS_TRIAL[LessonKind(int(kind_E[i]))] and reward > 0:
+                    self.archive.add_episode(obs_buf, act_buf, reward, self.gamma)
+                    self.episodes_stored += 1
+                self._bufs[i] = ([], [])
+                self._skip[i] = True
+
+
+def _sil_losses(logp_B, value_B, returns_B):
+    """SIL's two loss terms (Oh et al. 2018): imitate only where the achieved
+    return beats the current value estimate. Returns (policy_loss, value_loss,
+    positive-advantage fraction) — the advantage is detached, so the policy
+    term pushes log-prob only and the value term only pulls V up toward R."""
+    adv_B = (returns_B - value_B).detach().clamp(min=0)
+    policy_loss = -(logp_B * adv_B).mean()
+    value_loss = 0.5 * (returns_B - value_B).clamp(min=0).pow(2).mean()
+    frac_pos = (adv_B > 0).float().mean()
+    return policy_loss, value_loss, frac_pos
+
+
 def _explained_variance(y_true: np.ndarray, y_pred: np.ndarray) -> float:
     """1 - Var(y_true - y_pred) / Var(y_true). NaN for a constant y_true."""
     if y_true.size == 0:
@@ -1870,6 +1953,9 @@ if __name__ == "__main__":
                 wandb.define_metric(f"critic/{ln}/{m}", summary="last")
         for m in ["lr", "critic_lr", "ent_coef", "grad_norm", "critic_warmup"]:
             wandb.define_metric(f"optim/{m}", summary="last")
+        for m in ["policy_loss", "value_loss", "frac_positive_adv",
+                  "buffer_size", "episodes_stored"]:
+            wandb.define_metric(f"sil/{m}", summary="last")
         for m in ["sps", "rollout_seconds", "update_seconds", "eval_seconds"]:
             wandb.define_metric(f"perf/{m}", summary="last")
     print("Registering factorio Gym env")
@@ -2077,6 +2163,17 @@ if __name__ == "__main__":
             'num_missing_entities': float('inf'),
         }
     )
+    # Self-imitation state (#358). The tracker needs the obs each env acted
+    # FROM as a stable host array: SyncVectorEnv reuses its observation buffer
+    # across steps, so a copy is taken per step (num_envs x C x W x H floats —
+    # microseconds against the ~1ms env step).
+    if args.sil_updates_per_iter > 0:
+        sil_archive = SilArchive(args.sil_buffer_size, obs_shape)
+        sil_tracker = SilEpisodeTracker(args.num_envs, sil_archive, args.gamma)
+        sil_obs_host = np.array(next_obs_ECWH, dtype=np.float32, copy=True)
+    else:
+        sil_archive, sil_tracker, sil_obs_host = None, None, None
+    sil_rng = np.random.default_rng(args.seed)
     next_obs_ECWH = torch.as_tensor(np.array(next_obs_ECWH), dtype=torch.float32, device=device)
     next_done = torch.zeros(args.num_envs, dtype=torch.float32, device=device)
     # Lesson currently loaded in each env, tracked host-side. Can't read
@@ -2224,6 +2321,11 @@ if __name__ == "__main__":
             next_obs_ECWH, reward, terminations, truncations, infos = envs.step(action_ED_numpy)
             next_done = np.logical_or(terminations, truncations)
             rewards_SE[step] = torch.as_tensor(reward, dtype=torch.float32, device=device)
+            if sil_tracker is not None:
+                # current_kind_E still names the episode each env just acted
+                # in (the autoreset refresh happens below).
+                sil_tracker.step(sil_obs_host, action_EA_np, reward, next_done, current_kind_E)
+                sil_obs_host = np.array(next_obs_ECWH, dtype=np.float32, copy=True)
             # Refresh the tracker for envs that reset this step (autoreset
             # surfaces the new episode's kind, masked by infos["_kind"]).
             if "kind" in infos:
@@ -2412,6 +2514,51 @@ if __name__ == "__main__":
                 f"or a rollout/update bookkeeping mismatch."
             )
 
+        # ── Self-imitation updates (#358): replay archived successful trial
+        # episodes so rare deliveries compound. Eager forward on the plain
+        # module (the compiled handles above are separate callables), so the
+        # CUDA-graph pools are untouched. Skipped during warmup — the actor is
+        # frozen and the archive is empty that early anyway.
+        sil_metrics: dict[str, float] = {}
+        sil_seconds = 0.0
+        if (
+            sil_archive is not None
+            and not in_warmup
+            and len(sil_archive) >= args.sil_batch_size
+        ):
+            t_sil = time.time()
+            sil_p_sum = sil_v_sum = sil_pos_sum = 0.0
+            for _ in range(args.sil_updates_per_iter):
+                obs_np, act_np, ret_np = sil_archive.sample(args.sil_batch_size, sil_rng)
+                sil_obs_B = torch.as_tensor(obs_np, device=device)
+                sil_act_B = torch.as_tensor(act_np, device=device)
+                sil_ret_B = torch.as_tensor(ret_np, device=device)
+                _a, sil_logp_B, _e, sil_value_B = agent.get_action_and_value(
+                    sil_obs_B, sil_act_B
+                )
+                sil_policy_loss, sil_value_loss, sil_frac_pos = _sil_losses(
+                    sil_logp_B, sil_value_B.reshape(-1), sil_ret_B
+                )
+                sil_loss = sil_policy_loss + args.sil_value_coef * sil_value_loss
+                optimizer.zero_grad(set_to_none=True)
+                sil_loss.backward()
+                nn.utils.clip_grad_norm_(agent.parameters(), args.max_grad_norm)
+                optimizer.step()
+                sil_p_sum += float(sil_policy_loss)
+                sil_v_sum += float(sil_value_loss)
+                sil_pos_sum += float(sil_frac_pos)
+            n = args.sil_updates_per_iter
+            sil_seconds = time.time() - t_sil
+            sil_metrics = {
+                "sil/policy_loss": sil_p_sum / n,
+                "sil/value_loss": sil_v_sum / n,
+                "sil/frac_positive_adv": sil_pos_sum / n,
+            }
+        if sil_archive is not None and sil_tracker is not None:
+            sil_metrics["sil/buffer_size"] = float(len(sil_archive))
+            sil_metrics["sil/episodes_stored"] = float(sil_tracker.episodes_stored)
+            sil_metrics["perf/sil_seconds"] = sil_seconds
+
         # Value-head (critic) diagnostics, global + per-lesson.
         keep_B = valid_B.cpu().numpy() > 0  # drop the autoreset junk (#233)
         critic_metrics = _critic_diagnostics(
@@ -2463,6 +2610,7 @@ if __name__ == "__main__":
         for h, s in _head_ent_sum.items():
             iter_metrics[f"policy/entropy_{h}"] = float(s) / n_steps
         iter_metrics.update(critic_metrics)
+        iter_metrics.update(sil_metrics)
         iter_metrics.update(eval_metrics)
 
         if iteration == 1:

--- a/tests/test_sil.py
+++ b/tests/test_sil.py
@@ -1,0 +1,108 @@
+"""Self-imitation (#358): archive, episode tracker, and loss gating."""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+import torch
+
+os.environ["WANDB_MODE"] = "disabled"
+os.environ["WANDB_DISABLED"] = "true"
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from factorion import LessonKind  # noqa: E402
+from ppo import SilArchive, SilEpisodeTracker, _sil_losses  # noqa: E402
+
+OBS_SHAPE = (5, 3, 3)
+TRIAL = LessonKind.TRIAL_RECIPE_TREE_DEPTH_1.value
+LESSON = LessonKind.MOVE_ONE_ITEM.value
+
+
+def _episode(n, fill):
+    obs = [np.full(OBS_SHAPE, fill + t, dtype=np.float32) for t in range(n)]
+    act = [np.full(7, t, dtype=np.int64) for t in range(n)]
+    return obs, act
+
+
+class TestSilArchive:
+    def test_returns_are_terminal_reward_discounted_backwards(self):
+        arch = SilArchive(capacity=10, obs_shape=OBS_SHAPE)
+        obs, act = _episode(3, fill=0)
+        arch.add_episode(obs, act, terminal_reward=2.0, gamma=0.5)
+        assert len(arch) == 3
+        # gamma^(T-1-t) * r: the terminal step keeps the full reward.
+        assert arch._ret[:3] == pytest.approx([0.5, 1.0, 2.0])
+
+    def test_ring_overwrites_oldest(self):
+        arch = SilArchive(capacity=4, obs_shape=OBS_SHAPE)
+        arch.add_episode(*_episode(3, fill=0), terminal_reward=1.0, gamma=1.0)
+        arch.add_episode(*_episode(3, fill=100), terminal_reward=5.0, gamma=1.0)
+        assert len(arch) == 4
+        obs_np, act_np, ret_np = arch.sample(64, np.random.default_rng(0))
+        assert obs_np.shape == (64, *OBS_SHAPE)
+        assert act_np.shape == (64, 7)
+        # The first two transitions of episode one were overwritten, so every
+        # sampled return comes from {1.0 (ep1's last kept step), 5.0-chain}.
+        assert set(np.round(ret_np, 4)) <= {1.0, 5.0}
+
+
+class TestSilEpisodeTracker:
+    def _step(self, tracker, reward, done, kind, fill=0.0):
+        obs = np.full((1, *OBS_SHAPE), fill, dtype=np.float32)
+        act = np.zeros((1, 7), dtype=np.int64)
+        tracker.step(obs, act, np.array([reward]), np.array([done]),
+                     np.array([kind]))
+
+    def test_successful_trial_is_archived_with_full_episode(self):
+        arch = SilArchive(capacity=100, obs_shape=OBS_SHAPE)
+        tracker = SilEpisodeTracker(1, arch, gamma=1.0)
+        self._step(tracker, 0.0, False, TRIAL)
+        self._step(tracker, 0.0, False, TRIAL)
+        self._step(tracker, 3.0, True, TRIAL)
+        assert tracker.episodes_stored == 1
+        assert len(arch) == 3
+
+    def test_zero_reward_trial_and_lesson_success_are_not_archived(self):
+        arch = SilArchive(capacity=100, obs_shape=OBS_SHAPE)
+        tracker = SilEpisodeTracker(1, arch, gamma=1.0)
+        self._step(tracker, 0.0, True, TRIAL)     # trial, no delivery
+        self._step(tracker, 0.0, False, LESSON)   # autoreset junk (skipped)
+        self._step(tracker, 7.0, True, LESSON)    # lesson success: not SIL's job
+        assert tracker.episodes_stored == 0
+        assert len(arch) == 0
+
+    def test_autoreset_junk_step_is_not_recorded(self):
+        """The step after a done is Gymnasium's swallowed-action reset step
+        (#233); it must not become the next episode's first transition."""
+        arch = SilArchive(capacity=100, obs_shape=OBS_SHAPE)
+        tracker = SilEpisodeTracker(1, arch, gamma=1.0)
+        self._step(tracker, 1.0, True, TRIAL, fill=1)   # episode 1 (archived)
+        self._step(tracker, 0.0, False, TRIAL, fill=99)  # junk: skipped
+        self._step(tracker, 0.0, False, TRIAL, fill=2)
+        self._step(tracker, 2.0, True, TRIAL, fill=3)    # episode 2 (archived)
+        assert tracker.episodes_stored == 2
+        assert len(arch) == 3, "episode 2 has 2 steps; the junk step is absent"
+        assert not (arch._obs[:3] == 99).any()
+
+
+class TestSilLosses:
+    def test_only_returns_above_value_produce_gradient(self):
+        logp = torch.tensor([-1.0, -1.0], requires_grad=True)
+        value = torch.tensor([2.0, 0.0])
+        returns = torch.tensor([1.0, 3.0])  # below V, above V
+        p_loss, v_loss, frac_pos = _sil_losses(logp, value, returns)
+        # Only the second transition carries advantage (3 - 0 = 3).
+        assert p_loss.item() == pytest.approx(-(-1.0 * 3.0) / 2)
+        assert v_loss.item() == pytest.approx(0.5 * 9.0 / 2)
+        assert frac_pos.item() == pytest.approx(0.5)
+
+    def test_value_at_or_above_return_is_a_no_op(self):
+        logp = torch.tensor([-1.0], requires_grad=True)
+        p_loss, v_loss, frac_pos = _sil_losses(
+            logp, torch.tensor([5.0]), torch.tensor([5.0])
+        )
+        assert p_loss.item() == 0.0 and v_loss.item() == 0.0
+        p_loss.backward()
+        assert logp.grad is not None and float(logp.grad.abs().sum()) == 0.0

--- a/training_config.py
+++ b/training_config.py
@@ -137,6 +137,20 @@ class PpoArgs(SharedArgs):
     clip_vloss: bool = True
     """Toggles whether or not to use a clipped loss for the value function, as per the paper."""
 
+    sil_updates_per_iter: int = 4
+    """self-imitation (SIL, Oh et al. 2018) minibatch updates per PPO
+    iteration, replaying archived successful TRIAL episodes so a rare real
+    delivery becomes persistent training signal instead of one gradient tick
+    (#358). Trials only: lessons already deliver on-policy reward, and the
+    (R - V)+ gate would zero most of their replay anyway. 0 disables SIL
+    entirely. Skipped during critic warmup."""
+    sil_batch_size: int = 512
+    """transitions per SIL minibatch (sampled uniformly from the archive)"""
+    sil_buffer_size: int = 20_000
+    """SIL archive capacity in transitions (a ring buffer; ~250 trial
+    episodes at their typical ~80 steps). Oldest transitions overwritten."""
+    sil_value_coef: float = 0.01
+    """weight of SIL's value term 0.5*||(R - V)+||^2 (beta in the paper)"""
     ent_coef_start: float = 0.008034
     """entropy coefficient at the start of training (high = more exploration)"""
     ent_coef_end: float = 0.0007372


### PR DESCRIPTION
## What

Self-Imitation Learning (Oh et al. 2018) scoped to trials: trial episodes that end with a real delivery (terminal reward > 0) are archived into a transition ring buffer (`sil_buffer_size` = 20k transitions ≈ 250 trial episodes) and replayed after each PPO update — `sil_updates_per_iter` = 4 eager minibatches of 512 with the SIL loss:

```
adv = (R − V).detach().clamp(min=0)
L = −(logπ(a|s)·adv).mean() + sil_value_coef · 0.5·((R−V)⁺)².mean()
```

`R` is the discounted terminal reward (γ^(T−1−t)·r_T). The (R−V)⁺ gate means the policy only imitates transitions whose achieved return still beats the critic's estimate, so replay pressure decays automatically as the behavior is absorbed. `--sil-updates-per-iter 0` disables everything.

Engineering notes: the SIL forward runs **eager** on the plain module (the compiled rollout/update handles are separate callables), keeping the CUDA-graph pools untouched; the episode tracker skips Gymnasium's autoreset junk step (#233) so a swallowed action never becomes a new episode's first pair; host-side per-step obs copies cost ~150 KB/step against a ~1 ms env step.

## Why (hypothesis)

The core trial problem (#371 diagnosis) is that on-policy successes exist but don't compound: depth-1 trial rollouts deliver 0.04–0.09 normalized with spikes to 0.23, and each success contributes one gradient tick before vanishing. This is the textbook sparse-success regime SIL was built for — and unlike the refuted connectivity shaping (#370: a proxy objective the policy learned to farm), SIL is **delivery-aligned by construction**: only episodes that actually delivered are ever imitated, so there is no proxy to exploit.

Trials-only scoping because lessons already deliver dense on-policy reward (their replay would be gated to ~zero by (R−V)⁺ anyway), and because the goal metric is `eval/trial_thput`.

## Predictions (before the compare)

1. **Mechanism**: `sil/episodes_stored` grows steadily (main's rollouts show a few dozen depth-1 deliveries per 2M steps); `sil/frac_positive_adv` starts high and decays as the policy absorbs the archive.
2. **Primary**: smoothed-final `eval/TRIAL_RECIPE_TREE_DEPTH_1/thput` and pooled `eval/trial_thput` > main — successful build patterns get replayed hundreds of times instead of once.
3. `rollout/TRIAL_RECIPE_TREE_DEPTH_1/thput` trends up rather than flat — the amplification loop (more successes → more replay → more successes) is the whole point.
4. **Guardrail**: `eval/thput` within noise (±0.02–0.03 at 1 seed per #371's measured floor) — SIL touches shared weights, so some lesson interference is possible; the gate is no *significant* regression.
5. Failure mode to watch: overfitting to a few archived layouts — `sil/frac_positive_adv` pinned near 1.0 with `eval/trial_thput` flat would mean the critic never catches up and replay never converges.

## Testing

`tests/test_sil.py`: archive return discounting and ring overwrite; tracker archives successful trials only (zero-reward trials and lesson successes excluded), skips the autoreset junk step; loss gating (value ≥ return ⇒ exactly zero gradient). Plus lint/types/smoke and a direct eager exercise of the SIL update path (archive → sample → forward → backward → step). Full suites in CI.

## Compare

Queued — E3 (#374) and E4a (#375) hold the two compare slots; launching when one frees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYAAUaTkkMyHYZmkdwkEgB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYAAUaTkkMyHYZmkdwkEgB)_