### PR TITLE
Generate a provenance description on copied fixtures

### DIFF
--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -19,9 +19,11 @@ import base64
 import io
 import json
 import os
+import subprocess
 import sys
 import traceback
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Iterator, Optional
@@ -375,9 +377,51 @@ _FixtureDumper.add_representer(
 )
 
 
-def factory_yaml(grid: list[list[dict]]) -> str:
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _git_commit(root: Path = _REPO_ROOT) -> Optional[str]:
+    """The checkout's short sha, `+dirty` when the tree has uncommitted
+    changes. ``None`` when git is missing or `root` isn't a repo — plenty of
+    environments are neither, and a fixture is still worth copying."""
+    def run(*args: str) -> str:
+        return subprocess.run(
+            ["git", "-C", str(root), *args],
+            capture_output=True, text=True, timeout=10, check=True,
+        ).stdout.strip()
+
+    try:
+        sha = run("rev-parse", "--short", "HEAD")
+        dirty = bool(run("status", "--porcelain"))
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return f"commit {sha}{' +dirty' if dirty else ''}" if sha else None
+
+
+def _provenance(source: Optional[str]) -> Optional[str]:
+    """One line on where a copied factory came from: what produced it, the
+    checkout it was produced at, and when. Every part is best-effort, so an
+    environment missing git or a usable clock simply contributes less;
+    ``None`` when nothing at all is known."""
+    try:
+        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    except (OSError, ValueError):
+        stamp = None
+    known = [part for part in (source, _git_commit(), stamp) if part]
+    if not known:
+        return None
+    return "Captured from the factory builder — " + ", ".join(known) + "."
+
+
+def factory_yaml(grid: list[list[dict]], source: Optional[str] = None) -> str:
     """Serialise a grid as a textual test fixture, ready to paste into
     ``factorion_rs/tests/factories/*.yaml``.
+
+    ``source`` describes what produced the factory (e.g. ``"MOVE_ONE_ITEM
+    seed 4"``); it is folded into a generated ``description:`` alongside the
+    commit and timestamp. The caller owns that wording because only the page
+    knows whether a grid is a generator's output, a model's rebuild, or a
+    hand-edit of either.
 
     The `factory:` block comes from the canonical renderer and `throughput:`
     from the engine's own per-sink deliveries, so the fixture asserts what the
@@ -418,13 +462,21 @@ def factory_yaml(grid: list[list[dict]]) -> str:
         if item is not None
     ]
     doc: dict = {}
+    note = _provenance(source)
+    if note:
+        doc["description"] = _Block(note + "\n")
     if bindings:
         doc["items"] = bindings
     if throughput:
         doc["throughput"] = throughput
     doc["factory"] = _Block(render_factory(world_WHC.permute(2, 0, 1)) + "\n")
-    # `width` off so a long flow mapping is never wrapped mid-entry.
-    return yaml.dump(doc, Dumper=_FixtureDumper, sort_keys=False, width=10**9)
+    # `width` off so a long flow mapping is never wrapped mid-entry;
+    # `allow_unicode` so a non-ASCII description keeps its block style instead
+    # of being escaped into a quoted scalar.
+    return yaml.dump(
+        doc, Dumper=_FixtureDumper, sort_keys=False,
+        width=10**9, allow_unicode=True,
+    )
 
 
 # ── Model inference ──────────────────────────────────────────────────────────
@@ -1417,6 +1469,8 @@ let grid = [];           // grid[y][x] = cell dict
 let selected = null;     // {{x, y}} or null
 let activeHotbar = null; // 0..9 or null
 let prediction = null;   // last /predict response (or null)
+let gridSource = null;   // what produced `grid`, or null if hand-built
+let gridSnapshot = '';   // `grid` as adopted, to detect later edits
 let autoApplying = false;
 let autoApplyGeneration = 0;
 let autoApplyFrame = null;
@@ -2005,13 +2059,13 @@ async function computeGraph() {{
 // Serialise `g` server-side (the renderer and the throughput engine both live
 // there) and put the fixture on the clipboard. The icon doubles as the status
 // readout — there is nowhere else on a scan card to put one.
-async function copyYaml(g, btn) {{
+async function copyYaml(g, btn, source) {{
   const icon = btn.innerHTML;
   try {{
     const resp = await fetch('/factory_yaml', {{
       method: 'POST',
       headers: {{ 'Content-Type': 'application/json' }},
-      body: JSON.stringify({{ grid: g }}),
+      body: JSON.stringify({{ grid: g, source }}),
     }});
     const data = await resp.json();
     if (data.error) throw new Error(data.error);
@@ -2024,8 +2078,19 @@ async function copyYaml(g, btn) {{
   }}
   setTimeout(() => {{ btn.innerHTML = icon; }}, 1500);
 }}
+// What produced the grid on screen, for the fixture's provenance note.
+// Diffing against the snapshot taken when the grid was adopted is what keeps
+// a hand-edited factory from claiming to be that seed's own output; every
+// edit path already funnels through a wholesale swap or mutates `grid`, so
+// one comparison covers them all.
+function buildSource() {{
+  if (!gridSource) return null;
+  return JSON.stringify(grid) === gridSnapshot
+    ? gridSource
+    : gridSource + ', hand-edited';
+}}
 document.getElementById('copy-yaml').addEventListener('click', (ev) =>
-  copyYaml(grid, ev.currentTarget));
+  copyYaml(grid, ev.currentTarget, buildSource()));
 
 document.getElementById('model-apply').addEventListener('click', applyPrediction);
 document.getElementById('model-load').addEventListener('click', loadModel);
@@ -2107,11 +2172,13 @@ async function loadModel() {{
 // and prediction have to be dropped along with the old grid — otherwise the
 // ghost overlays and argmax border are drawn over a factory they don't
 // belong to — so every wholesale swap goes through here.
-function adoptGrid(size, cells) {{
+function adoptGrid(size, cells, source) {{
   SIZE = size;
   grid = cells;
   selected = null;
   prediction = null;
+  gridSource = source || null;
+  gridSnapshot = JSON.stringify(grid);
   document.getElementById('size').value = SIZE;
   renderGrid(); syncEditor();
   scheduleCompute();
@@ -2137,7 +2204,7 @@ async function generateLesson() {{
     }});
     const data = await resp.json();
     if (data.error) {{ status.textContent = 'error: ' + data.error; return; }}
-    adoptGrid(data.size, data.grid);
+    adoptGrid(data.size, data.grid, kind + ' seed ' + data.used_seed);
     document.getElementById('lesson-seed').value = data.next_seed;
     // `num_removed` is what blank_entities actually cleared, which can be
     // less than requested when the lesson protects most of its entities.
@@ -2158,11 +2225,7 @@ document.getElementById('lesson-generate').addEventListener('click', generateLes
 document.getElementById('resize').addEventListener('click', () => {{
   const n = parseInt(document.getElementById('size').value, 10);
   if (!Number.isFinite(n) || n < 2 || n > 20) return;
-  SIZE = n;
-  grid = newGrid(SIZE);
-  selected = null;
-  renderGrid(); syncEditor();
-  scheduleCompute();
+  adoptGrid(n, newGrid(n), null);
 }});
 document.getElementById('export').addEventListener('click', async () => {{
   const text = JSON.stringify({{ size: SIZE, grid }}, null, 2);
@@ -2311,13 +2374,18 @@ function scanCard(r, showRef) {{
     : '';
   card.innerHTML = head + `<div class="pair">${{built}}${{ref}}</div>`;
   card.title = 'Open this factory in the Build tab';
+  // The card holds what the model built from this lesson's markers, not the
+  // generator's own solution, so the seed alone would misdescribe it.
+  const source = r.kind + ' seed ' + r.seed + ', model rebuild';
   card.querySelector('.copy-yaml').addEventListener('click', (ev) => {{
     ev.stopPropagation();  // the card's own click adopts the grid instead
-    copyYaml(r.grid, ev.currentTarget);
+    copyYaml(r.grid, ev.currentTarget, source);
   }});
   card.addEventListener('click', () => {{
     switchTab('build');
-    adoptGrid(r.size, r.grid.map(row => row.map(c => Object.assign({{}}, c))));
+    adoptGrid(
+      r.size, r.grid.map(row => row.map(c => Object.assign({{}}, c))), source,
+    );
   }});
   return card;
 }}
@@ -2644,7 +2712,9 @@ class Handler(BaseHTTPRequestHandler):
             if self.path == "/graph":
                 result = render_graph_png(payload["grid"])
             elif self.path == "/factory_yaml":
-                result = {"yaml": factory_yaml(payload["grid"])}
+                result = {
+                    "yaml": factory_yaml(payload["grid"], payload.get("source"))
+                }
             elif self.path == "/predict":
                 if payload.get("detail") == "action":
                     result = _predict_action(payload["grid"])

--- a/tests/test_factory_builder.py
+++ b/tests/test_factory_builder.py
@@ -1006,7 +1006,7 @@ class TestFactoryYaml:
         assert "factory: |\n" in text
         assert "\n- {x: " in text
         # `Header` is deny_unknown_fields, so a stray key is a parse error.
-        assert set(doc) <= {"items", "throughput", "factory"}
+        assert set(doc) <= {"description", "items", "throughput", "factory"}
         assert all(set(b) == {"x", "y", "item"} for b in doc["items"])
         assert all(set(t) == {"item", "per_second"} for t in doc["throughput"])
         # The grid is the canonical renderer's, not a second implementation.
@@ -1051,6 +1051,32 @@ class TestFactoryYaml:
             for _x, _y, item, rate in factorion_rs.py_sink_deliveries(world_WHC)
         )
 
+    def test_description_carries_the_provenance_it_can_get(self):
+        _factory, grid = self._grid(LessonKind.SPLITTER_SPLIT)
+        doc = yaml.safe_load(fb.factory_yaml(grid, "SPLITTER_SPLIT seed 3"))
+        assert "SPLITTER_SPLIT seed 3" in doc["description"]
+        # This checkout is a git repo, so the sha is a fact the note must
+        # carry rather than an optional nicety.
+        head = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True, text=True, cwd=Path(fb.__file__).parent.parent,
+        ).stdout.strip()
+        assert head and head in doc["description"]
+
+    def test_provenance_degrades_instead_of_failing(self, monkeypatch, tmp_path):
+        """Plenty of environments have no git, no repo, or no useful clock.
+        Each missing part drops out on its own; only when nothing at all is
+        known does the key disappear."""
+        assert fb._git_commit(tmp_path) is None  # a real directory, not a repo
+        monkeypatch.setattr(fb, "_git_commit", lambda *a, **k: None)
+        _factory, grid = self._grid(LessonKind.SPLITTER_SPLIT)
+        doc = yaml.safe_load(fb.factory_yaml(grid, "SPLITTER_SPLIT seed 3"))
+        assert "commit" not in doc["description"]
+        assert "SPLITTER_SPLIT seed 3" in doc["description"]
+
+        monkeypatch.setattr(fb, "_provenance", lambda source: None)
+        assert "description" not in yaml.safe_load(fb.factory_yaml(grid))
+
     def test_untagged_sink_is_left_out(self):
         """A throughput entry requires an `item:`, so a sink with nothing
         bound has no fixture form. Emitting one anyway would make the whole
@@ -1064,7 +1090,7 @@ class TestFactoryYaml:
             ["stack_inserter", "transport_belt", "bulk_inserter"]
         ):
             grid[0][x] |= {"entity": entity, "direction": "EAST"}
-        assert set(yaml.safe_load(fb.factory_yaml(grid))) == {"factory"}
+        assert "throughput" not in yaml.safe_load(fb.factory_yaml(grid))
 
     def test_every_lesson_round_trips(self):
         """The generators are the main source of factories to copy, so every
@@ -1101,6 +1127,14 @@ class TestRenderIndexCopyYaml:
         """A scan card adopts its grid on click; the button sits inside it."""
         html = fb.render_index(default_size=11)
         assert "ev.stopPropagation();" in html
+
+    def test_page_sends_provenance_the_endpoint_reads(self):
+        """The lesson/seed is the page's to know, so a rename on either side
+        would otherwise silently start copying fixtures with no `description:`."""
+        html = fb.render_index(default_size=11)
+        assert "JSON.stringify({ grid: g, source })" in html
+        assert "source" in inspect.signature(fb.factory_yaml).parameters
+        assert 'payload.get("source")' in inspect.getsource(fb.Handler.do_POST)
 
 
 class TestIconCoverage:


### PR DESCRIPTION
Follow-up to #393. A copied fixture now says where it came from:

```yaml
description: |
  Captured from the factory builder — SPLITTER_SPLIT seed 3, commit 4bee5f8 +dirty, 2026-08-11T09:40:45Z.
items:
- {x: 4, y: 1, item: lab}
```

Three independently-optional facts: what produced the factory, the checkout it
was produced at (`git rev-parse --short HEAD`, `+dirty` when the tree is not
clean), and a UTC timestamp.

## Best-effort by design

Every part drops out on its own, and the `description:` key disappears entirely
when nothing at all is known:

| environment | result |
|---|---|
| normal checkout | lesson + seed, commit, timestamp |
| no git binary / not a repo | lesson + seed, timestamp |
| hand-built grid (no lesson) | commit, timestamp |
| nothing available | no `description:` key |

## Who owns the wording

The page supplies the "what produced it" clause, not the server — only the
browser can tell a generator's output from a model rebuild from a hand-edit of
either. The five states, all verified in a real browser:

| action | description clause |
|---|---|
| blank / hand-built grid | *(omitted)* |
| Generate lesson | `SPLITTER_SPLIT seed 3` |
| …then edit a tile | `SPLITTER_SPLIT seed 3, hand-edited` |
| Scan card, or opening one in the Build tab | `MOVE_ONE_ITEM seed 7, model rebuild` |
| resize / clear | *(omitted)* |

The `hand-edited` flag comes from diffing the grid against a snapshot taken
when it was adopted, rather than from hooking each of the nine mutation paths.
That way an edit path nobody remembered to instrument still can't let a
modified factory claim to be the seed's own output. `resize` now routes through
`adoptGrid` too, so clearing the grid clears the provenance with it.

A scan card describes itself as a `model rebuild` because it holds what the
model built from that lesson's markers, not the generator's own solution — the
seed alone would misdescribe it.

## Note on `allow_unicode`

`yaml.dump` defaults to escaping non-ASCII, which turned the em-dash into
`—` **and** silently demoted `description:` from a block scalar to a
double-quoted string. Fixed with `allow_unicode=True`; the style assertions
added in #393 would have caught this on `factory:` but not on a key that didn't
exist yet.

## Testing

- `test_description_carries_the_provenance_it_can_get` — the source clause and
  the real `git rev-parse --short HEAD` both land in the note.
- `test_provenance_degrades_instead_of_failing` — `_git_commit` against a real
  non-repo directory returns `None`; with git stubbed out the note keeps its
  other parts; with the whole note gone the key is absent.
- `test_page_sends_provenance_the_endpoint_reads` — pins the client payload to
  the server signature and the handler, so a rename on either side can't
  silently start emitting fixtures with no description.
- Regenerated all 56 documents (every `LessonKind` × 4 seeds) into
  `factorion_rs/tests/factories/` and re-ran `test_all_yamls_in_factories_dir`:
  all parse and match their asserted throughput, with zero block-scalar
  fallbacks on either `description:` or `factory:`.
- Full suite: 3298 passed, `ruff check`, `ty check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_017BTd284p9G3UsEKQXogEGw)_