### PR TITLE
Connect a splitter to the splitter in front of it

### DIFF
--- a/factorion_rs/src/entities.rs
+++ b/factorion_rs/src/entities.rs
@@ -888,8 +888,13 @@ impl FactoryEntity for Splitter {
                         let dst_is_belt =
                             matches!(dst_entity, Item::TransportBelt | Item::UndergroundBelt);
                         let dst_is_sink = matches!(dst_entity, Item::Source | Item::Sink);
+                        // Stacked splitters are the building block of every
+                        // belt balancer. A splitter only takes input on its
+                        // back, so it accepts this feed only facing the same
+                        // way — a side or head-on neighbour stays severed.
+                        let dst_is_splitter = dst_entity == Item::Splitter && dst_dir == dir;
                         let dst_not_opposing = dst_dir != dir.opposite();
-                        if (dst_is_belt || dst_is_sink)
+                        if (dst_is_belt || dst_is_sink || dst_is_splitter)
                             && dst_not_opposing
                             && !tile_set.contains(&out_pos)
                         {
@@ -1643,6 +1648,72 @@ mod tests {
             Some(Item::CopperCable),
         );
         assert!(!is_curved_belt(&w, (1, 1)));
+    }
+
+    #[test]
+    fn test_splitter_to_splitter_every_orientation_and_offset() {
+        // Two splitters, every direction pair × every relative offset: the
+        // edges between them must be exactly what the game gives. A splitter
+        // takes input only on its back, so a receiver has to face the same
+        // way; every tile-lane then fans out to every receiver, since a
+        // splitter balances internally and an item entering either tile can
+        // leave by either output.
+        use std::collections::HashSet;
+        let a_pos = (4, 4);
+        for a_dir in CARDINALS {
+            for b_dir in CARDINALS {
+                for bx in 1..=7 {
+                    for by in 1..=7 {
+                        let (b_pos, mut w) = ((bx, by), World::empty(9, 9));
+                        w.place_multi_tile(a_pos.0, a_pos.1, Item::Splitter, a_dir, None, 2, 1);
+                        // Overlapping footprints are not a placeable world.
+                        if !w.place_multi_tile(bx, by, Item::Splitter, b_dir, None, 2, 1) {
+                            continue;
+                        }
+
+                        let mut want: HashSet<Edge> = HashSet::new();
+                        for ((src, s_dir), (dst, d_dir)) in [
+                            ((a_pos, a_dir), (b_pos, b_dir)),
+                            ((b_pos, b_dir), (a_pos, a_dir)),
+                        ] {
+                            if s_dir != d_dir {
+                                continue;
+                            }
+                            let (ddx, ddy) = s_dir.delta();
+                            let src_tiles = entity_tiles(src.0, src.1, s_dir, 2, 1).unwrap();
+                            let recvs = entity_tiles(dst.0, dst.1, d_dir, 2, 1).unwrap();
+                            for recv in recvs {
+                                if !src_tiles.contains(&Pos::new(recv.x - ddx, recv.y - ddy)) {
+                                    continue;
+                                }
+                                let node = |p: Pos, l| {
+                                    NodeId::new(Item::Splitter, p.x as usize, p.y as usize, Some(l))
+                                };
+                                for &tile in &src_tiles {
+                                    want.extend(
+                                        Lane::iter().map(|l| (node(tile, l), node(recv, l))),
+                                    );
+                                }
+                            }
+                        }
+
+                        let got: HashSet<Edge> = [(a_pos, a_dir), (b_pos, b_dir)]
+                            .into_iter()
+                            .flat_map(|(pos, dir)| Splitter.connections(pos, dir, &w))
+                            .filter(|(s, d)| {
+                                s.entity_kind == Item::Splitter && d.entity_kind == Item::Splitter
+                            })
+                            .collect();
+                        assert_eq!(
+                            got,
+                            want,
+                            "A={a_dir:?}@{a_pos:?} B={b_dir:?}@{b_pos:?}\n{}",
+                            crate::render::render(&w)
+                        );
+                    }
+                }
+            }
+        }
     }
 
     #[test]

--- a/factorion_rs/tests/factories/splitter_to_splitter.yaml
+++ b/factorion_rs/tests/factories/splitter_to_splitter.yaml
@@ -1,0 +1,50 @@
+description: |
+  Two splitters stacked back to back — the building block every belt balancer
+  is made of. A splitter's output side feeds whatever belt-connectable entity
+  sits in front of it, and another splitter is belt-connectable, so the full
+  15 i/s reaches the sink.
+items:
+- { x: 0, y: 0, item: iron_plate }
+- { x: 0, y: 5, item: iron_plate }
+throughput:
+- { item: iron_plate, per_second: 15 }
+graph: |
+  S@0,0 -> b@0,1
+  b@0,1 -> Y@0,2
+  Y@0,2 -> Y@0,3
+  Y@0,2 -> Y@1,3
+  Y@1,2 -> Y@0,3
+  Y@1,2 -> Y@1,3
+  Y@0,3 -> b@0,4
+  Y@1,3 -> b@0,4
+  b@0,4 -> K@0,5
+factory: |
+  Sv ..
+  bv ..
+  YvvvY
+  YvvvY
+  bv ..
+  Kv ..
+---
+description: |
+  The same pair staggered by a tile, so only one output faces the splitter
+  below. The other output backs up against bare ground and the whole 15 i/s
+  goes through the tile that does connect.
+items:
+- { x: 0, y: 0, item: iron_plate }
+- { x: 2, y: 4, item: iron_plate }
+throughput:
+- { item: iron_plate, per_second: 15 }
+graph: |
+  S@0,0 -> b@0,1
+  b@0,1 -> Y@0,2
+  Y@0,2 -> Y@1,3
+  Y@1,2 -> Y@1,3
+  Y@1,3 -> K@2,4
+  Y@2,3 -> K@2,4
+factory: |
+  Sv .. ..
+  bv .. ..
+  YvvvY ..
+  .. YvvvY
+  .. .. Kv


### PR DESCRIPTION
Closes #388.

## Mechanism

`Splitter::connections` collected its receivers from belts, undergrounds and the source/sink markers — `Item::Splitter` was simply absent from the list, so a splitter never fed the splitter in front of it. One line, plus the guard that keeps it honest:

```rust
let dst_is_splitter = dst_entity == Item::Splitter && dst_dir == dir;
```

A splitter takes input only on its **back**, so the receiver has to face the same way — a side or head-on neighbour stays severed, exactly as the input side already required `src_dir == dir` for belts. The feed goes through the existing `calc_lane_aware_edges`, which gives the lane-preserving pair for a same-direction handoff; the [wiki](https://wiki.factorio.com/Belt_transport_system) confirms that is the game's behaviour ("Splitters preserve the lanes of the items … an item on the right lane will not be moved to the left lane").

The receiver joins the existing fan-out, so each tile-lane feeds the same lane of every receiver. That is right for a splitter pair: an item entering either input tile can leave by either output, which is what the entity does.

Nothing was needed on the downstream splitter's input side — `build_graph` unions the edges every entity emits and dedupes, so the upstream splitter emitting them is the whole fix.

## Verification

**Exhaustive orientation/offset sweep** (`test_splitter_to_splitter_every_orientation_and_offset`): two splitters, all 4×4 direction pairs at every relative offset in a 7×7 window — 728 placeable configurations. It pins the edge set in *both* directions, so it fails on a missing edge and equally on a spurious one:

| mutation | result |
|---|---|
| unfixed (`dst_is_splitter = false`) | fails — `MISSING Y@4,4:L -> Y@4,3:L`, … |
| over-connecting (drop the `dst_dir == dir` guard) | fails — extra edges into a perpendicular splitter |
| as committed | passes |

The failure message renders the offending world, so a regression names the layout rather than a node id.

**End-to-end throughput** (`tests/factories/splitter_to_splitter.yaml`): the issue's minimal repro delivers the full 15 i/s, and the same pair staggered by a tile — only one output facing the splitter below, the other backing up against bare ground — also delivers 15.

**No movement in the training data.** Every `LessonKind` × 150 seeds produces bit-identical throughput, orphan count and `max_throughput` before and after. No generator stacks splitters, so this only changes layouts a policy places itself — which is the point: those scored 0 for the whole downstream factory.

## ⚠️ Correct connectivity exposes the cycle limitation

Connecting splitters makes some previously-severed graphs genuinely cyclic, and the topological solver still carries no flow through a cycle (#381, and explicitly out of scope in #382's "what this does NOT fix"). I measured this on the 45 balancer fixtures from #385: **7 → 16 pass**, but 6 designs whose loop-return belt now closes a real cycle drop to 0, including `belt_3_to_2` (30.0 → 0). Concretely, in `belt_3_to_2` the edge `Y@4,6 -> Y@3,5` closes `b@3,4 → b@4,4 → b@5,4 → b@5,5 → b@5,6 → b@5,7 → b@4,7 → Y@4,6 → Y@3,5 → b@3,4`.

That loop is physically there in the blueprint — the missing edge had been breaking it by accident. I confirmed the bail-out removal in #382 does not help: those 6 stay at 0 either way, because Kahn's pass never gives a cycle node in-degree 0. Carrying flow through a loop needs a real flow solver with back-pressure.

So #388's acceptance test (unparking #385's fixtures) still needs #386 **and** the cycle work; this PR is the connectivity half. The remaining balancer failures are other engine bugs and out of scope here.

## ⚠️ Reward numbers are not comparable across this change

The terminal reward is throughput-based, so any layout containing stacked splitters scores differently after this. Mostly upward — a severed factory starts delivering — but **not monotonically**: where the new edge closes a belt loop, the arm through it drops to 0 (the 6 balancers above). A policy that had learned to build around the missing edge is scored on different ground after this commit.

## Checks

`cargo fmt` / `cargo clippy -- -D warnings` / `cargo test` (167 passed), `maturin develop --release`, `pytest tests/` (3268 passed, 708 skipped), `ruff check`, `ty check` — all green. No CI runs launched; the retrain/compare call is yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnzCYcCHdeRT6ysJxLWk8u