### PR TITLE
Enforce the pre-completion checklist in CI (clippy, fmt, ty, pyo3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,17 @@ jobs:
           # imported by the tested modules are installed — marimo, tensorboard
           # and pandas are deliberately omitted (the first two are mocked in
           # tests/test_grid_sizes.py, none are imported at module load).
-          uv pip install --system pytest pytest-timeout maturin
+          uv pip install --system pytest pytest-timeout maturin ty==0.0.19
           uv pip install --system torch --index-url https://download.pytorch.org/whl/cpu
           uv pip install --system numpy gymnasium networkx tyro tqdm matplotlib plotly wandb runpod requests
       - name: Build and install factorion_rs
         run: cd factorion_rs && maturin build --release --out dist && uv pip install --system dist/*.whl
+      # Shares this job's interpreter rather than paying for a second torch
+      # install. --python is required, not decorative: the deps land in the
+      # system interpreter, and with no .venv to discover ty resolves nothing
+      # and reports every third-party import as unresolved.
+      - name: Run ty
+        run: ty check . --python "$(which python)"
       - name: Run Python tests
         env:
           WANDB_MODE: disabled

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,31 @@ jobs:
       - name: Run ruff
         run: ruff check .
 
+  rust-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: factorion_rs
+      - name: Check formatting
+        run: cd factorion_rs && cargo fmt --check
+      # --all-targets so #[cfg(test)] code is linted too; a plain `cargo
+      # clippy` silently skips every test module. Default features are left on
+      # so the pyo3 binding code is covered (clippy never links, so
+      # extension-module is fine here even though `cargo test` needs it off).
+      - name: Run clippy
+        run: cd factorion_rs && cargo clippy --all-targets -- -D warnings
+
   python-tests:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,7 @@ jobs:
       - name: Check formatting
         run: cd factorion_rs && cargo fmt --check
       # --all-targets so #[cfg(test)] code is linted too; a plain `cargo
-      # clippy` silently skips every test module. Default features are left on
-      # so the pyo3 binding code is covered (clippy never links, so
-      # extension-module is fine here even though `cargo test` needs it off).
+      # clippy` silently skips every test module.
       - name: Run clippy
         run: cd factorion_rs && cargo clippy --all-targets -- -D warnings
 
@@ -101,10 +99,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+      # pyo3's build script needs an interpreter to resolve the ABI.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: factorion_rs
+      # Default features on, so the pyo3 bindings are compiled in the same
+      # configuration that ships. The test binary links because nothing in the
+      # tests references libpython, which extension-module leaves undefined.
       - name: Run Rust tests
-        run: cd factorion_rs && cargo test --no-default-features
+        run: cd factorion_rs && cargo test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,7 +278,7 @@ Before claiming work is done, run all of the following:
   - [ ] not have excessive helpers, 
   - [ ] not have functions that could be inlined, 
   - [ ] should contain *ZERO* references to previous states of the codebase
-1. **Rust format + lint**: `cd factorion_rs && cargo fmt && cargo clippy -- -D warnings && cd ..`
+1. **Rust format + lint**: `cd factorion_rs && cargo fmt && cargo clippy --all-targets -- -D warnings && cd ..`
 2. **Rust tests**: `cd factorion_rs && cargo test && cd ..`
 3. **Build the Rust extension**: `cd factorion_rs && maturin develop --release && cd ..`
 4. **Python tests**: `WANDB_MODE=disabled WANDB_DISABLED=true uv run python -m pytest tests/ -v`

--- a/ci/README.md
+++ b/ci/README.md
@@ -118,7 +118,7 @@ RunPod console (the pod's container logs; the job also tees to
 
 ## GitHub Actions (thin pointers into this directory)
 
-- `ci.yml` — lint + Python tests + Rust tests on PRs. No GPU jobs.
+- `ci.yml` — ruff + ty, fmt + clippy, Python tests + Rust tests on PRs. No GPU jobs.
 - `ci-command.yml` — the `/ci` comment dispatcher (collaborators only).
 - `ci-reporter.yml` — 30-min cron posting result comments for finished runs.
 - `pod-watchdog.yml` — the 6-hourly leaked-pod reaper.

--- a/factorion_rs/src/types.rs
+++ b/factorion_rs/src/types.rs
@@ -1947,7 +1947,7 @@ mod tests {
         // A standard `crafting` recipe lists all three assembler tiers.
         let ec = get_recipe(Item::ElectronicCircuit).unwrap();
         assert_eq!(
-            ec.produced_by.iter().copied().collect::<Vec<_>>(),
+            ec.produced_by.to_vec(),
             vec![
                 Item::AssemblingMachine1,
                 Item::AssemblingMachine2,
@@ -1957,7 +1957,7 @@ mod tests {
         // The one `advanced-crafting` recipe excludes assembling machine 1.
         let eu = get_recipe(Item::EngineUnit).unwrap();
         assert_eq!(
-            eu.produced_by.iter().copied().collect::<Vec<_>>(),
+            eu.produced_by.to_vec(),
             vec![Item::AssemblingMachine2, Item::AssemblingMachine3]
         );
     }


### PR DESCRIPTION
## Why CI was green with clippy errors on main

`.github/workflows/ci.yml` had three jobs — `lint` (ruff, Python only),
`python-tests`, and `rust-tests` (`cargo test --no-default-features`).
**Neither `cargo clippy` nor `cargo fmt` ran anywhere in CI.** The only
mention of clippy in the entire repo was the manual pre-completion checklist
in `CLAUDE.md`, which nothing enforces on a PR.

The checklist command was also insufficient on its own. `cargo clippy -- -D
warnings` without `--all-targets` never lints `#[cfg(test)]` code, and both
warnings live in a `mod tests` block in `src/types.rs`. Verified locally at
the parent commit:

| command | result |
|---|---|
| `cargo clippy -- -D warnings` (the documented checklist form) | passes clean |
| `cargo clippy --all-targets -- -D warnings` | 2 errors |
| `cargo clippy --all-targets --no-default-features -- -D warnings` | 2 errors |

So even someone following the checklist to the letter would not have caught
these. The root problem is broader than clippy: of the seven checklist gates,
CI enforced only ruff and the two test suites. This PR closes the rest.

## Changes

One commit each:

1. **`to_vec()` for the `produced_by` assertions** — the two flagged
   `iter().copied().collect::<Vec<_>>()` calls over the `&'static [Item]`
   slice, exactly as clippy suggests. Committed first so the new gate is
   green the moment it exists.
2. **`rust-lint` job** — `cargo fmt --check` plus `cargo clippy --all-targets
   -- -D warnings`, with default features left on so the pyo3 binding code is
   linted too (28 `feature = "pyo3-bindings"` cfg sites in `lib.rs`/`world.rs`
   are invisible under `--no-default-features`). Clippy never links, so
   `extension-module` is not a problem here. `CLAUDE.md` checklist item 1 now
   carries `--all-targets`.
3. **`ty` in CI** — runs inside `python-tests` to reuse that job's
   interpreter instead of paying for a second torch install.
4. **pyo3 compiled in `rust-tests`** — dropped `--no-default-features`, added
   `setup-python` for pyo3's build script.

### Two things worth knowing about the ty step

`ty check .` on its own would have been a no-op gate — the same failure mode
this PR exists to fix. That job installs via `uv pip install --system`, so
there is no `.venv` for ty to auto-detect. Measured against a fresh clone
with a venv matching the job's exact dep list:

| invocation | result |
|---|---|
| `ty check .` (no `VIRTUAL_ENV`) | **167 diagnostics** — every third-party import unresolved |
| `ty check . --python "$(which python)"` | clean |

Hence the explicit `--python`. Separately, the job's deliberately-curated dep
set is sufficient: nothing statically imports the omitted `pandas`/`marimo`/
`tensorboard`, and `factorion_rs` resolves via its `.pyi` stub rather than
needing the built extension.

### On the pyo3 change

The bindings were already compiled in CI by `maturin build --release` in
`python-tests`. The narrower real gap: they were never compiled *in the test
profile*, so `cargo test` exercised a different cfg configuration than the one
that ships. Test count is unchanged at 169, so this is purely additive
compilation. The test binary links because nothing in the tests references
libpython, which `extension-module` leaves undefined.

## Verification

Full checklist locally: `cargo fmt --check`, `cargo clippy --all-targets -- -D
warnings`, `cargo test` (168 passed, 1 ignored), `maturin develop --release`,
`pytest tests/` (3295 passed, 708 skipped), `ruff check .`, `ty check .` — all
clean.

CI green on all four jobs, and I confirmed from the job logs that the new
steps did real work rather than passing vacuously:

- `python-tests` → `Run ty check . --python "$(which python)"` → `All checks passed!`
- `rust-tests` → `Compiling pyo3-ffi v0.23.5`, `Compiling pyo3 v0.23.5`,
  `Compiling numpy v0.23.0` — none of which happened under
  `--no-default-features`.

## Remaining follow-up, not addressed here

`dtolnay/rust-toolchain@stable` drifts, and clippy is now a blocking gate, so
a new clippy release can turn an unrelated PR red without anyone changing
code. Kept `@stable` to match the existing convention in this workflow;
pinning is the alternative, at the cost of lints going stale until someone
bumps it.