### PR TITLE
Decode real Factorio blueprints faithfully

### DIFF
--- a/factorion.py
+++ b/factorion.py
@@ -9,6 +9,7 @@ import base64
 import functools
 import glob
 import json
+import math
 import os
 import random
 import zlib
@@ -542,6 +543,27 @@ _BP_DIR_TO_MODEL = {
     12: Direction.WEST,
 }
 
+# The engine models one belt tier, so a higher-tier belt decodes to its yellow
+# equivalent: under-reporting speed keeps the layout intact, where dropping the
+# entity silently decodes a broken factory instead.
+_BELT_TIER_ALIASES = {
+    f"{tier}-{base}": base
+    for tier in ("fast", "express", "turbo")
+    for base in ("transport-belt", "underground-belt", "splitter")
+}
+
+# Collapsing the tiers is only sound while none of them is placeable — the fast
+# tier is already in the registry as a craftable item, but nothing that goes on
+# the grid moves faster than yellow. The day a tier becomes placeable, this
+# table starts reporting a blue belt at a yellow belt's rate, so break at
+# import rather than let that number through.
+_aliased_tiers = {name.replace("-", "_") for name in _BELT_TIER_ALIASES}
+assert not _aliased_tiers & {i.name for i in items.values() if i.is_placeable}, (
+    "a higher belt tier is placeable now, so it can no longer be aliased onto "
+    "the yellow tier: give blueprint2world the real mapping and revisit every "
+    "rate that assumed one belt speed"
+)
+
 # Arrow virtual signals in a constant-combinator marker encode the
 # source/sink direction (see factorion-mod/server/blueprint.py).
 _ARROW_TO_DIR = {
@@ -585,7 +607,7 @@ def _parse_combinator_marker(e):
 
 
 def blueprint2world(bp):
-    """Decode a Factorio 2.0 blueprint string into a (C, W, H) world
+    """Decode a Factorio blueprint string into a (C, W, H) world
     tensor matching the encoder in factorion-mod/server/blueprint.py.
 
     Conventions:
@@ -593,7 +615,8 @@ def blueprint2world(bp):
         an N×M entity rotated to occupy w×h tiles, top-left tile is
         floor(center - (w/2, h/2)).
       - Direction is a 16-step enum (0/4/8/12 = N/E/S/W). Diagonal
-        values (2/6/10/14) are rejected.
+        values (2/6/10/14) are rejected. Pre-2.0 blueprints encode the
+        same four facings in 8 steps, and are scaled up on read.
       - Inserter direction in a blueprint points to the drop tile;
         flip by +8 (mod 16) to get the pickup-pointing model
         direction.
@@ -603,7 +626,11 @@ def blueprint2world(bp):
         with the corresponding ITEMS / DIRECTION channel values.
     """
     obj = b64_to_dict(bp)
-    raw_entities = obj.get("blueprint", {}).get("entities", [])
+    blueprint = obj.get("blueprint", {})
+    raw_entities = blueprint.get("entities", [])
+    # Factorio 2.0 doubled the direction enum from 8 steps to 16; the major
+    # version sits in the top 16 bits of the packed version field.
+    dir_scale = 1 if (blueprint.get("version", 0) >> 48) >= 2 else 2
 
     # First pass: resolve each blueprint entity to a placement
     # (entity_name, top_left_x, top_left_y, w, h, direction, item_value, misc).
@@ -625,8 +652,8 @@ def blueprint2world(bp):
                 continue
             role, item_name, model_dir = parsed
             ent_name = "stack_inserter" if role == "source" else "bulk_inserter"
-            tlx = int(cx - 0.5)
-            tly = int(cy - 0.5)
+            tlx = math.floor(cx - 0.5)
+            tly = math.floor(cy - 0.5)
             item_val = 0
             if item_name is not None:
                 item_meta = str2item(item_name)
@@ -637,12 +664,12 @@ def blueprint2world(bp):
             )
             continue
 
-        proto = str2ent(name)
+        proto = str2ent(_BELT_TIER_ALIASES.get(name, name))
         if proto is None:
             print(f"WARN: skipping unknown entity {name} at ({cx},{cy})")
             continue
 
-        bp_dir = e.get("direction", 0)
+        bp_dir = e.get("direction", 0) * dir_scale
         if "inserter" in proto.name:
             # Blueprint direction = drop tile; model direction = pickup.
             bp_dir = (bp_dir + 8) % 16
@@ -658,8 +685,8 @@ def blueprint2world(bp):
         w, h = proto.width, proto.height
         if model_dir in (Direction.EAST, Direction.WEST):
             w, h = h, w
-        tlx = int(cx - w / 2)
-        tly = int(cy - h / 2)
+        tlx = math.floor(cx - w / 2)
+        tly = math.floor(cy - h / 2)
 
         item_val = 0
         if "assembling_machine" in proto.name:


### PR DESCRIPTION
P1 of the split. One file, `factorion.py`. The balancer fixtures that came out of this work are separate, in #389.

`blueprint2world` mangles essentially every blueprint the game actually produces. Three independent causes:

1. **`int()` where the docstring says `floor()`.** `tlx = int(cx - w / 2)` truncates toward zero, so an entity at a negative coordinate lands one tile off — and then overwrites whatever is already there. Real blueprints are centred on 0, so this corrupts most of them. Sliding a blueprint across the plane is a no-op in Factorio but changed the decode; that asymmetry is how it surfaced.
2. **Pre-2.0 direction enum unhandled.** 2.0 doubled the direction enum from 8 steps to 16, so a 1.x blueprint's east/west belts read as `2`/`6`, which the decoder rejects as "non-cardinal" and drops with a `WARN`. Every balancer book in circulation is 1.x.
3. **Higher-tier belts decoded to junk.** These fail two different ways, and the second is the nastier one:
   - `express-`/`turbo-` are absent from the registry entirely, so `str2ent` returns `None` and the entity is skipped, leaving a hole.
   - `fast-` **is** in the registry — as a *craftable item*, not a placeable entity. So `str2ent("fast-transport-belt")` succeeds and writes `fast_transport_belt` (`is_placeable=False`, `flow=0.0`) into the ENTITIES channel, and `fast-splitter` lands as a 1×1 instead of 2×1. A red-belt blueprint decoded into a full-looking grid of zero-flow entities at the wrong footprint. Both now alias to the yellow equivalents.

## The tier assert

Aliasing is only sound while no tier is placeable. Adding one would silently start reporting a blue belt at a yellow belt's rate, so there's now an import-time assert next to the table that fails the moment any `fast_`/`express_`/`turbo_` belt, underground or splitter becomes placeable. It deliberately tests `is_placeable` rather than mere presence, since the fast tier is already in the registry as an item.

## One thing to push back on if you disagree

**The tier aliasing is a judgement call.** A blue-belt blueprint now decodes with yellow speeds — a visible wrong number instead of today's invisible broken layout. I think that's the better failure, and the assert bounds how long it can stay wrong, but a hard error is equally defensible. Easy to switch.

**No tests in this PR** — you said not to test the decoder, so the only new assertion is the tier guard above. The evidence is empirical and lives in #389: measured over the 65-design FactorioBin belt balancer book, **57 of 65 decoded wrong before this change and 0 after** (decoded tile count vs each blueprint's own entity footprint). Say the word if you want that check committed as a test after all.

Checks: `pytest tests/` 3268 passed / 708 skipped, `ruff check`, `ty check`. No engine code touched, so no training numbers move.