### PR TITLE
E7: partial blanking — uniform-random missing-entity count per PPO episode

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -784,7 +784,12 @@ class FactorioEnv(gym.Env):
         self._terminated = False
         self._truncated = False
         self.max_entities = 2
-        self._num_missing_entities = self._reset_options.get('num_missing_entities', float('inf'))
+        nme = self._reset_options.get('num_missing_entities', float('inf'))
+        if nme == 'uniform':
+            # Fresh draw per episode (np_random was just reseeded above, so
+            # the draw is deterministic per episode seed).
+            nme = int(self.np_random.integers(1, self.size * self.size + 1))
+        self._num_missing_entities = nme
 
         self.actions = []
         # Running count of valid non-empty placements, kept incrementally instead
@@ -2074,7 +2079,8 @@ if __name__ == "__main__":
     next_obs_ECWH, reset_infos = envs.reset(
         seed=args.seed,
         options={
-            'num_missing_entities': float('inf'),
+            'num_missing_entities':
+                'uniform' if args.partial_blanking else float('inf'),
         }
     )
     next_obs_ECWH = torch.as_tensor(np.array(next_obs_ECWH), dtype=torch.float32, device=device)

--- a/tests/test_partial_blanking.py
+++ b/tests/test_partial_blanking.py
@@ -1,0 +1,52 @@
+"""Tests for the 'uniform' num_missing_entities reset option (partial blanking)."""
+
+import os
+import sys
+
+os.environ["WANDB_MODE"] = "disabled"
+os.environ["WANDB_DISABLED"] = "true"
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from factorion import LessonKind  # noqa: E402
+from ppo import FactorioEnv  # noqa: E402
+
+SIZE = 11
+OPTS = {"num_missing_entities": "uniform", "kind": LessonKind.FACTORY_1_INGREDIENT}
+
+
+def _missing(seed: int) -> int:
+    env = FactorioEnv(size=SIZE, idx=0)
+    env.reset(seed=seed, options=OPTS)
+    return env.min_entities_required
+
+
+def test_uniform_blanking_varies_across_episodes():
+    counts = {_missing(seed) for seed in range(20)}
+    assert len(counts) > 1, f"blank count never varied: {counts}"
+    assert all(c >= 1 for c in counts)
+
+
+def test_uniform_blanking_deterministic_per_seed():
+    assert _missing(7) == _missing(7)
+
+
+def test_numeric_option_still_exact():
+    env = FactorioEnv(size=SIZE, idx=0)
+    env.reset(seed=3, options={"num_missing_entities": 2,
+                               "kind": LessonKind.FACTORY_1_INGREDIENT})
+    assert env.min_entities_required == 2
+
+
+def test_uniform_can_leave_factory_partially_built():
+    # With draws in [1, size*size] and FACTORY_1_INGREDIENT factories holding
+    # tens of removable units, some seeds must draw below the removable count.
+    for seed in range(40):
+        env = FactorioEnv(size=SIZE, idx=0)
+        env.reset(seed=seed, options=OPTS)
+        env_full = FactorioEnv(size=SIZE, idx=0)
+        env_full.reset(seed=seed, options={"num_missing_entities": float("inf"),
+                                           "kind": LessonKind.FACTORY_1_INGREDIENT})
+        if env.min_entities_required < env_full.min_entities_required:
+            return
+    raise AssertionError("no seed in 0..39 produced a partial blank")

--- a/training_config.py
+++ b/training_config.py
@@ -137,6 +137,13 @@ class PpoArgs(SharedArgs):
     clip_vloss: bool = True
     """Toggles whether or not to use a clipped loss for the value function, as per the paper."""
 
+    partial_blanking: bool = True
+    """blank a uniform-random number of entity units in [1, size*size] per
+    training episode instead of always the whole grid. Draws above a factory's
+    removable count blank everything, so most episodes of small factories still
+    start empty, while a fraction start near-complete and put reward within a
+    few placements. Trials are unaffected (nothing to blank). Eval always
+    blanks fully."""
     ent_coef_start: float = 0.008034
     """entropy coefficient at the start of training (high = more exploration)"""
     ent_coef_end: float = 0.0007372


### PR DESCRIPTION
Owner-directed experiment (2026-08-08): train PPO with partial blanking, `num_missing_entities` drawn uniformly from [1, size*size] per episode.

## Hypothesis

Full blanking puts reward many coordinated placements away on every episode. Partial blanks put reward within a few placements: the episode starts near-complete and the policy must place the last 1–N entities. This trains exactly the completion skill the watched episodes (#371) show is missing — greedy rollouts stop 1–3 entities short of a working factory (missing output inserter, missing assembler). Completion skill learned on partial lessons should transfer to full-blank greedy eval.

## Diff

+67/−2, no Rust changes:
- `FactorioEnv.reset` accepts `num_missing_entities: 'uniform'` → per-episode draw from `[1, size*size]` via `self.np_random` (deterministic per episode seed).
- `PpoArgs.partial_blanking: bool = True`; the training reset passes `'uniform'` when set.
- Tests: variation across episodes, per-seed determinism, numeric option unchanged, partial blanks occur.

Notes:
- Draws above a factory's removable count blank everything. A ~15-entity factory therefore still trains ~87% full-blank; big FACTORY_1_INGREDIENT factories get the most partial episodes.
- Trials have `total_entities == 0` — their training episodes are byte-identical to main. Any trial movement is transfer.
- Eval always blanks fully → `eval/*` is cross-side comparable (same 14 kinds both sides).
- `rollout/*` is NOT cross-side comparable (episode difficulty distribution changed: shorter episodes, mechanically higher rollout thput).

## Pre-registered predictions

1. **Primary gate: `eval/thput` (smoothed final) > main.** Completion skill transfers to the greedy mode.
2. `eval/FACTORY_1_INGREDIENT/thput` up vs main (largest factories → most partial episodes → most completion training).
3. `eval/trial_thput` / `eval/TRIAL_RECIPE_TREE_DEPTH_1/thput` ≥ main (near-miss completion is the observed trial failure mode; any lift here is transfer).
4. `rollout/*` shifts mechanically — excluded from judgment.

**Falsified if** `eval/thput` ≤ main. Post-mortem would echo #375 (exposure moves sampled skill, not the greedy mode) — but unlike #375 this changes the *reward distance* of training states, not just their frequency, so the mechanisms are distinct.

Plan: 1-seed 2M compare; if gate passes, +2 seeds and paired stats. Analysis via smoothed finals from the W&B API (σ≈12, last-quartile).

Part of the loop tracked in #371.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYAAUaTkkMyHYZmkdwkEgB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYAAUaTkkMyHYZmkdwkEgB)_