### PR TITLE
E6: FACTORY_1_INGREDIENT_EDGE — a solvable lesson with trial-style edge markers

### DIFF
--- a/factorion_rs/src/factory_gen.rs
+++ b/factorion_rs/src/factory_gen.rs
@@ -47,6 +47,7 @@ pub enum LessonKind {
     TrialRecipeTreeDepth1 = 16,
     TrialRecipeTreeDepth2 = 17,
     TrialRecipeTreeDepth3 = 18,
+    Factory1IngredientEdge = 19,
 }
 
 impl LessonKind {
@@ -70,6 +71,7 @@ impl LessonKind {
             16 => Some(LessonKind::TrialRecipeTreeDepth1),
             17 => Some(LessonKind::TrialRecipeTreeDepth2),
             18 => Some(LessonKind::TrialRecipeTreeDepth3),
+            19 => Some(LessonKind::Factory1IngredientEdge),
             _ => None,
         }
     }
@@ -108,6 +110,7 @@ impl LessonKind {
             LessonKind::MoveOneItemChaos => "MOVE_ONE_ITEM_CHAOS",
             LessonKind::CrossUnderBelt => "CROSS_UNDER_BELT",
             LessonKind::Factory1Ingredient => "FACTORY_1_INGREDIENT",
+            LessonKind::Factory1IngredientEdge => "FACTORY_1_INGREDIENT_EDGE",
             LessonKind::TrialRecipeTreeDepth1 => "TRIAL_RECIPE_TREE_DEPTH_1",
             LessonKind::TrialRecipeTreeDepth2 => "TRIAL_RECIPE_TREE_DEPTH_2",
             LessonKind::TrialRecipeTreeDepth3 => "TRIAL_RECIPE_TREE_DEPTH_3",
@@ -141,6 +144,7 @@ pub fn all_lesson_kinds() -> &'static [LessonKind] {
         LessonKind::MoveOneItemChaos,
         LessonKind::CrossUnderBelt,
         LessonKind::Factory1Ingredient,
+        LessonKind::Factory1IngredientEdge,
         LessonKind::TrialRecipeTreeDepth1,
         LessonKind::TrialRecipeTreeDepth2,
         LessonKind::TrialRecipeTreeDepth3,
@@ -616,7 +620,12 @@ pub fn build_factory(
         LessonKind::CrossUnderBelt => {
             build_cross_under_belt(size, &mut rng, random_item, max_entities)
         }
-        LessonKind::Factory1Ingredient => build_factory_1_ingredient(size, &mut rng, max_entities),
+        LessonKind::Factory1Ingredient => {
+            build_factory_1_ingredient(size, &mut rng, max_entities, false)
+        }
+        LessonKind::Factory1IngredientEdge => {
+            build_factory_1_ingredient(size, &mut rng, max_entities, true)
+        }
         LessonKind::TrialRecipeTreeDepth1 => build_recipe_tree_trial(size, &mut rng, 1),
         LessonKind::TrialRecipeTreeDepth2 => build_recipe_tree_trial(size, &mut rng, 2),
         LessonKind::TrialRecipeTreeDepth3 => build_recipe_tree_trial(size, &mut rng, 3),
@@ -2480,10 +2489,17 @@ fn tunnels_crossed(paths: &[&[UgPlacement]]) -> bool {
 /// directions of its lane are tried, keeping the combination with the
 /// shortest route (ties random): a player rotates the source/sink and feeds
 /// the lane from whichever end gives the shortest belt line.
+/// With `edge_markers`, the source/sink use the trial marker convention
+/// (`build_recipe_tree_trial`): both sit on the grid edge, the source facing
+/// its wall's inward normal and the sink facing outward (pulling from its
+/// interior neighbour). This makes the lesson's observation — a blank grid
+/// with edge markers — match what a trial episode presents, while still
+/// carrying a known solution.
 fn build_factory_1_ingredient(
     size: usize,
     rng: &mut Rng,
     max_entities: f64,
+    edge_markers: bool,
 ) -> Option<BuiltFactory> {
     let s = size as i64;
     // Canonical footprint is 7 rows: input lane, input inserters, 3 assembler
@@ -2575,15 +2591,19 @@ fn build_factory_1_ingredient(
         // well as top/bottom. (No assembler-perimeter exclusion is needed:
         // every perimeter cell lies strictly between the two bands.)
         let free = available_cells(s, &reserved);
+        let on_edge =
+            |&(x, y): &Cell| !edge_markers || x == 0 || x == s - 1 || y == 0 || y == s - 1;
         let src_band: Vec<Cell> = free
             .iter()
             .copied()
             .filter(|&(_, y)| y <= in_lane_y)
+            .filter(on_edge)
             .collect();
         let snk_band: Vec<Cell> = free
             .iter()
             .copied()
             .filter(|&(_, y)| y >= out_lane_y)
+            .filter(on_edge)
             .collect();
         if src_band.is_empty() || snk_band.is_empty() {
             continue;
@@ -2610,7 +2630,11 @@ fn build_factory_1_ingredient(
         // cell (which must stay empty: sinks connect like belts, so a sink
         // pointing into a belt would FEED it, and output items leaking back
         // close a cycle the throughput engine scores as a dead factory).
-        let mut facing_choices = DIRS;
+        let mut facing_choices: Vec<Direction> = if edge_markers {
+            inward_normals(source_pos, s)
+        } else {
+            DIRS.to_vec()
+        };
         rng.shuffle(&mut facing_choices);
         let mut dir_choices = [Direction::East, Direction::West];
         rng.shuffle(&mut dir_choices);
@@ -2674,6 +2698,12 @@ fn build_factory_1_ingredient(
         // arrive on the exit cell travelling the lane direction (from the
         // lane belt behind it, or dropped by the inserter above it), which
         // also rules out a 180° reversal.
+        if edge_markers {
+            facing_choices = inward_normals(sink_pos, s)
+                .into_iter()
+                .map(Direction::opposite)
+                .collect();
+        }
         rng.shuffle(&mut facing_choices);
         rng.shuffle(&mut dir_choices);
         // (sink_dir, out_dir, exit, route)
@@ -3446,6 +3476,50 @@ mod tests {
         }
         assert!(built > 40, "most seeds should build, got {built}");
         assert!(asm_counts.len() > 1, "assembler count never varied");
+    }
+
+    #[test]
+    fn test_factory_1_ingredient_edge_markers() {
+        // Both markers follow the trial convention: on the grid edge, source
+        // facing its wall's inward normal, sink facing outward (so it pulls
+        // from its interior neighbour).
+        let s = 11i64;
+        let mut built = 0;
+        for seed in 0..50u64 {
+            let Some(f) = build_factory(
+                s as usize,
+                LessonKind::Factory1IngredientEdge,
+                seed,
+                true,
+                f64::INFINITY,
+            ) else {
+                continue;
+            };
+            built += 1;
+            let (tp, unreachable) = tp_unreachable(&f.world);
+            assert!(tp > 0.0, "seed={seed}");
+            assert_eq!(unreachable, 0, "seed={seed} has orphan tiles");
+            for x in 0..f.world.width() {
+                for y in 0..f.world.height() {
+                    let cell = (x as i64, y as i64);
+                    let dir = f.world.direction_at(x, y);
+                    match f.world.entity_at(x, y) {
+                        Some(Item::Source) => assert!(
+                            inward_normals(cell, s).contains(&dir),
+                            "seed={seed}: source at {cell:?} facing {dir:?} \
+                             is not on the edge working inward"
+                        ),
+                        Some(Item::Sink) => assert!(
+                            inward_normals(cell, s).contains(&dir.opposite()),
+                            "seed={seed}: sink at {cell:?} facing {dir:?} \
+                             is not on the edge facing outward"
+                        ),
+                        _ => {}
+                    }
+                }
+            }
+        }
+        assert!(built > 40, "most seeds should build, got {built}");
     }
 
     /// Every ingredient of `item`'s recipe either is a source or is itself


### PR DESCRIPTION
## Hypothesis

`eval/trial_thput` is stuck near zero because trials are the **only** place the policy ever sees the trial observation regime — bare markers on the grid edge, everything else blank — and in that regime it gets ~zero on-policy reward, hence no gradient (#371's core diagnosis). Every existing lesson puts markers at interior cells, so nothing rewardable teaches "markers on the wall → route inward, place an assembler, route out."

This PR adds the missing transfer bridge: **`FACTORY_1_INGREDIENT_EDGE`**, which is `FACTORY_1_INGREDIENT` with the trial marker convention — source on the grid edge facing its wall's inward normal, sink on the edge facing outward, pulling from its interior neighbour (exactly `build_recipe_tree_trial`'s geometry). Since PPO blanks every episode fully, an episode of this lesson presents **the same observation class as a depth-1 trial with one ingredient**, but with a known solution, a simulated `max_throughput` reference, and — crucially — a reward the current policy can actually reach.

Supporting evidence that transfer along this axis is real: the SFT base already scores 0.075 on `TRIAL_RECIPE_TREE_DEPTH_1` *without any trial training at all* — pure transfer from interior-marker lessons. Closing the geometry gap should widen that channel.

## Diff

One file, +76/−2: `build_factory_1_ingredient` gains an `edge_markers: bool` (marker cells restricted to edge cells of their band; source facings restricted to `inward_normals`, sink facings to their opposites), a new `LessonKind::Factory1IngredientEdge = 19` wired through `from_i64`/`name`/`all_lesson_kinds`/dispatch, and a Rust test asserting the marker convention across 50 seeds. The non-edge path consumes the RNG stream identically to before, so existing `FACTORY_1_INGREDIENT` factories are bit-for-bit unchanged per seed. The no-orphan invariant test picks the new kind up automatically. The Python `LessonKind` derives from `py_lesson_kinds()`, so the train + eval mixes include the new lesson with no Python changes.

## Pre-registered predictions

1. `rollout/FACTORY_1_INGREDIENT_EDGE/thput` climbs well above 0 (the policy can learn it — it's FACTORY_1_INGREDIENT-difficulty, which sits ~0.3).
2. **Primary gate:** `eval/TRIAL_RECIPE_TREE_DEPTH_1/thput` (smoothed final) > main's. This is the transfer claim.
3. `eval/trial_thput` ≥ main (would follow from 2, since depth-1 is its only nonzero component).
4. Shared-kind eval metrics (each `eval/<KIND>/thput` for the 14 pre-existing kinds) within noise of main.

**Falsified if** prediction 1 holds but prediction 2 doesn't — that would mean the policy masters edge-marker factories yet nothing transfers to trials, killing the "geometry gap" hypothesis (post-mortem: the gap is the recipe tree / item identity, not marker geometry).

## ⚠️ Metric comparability

Adding a lesson kind changes the eval pool: the PR side pools **15** kinds into `eval/thput` / `rollout/thput` where main pools 14. The pooled aggregates are therefore **not cross-side comparable** on this compare — judge on per-kind metrics (`eval/TRIAL_RECIPE_TREE_DEPTH_1/thput` and the 14 shared kinds) and on `eval/trial_thput` (trial pool is unchanged). Recorded in #371.

## Plan

1-seed `/ci compare ppo --start-from h76h80yb --total-timesteps 2000000`; if prediction 2 looks good, +2 seeds and paired stats on the per-kind metrics. Analysis via smoothed finals from the W&B API, never the report's `summary=max` asserts.

Part of the PPO-training investigation tracked in #371.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYAAUaTkkMyHYZmkdwkEgB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYAAUaTkkMyHYZmkdwkEgB)_