### PR TITLE
Put a throughput verdict above the grid

### DIFF
--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -111,11 +111,13 @@ DISPLAY_NAME = {
     "stack_inserter": "source",
     "bulk_inserter": "sink",
 }
-def _stroke_icon(path: str, width: float = 2.2) -> str:
+
+
+def _stroke_icon(path: str) -> str:
     """A one-path inline SVG that inherits its colour from the text around it."""
     return (
         f'<svg viewBox="0 0 16 16" width="12" height="12" aria-hidden="true" '
-        f'fill="none" stroke="currentColor" stroke-width="{width}" '
+        f'fill="none" stroke="currentColor" stroke-width="2.2" '
         f'stroke-linecap="round" stroke-linejoin="round"><path d="{path}"/></svg>'
     )
 
@@ -125,7 +127,6 @@ def _stroke_icon(path: str, width: float = 2.2) -> str:
 # and this one carries the whole answer.
 OK_ICON = _stroke_icon("M3 8.5l3.5 3.5L13 4.5")
 BAD_ICON = _stroke_icon("M4 4l8 8M12 4l-8 8")
-FLOW_ICON = _stroke_icon("M2 8h9M8 4.5L11.5 8 8 11.5", width=1.7)
 
 # Inline rather than an emoji: the button carries no text, so a glyph the
 # user's font happens not to cover would leave it blank. `currentColor` keeps
@@ -1214,10 +1215,13 @@ def render_index(default_size: int) -> str:
     padding: 0.4em 0.6em;
     border: 1px solid #ddd; border-radius: 5px; background: #fafafa;
   }}
+  /* Tints the whole card with the verdict, so it reads from the corner of
+     the eye without competing with the grid for attention. */
+  .thput.ok {{ border-color: #9ccfad; background: #f6fbf7; }}
+  .thput.bad {{ border-color: #e6adad; background: #fdf7f7; }}
   .thput-icon {{ display: inline-flex; }}
   .thput-icon.ok {{ color: #1a7f37; }}
   .thput-icon.bad {{ color: #c62828; }}
-  .thput-icon.flow {{ color: #1a7f37; opacity: 0.5; }}
   .thput-value {{ font-weight: bold; }}
   .thput-sub {{ color: #888; font-size: 0.9em; }}
   .spinner {{
@@ -1522,7 +1526,6 @@ const DIR_CYCLE = ['NORTH', 'EAST', 'SOUTH', 'WEST'];
 const EOT_STOP_THRESHOLD = {EOT_STOP_THRESHOLD};
 const OK_ICON = '{OK_ICON}';
 const BAD_ICON = '{BAD_ICON}';
-const FLOW_ICON = '{FLOW_ICON}';
 // `modelLoaded` is set by refreshModelInfo() at startup and after each
 // successful /load_model call. Prediction calls are gated on it so we
 // don't pester the server with /predict when no checkpoint is loaded.
@@ -1826,29 +1829,30 @@ function clearSelected() {{
 const THPUT_LABEL = '<span>factory throughput:</span>';
 
 function showThputPending() {{
-  document.getElementById('thput').innerHTML = THPUT_LABEL +
+  const el = document.getElementById('thput');
+  el.className = 'thput';
+  el.innerHTML = THPUT_LABEL +
     '<span class="spinner"></span><span class="thput-sub">calculating…</span>';
 }}
 
 function showThput(data) {{
   const el = document.getElementById('thput');
   if (data.thput === null || data.thput === undefined) {{
+    el.className = 'thput';
     el.innerHTML = THPUT_LABEL +
       '<span class="thput-sub">' + escHtml(data.note || 'unavailable') + '</span>';
     return;
   }}
   const flowing = data.thput > 0;
+  el.className = flowing ? 'thput ok' : 'thput bad';
   el.innerHTML = THPUT_LABEL +
     '<span class="thput-icon ' + (flowing ? 'ok' : 'bad') + '">' +
       (flowing ? OK_ICON : BAD_ICON) + '</span>' +
     '<span class="thput-value">' + data.thput.toFixed(2) +
       ' items per second</span>' +
-    (flowing ? '<span class="thput-icon flow">' + FLOW_ICON + '</span>' : '') +
-    (flowing
-      ? (data.unreachable
-          ? '<span class="thput-sub">' + data.unreachable + ' unreachable</span>'
-          : '')
-      : '<span class="thput-sub">nothing reaches a sink</span>');
+    (flowing && data.unreachable
+      ? '<span class="thput-sub">' + data.unreachable + ' unreachable</span>'
+      : '');
 }}
 
 // Every response that already built the world carries the throughput, so this

--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -111,6 +111,22 @@ DISPLAY_NAME = {
     "stack_inserter": "source",
     "bulk_inserter": "sink",
 }
+def _stroke_icon(path: str, width: float = 2.2) -> str:
+    """A one-path inline SVG that inherits its colour from the text around it."""
+    return (
+        f'<svg viewBox="0 0 16 16" width="12" height="12" aria-hidden="true" '
+        f'fill="none" stroke="currentColor" stroke-width="{width}" '
+        f'stroke-linecap="round" stroke-linejoin="round"><path d="{path}"/></svg>'
+    )
+
+
+# The throughput verdict. Inline SVG for the same reason as the copy icon
+# below: a glyph the viewer's font doesn't cover would render as a blank box,
+# and this one carries the whole answer.
+OK_ICON = _stroke_icon("M3 8.5l3.5 3.5L13 4.5")
+BAD_ICON = _stroke_icon("M4 4l8 8M12 4l-8 8")
+FLOW_ICON = _stroke_icon("M2 8h9M8 4.5L11.5 8 8 11.5", width=1.7)
+
 # Inline rather than an emoji: the button carries no text, so a glyph the
 # user's font happens not to cover would leave it blank. `currentColor` keeps
 # it in step with whatever the button inherits.
@@ -1198,9 +1214,11 @@ def render_index(default_size: int) -> str:
     padding: 0.4em 0.6em;
     border: 1px solid #ddd; border-radius: 5px; background: #fafafa;
   }}
-  .thput-flag {{ font-weight: bold; font-size: 1.15em; }}
-  .thput-flag.flowing {{ color: #1a7f37; }}
-  .thput-flag.blocked {{ color: #c62828; }}
+  .thput-icon {{ display: inline-flex; }}
+  .thput-icon.ok {{ color: #1a7f37; }}
+  .thput-icon.bad {{ color: #c62828; }}
+  .thput-icon.flow {{ color: #1a7f37; opacity: 0.5; }}
+  .thput-value {{ font-weight: bold; }}
   .thput-sub {{ color: #888; font-size: 0.9em; }}
   .spinner {{
     width: 11px; height: 11px; flex: 0 0 auto;
@@ -1502,6 +1520,9 @@ const DIR_ARROW = {{ NONE: '', NORTH: '↑', EAST: '→', SOUTH: '↓', WEST: '�
 const MISC_GLYPH = {{ NONE: '', UNDERGROUND_DOWN: '▼', UNDERGROUND_UP: '▲' }};
 const DIR_CYCLE = ['NORTH', 'EAST', 'SOUTH', 'WEST'];
 const EOT_STOP_THRESHOLD = {EOT_STOP_THRESHOLD};
+const OK_ICON = '{OK_ICON}';
+const BAD_ICON = '{BAD_ICON}';
+const FLOW_ICON = '{FLOW_ICON}';
 // `modelLoaded` is set by refreshModelInfo() at startup and after each
 // successful /load_model call. Prediction calls are gated on it so we
 // don't pester the server with /predict when no checkpoint is loaded.
@@ -1802,24 +1823,27 @@ function clearSelected() {{
 
 // The verdict above the grid. The flag is the whole point: it answers "did my
 // factory work?" before anyone has to know what a good number looks like.
+const THPUT_LABEL = '<span>factory throughput:</span>';
+
 function showThputPending() {{
-  document.getElementById('thput').innerHTML =
-    '<span class="spinner"></span>factory throughput: calculating…';
+  document.getElementById('thput').innerHTML = THPUT_LABEL +
+    '<span class="spinner"></span><span class="thput-sub">calculating…</span>';
 }}
 
 function showThput(data) {{
   const el = document.getElementById('thput');
   if (data.thput === null || data.thput === undefined) {{
-    el.innerHTML =
-      '<span class="thput-sub">' + escHtml(data.note || 'no throughput') + '</span>';
+    el.innerHTML = THPUT_LABEL +
+      '<span class="thput-sub">' + escHtml(data.note || 'unavailable') + '</span>';
     return;
   }}
   const flowing = data.thput > 0;
-  el.innerHTML =
-    (flowing
-      ? '<span class="thput-flag flowing">=&gt;&gt;=</span>'
-      : '<span class="thput-flag blocked">=X=</span>') +
-    '<span>factory throughput: ' + data.thput.toFixed(4) + '</span>' +
+  el.innerHTML = THPUT_LABEL +
+    '<span class="thput-icon ' + (flowing ? 'ok' : 'bad') + '">' +
+      (flowing ? OK_ICON : BAD_ICON) + '</span>' +
+    '<span class="thput-value">' + data.thput.toFixed(2) +
+      ' items per second</span>' +
+    (flowing ? '<span class="thput-icon flow">' + FLOW_ICON + '</span>' : '') +
     (flowing
       ? (data.unreachable
           ? '<span class="thput-sub">' + data.unreachable + ' unreachable</span>'

--- a/scripts/factory_builder.py
+++ b/scripts/factory_builder.py
@@ -341,16 +341,32 @@ def render_graph_png(grid: list[list[dict]]) -> dict:
     finally:
         plt.close("all")
 
-    try:
-        throughput, num_unreachable = factorion_rs.simulate_throughput(
-            world.numpy().astype(np.int64)
-        )
-        info = f"throughput: {throughput:.4f}  ·  unreachable nodes: {num_unreachable}"
-    except Exception as e:
-        info = f"throughput failed: {e}"
-
     edges = [[u, v] for u, v in G.edges]
+    info = f"{len(G.nodes)} nodes · {len(edges)} edges"
     return {"png": png_b64, "info": info, "edges": edges}
+
+
+def _throughput(world_WHC: torch.Tensor) -> dict:
+    """Simulate a world's throughput, as fields to merge into a response.
+
+    Split out of :func:`render_graph_png` — where the number used to arrive
+    bundled with the graph image — because it costs ~0.1 ms against that
+    function's ~1 s of matplotlib. At that price every response that has
+    already built the world carries it, so the readout never waits on a
+    request of its own.
+
+    ``thput`` is ``None`` when there is no meaningful answer — an empty grid,
+    or a failed simulation — so the UI can stay neutral instead of reporting
+    a factory as blocked.
+    """
+    arr = world_WHC.numpy().astype(np.int64)
+    if not arr[:, :, Channel.ENTITIES.value].any():
+        return {"thput": None, "note": "nothing placed yet"}
+    try:
+        thput, unreachable = factorion_rs.simulate_throughput(arr)
+    except Exception as e:
+        return {"thput": None, "note": f"throughput failed: {e}"}
+    return {"thput": float(thput), "unreachable": int(unreachable)}
 
 
 class _Flow(dict):
@@ -784,6 +800,7 @@ def _predict(grid: list[list[dict]]) -> dict:
         "misc_rest": misc_rest,
         "candidates": candidates,
         "eot_prob": eot_prob,
+        **_throughput(world_WHC),
     }
 
 
@@ -823,6 +840,9 @@ def _predict_action(grid: list[list[dict]]) -> dict:
         "item": _ITEM_NAMES.get(item, str(item)),
         "misc": _MISC_NAMES.get(misc, str(misc)),
         "eot_prob": eot_prob,
+        # Rides along so the readout tracks a held-`a` build as it happens,
+        # one placement behind, instead of going blank until the key is let go.
+        **_throughput(world_WHC),
     }
 
 
@@ -1167,7 +1187,27 @@ def render_index(default_size: int) -> str:
     display: flex; gap: 0.8em; align-items: flex-start;
     width: 100%; min-width: 0;
   }}
-  .grid-graph-row > #grid-host {{ flex: 0 0 auto; }}
+  .grid-graph-row > .grid-col {{
+    flex: 0 0 auto; display: flex; flex-direction: column; gap: 0.4em;
+  }}
+  /* The verdict sits above the grid because it is what the user is waiting
+     for after a build, and the flag reads before the digits do. */
+  .thput {{
+    display: flex; align-items: center; gap: 0.55em;
+    font-family: monospace; font-size: 0.92em; min-height: 1.5em;
+    padding: 0.4em 0.6em;
+    border: 1px solid #ddd; border-radius: 5px; background: #fafafa;
+  }}
+  .thput-flag {{ font-weight: bold; font-size: 1.15em; }}
+  .thput-flag.flowing {{ color: #1a7f37; }}
+  .thput-flag.blocked {{ color: #c62828; }}
+  .thput-sub {{ color: #888; font-size: 0.9em; }}
+  .spinner {{
+    width: 11px; height: 11px; flex: 0 0 auto;
+    border: 2px solid #d8d8d8; border-top-color: #666;
+    border-radius: 50%; animation: spin 0.7s linear infinite;
+  }}
+  @keyframes spin {{ to {{ transform: rotate(360deg); }} }}
   .graph-view {{ flex: 1 1 0; min-width: 0; }}
   .graph-view h3 {{ margin: 0 0 0.3em; font-size: 0.85em; text-transform: uppercase; color: #555; }}
   .controls {{ display: flex; gap: 0.4em; flex-wrap: wrap; align-items: center; }}
@@ -1369,7 +1409,10 @@ def render_index(default_size: int) -> str:
       <span id="lesson-status" class="help"></span>
     </div>
     <div class="grid-graph-row">
-      <div id="grid-host"></div>
+      <div class="grid-col">
+        <div class="thput" id="thput"></div>
+        <div id="grid-host"></div>
+      </div>
       <div class="graph-view">
         <h3>Graph
           <button class="copy-yaml" id="copy-yaml"
@@ -1757,15 +1800,63 @@ function clearSelected() {{
   scheduleCompute();
 }}
 
+// The verdict above the grid. The flag is the whole point: it answers "did my
+// factory work?" before anyone has to know what a good number looks like.
+function showThputPending() {{
+  document.getElementById('thput').innerHTML =
+    '<span class="spinner"></span>factory throughput: calculating…';
+}}
+
+function showThput(data) {{
+  const el = document.getElementById('thput');
+  if (data.thput === null || data.thput === undefined) {{
+    el.innerHTML =
+      '<span class="thput-sub">' + escHtml(data.note || 'no throughput') + '</span>';
+    return;
+  }}
+  const flowing = data.thput > 0;
+  el.innerHTML =
+    (flowing
+      ? '<span class="thput-flag flowing">=&gt;&gt;=</span>'
+      : '<span class="thput-flag blocked">=X=</span>') +
+    '<span>factory throughput: ' + data.thput.toFixed(4) + '</span>' +
+    (flowing
+      ? (data.unreachable
+          ? '<span class="thput-sub">' + data.unreachable + ' unreachable</span>'
+          : '')
+      : '<span class="thput-sub">nothing reaches a sink</span>');
+}}
+
+// Every response that already built the world carries the throughput, so this
+// is only for the case where nothing else will ask: no model loaded.
+async function computeThroughput() {{
+  try {{
+    const resp = await fetch('/throughput', {{
+      method: 'POST',
+      headers: {{ 'Content-Type': 'application/json' }},
+      body: JSON.stringify({{ grid }}),
+    }});
+    showThput(await resp.json());
+  }} catch (e) {{
+    showThput({{ thput: null, note: 'throughput failed: ' + e }});
+  }}
+}}
+
 let _predictionTimer = null;
 let _graphTimer = null;
-function scheduleCompute() {{
+function cancelCompute() {{
   clearTimeout(_predictionTimer);
   clearTimeout(_graphTimer);
+}}
+function scheduleCompute() {{
+  cancelCompute();
+  // Whatever number is on screen belongs to a grid that no longer exists.
+  showThputPending();
   if (autoApplying) return;
-  // Prediction is interactive; refresh it almost immediately. Matplotlib
-  // graph rendering is much heavier and shares the server thread, so only do
-  // it after the user has actually paused.
+  // Prediction is interactive; refresh it almost immediately, and the
+  // throughput rides back with it. Matplotlib graph rendering is ~1s and
+  // shares the server thread, so only do it after the user has actually
+  // paused — the readout must never queue behind it.
   _predictionTimer = setTimeout(computePrediction, 25);
   _graphTimer = setTimeout(computeGraph, 1000);
 }}
@@ -1800,6 +1891,7 @@ async function computePrediction() {{
     const out = document.getElementById('model-action');
     if (out) out.textContent = '';
     renderGrid();
+    computeThroughput();
     return;
   }}
   const info = document.getElementById('model-info');
@@ -1817,9 +1909,11 @@ async function computePrediction() {{
       if (out) out.textContent = '';
       prediction = null;
       renderGrid();
+      showThput({{ thput: null, note: 'error: ' + data.error }});
       return;
     }}
     prediction = data;
+    showThput(data);
     if (info) {{
       info.textContent = eotStop(data)
         ? eotStopMessage(data) + ' — no placement offered'
@@ -1929,6 +2023,7 @@ async function runAutoApply(generation) {{
     while (autoApplying && generation === autoApplyGeneration) {{
       const action = await requestFastPrediction();
       if (!autoApplying || generation !== autoApplyGeneration) break;
+      showThput(action);
       if (eotStop(action)) {{
         autoApplying = false;
         if (info) {{
@@ -1960,8 +2055,7 @@ async function runAutoApply(generation) {{
 
 function startAutoApply() {{
   if (autoApplying || !modelLoaded) return;
-  clearTimeout(_predictionTimer);
-  clearTimeout(_graphTimer);
+  cancelCompute();
   autoApplying = true;
   autoApplyGeneration += 1;
   runAutoApply(autoApplyGeneration);
@@ -1985,8 +2079,7 @@ function stopAutoApply() {{
 function beginApplyKey() {{
   if (!modelLoaded) return;
   applyKeyHeld = true;
-  clearTimeout(_predictionTimer);
-  clearTimeout(_graphTimer);
+  cancelCompute();
   // Preserve tap-to-apply: consume the visible prediction once, then only
   // enter the continuous request pump if the key remains down.
   let firstApply = Promise.resolve(true);
@@ -2598,6 +2691,7 @@ bindEditor();
 bindHelp();
 bindScan();
 refreshModelInfo();
+computeThroughput();
 </script>
 </body></html>"""
 
@@ -2699,6 +2793,7 @@ class Handler(BaseHTTPRequestHandler):
             "/load_lesson",
             "/batch_rollout",
             "/factory_yaml",
+            "/throughput",
         ):
             self.send_error(404)
             return
@@ -2711,6 +2806,8 @@ class Handler(BaseHTTPRequestHandler):
                 return
             if self.path == "/graph":
                 result = render_graph_png(payload["grid"])
+            elif self.path == "/throughput":
+                result = _throughput(build_world(payload["grid"]))
             elif self.path == "/factory_yaml":
                 result = {
                     "yaml": factory_yaml(payload["grid"], payload.get("source"))

--- a/tests/test_factory_builder.py
+++ b/tests/test_factory_builder.py
@@ -324,9 +324,12 @@ class TestRenderGraphPng:
                       "item": "copper_cable", "misc": "NONE",
                       "footprint": "AVAILABLE"}
         out = fb.render_graph_png(grid)
-        # A non-empty PNG was produced and throughput was computed.
         assert len(out["png"]) > 0
-        assert "throughput" in out["info"]
+        assert out["info"] == "6 nodes · 6 edges"
+        # Throughput deliberately does NOT ride on this response: it costs
+        # ~0.1 ms and this call costs ~1 s of matplotlib, so bundling them
+        # made the readout wait on the image.
+        assert "thput" not in out
         # The source→belt→belt→sink chain must be present (canonical
         # <char>@x,y node labels).
         flat = " ".join(u + " " + v for u, v in out["edges"])
@@ -525,6 +528,9 @@ class TestPredictSchema:
             result = fb._predict_action(_empty_grid(4))
             assert set(result) == {
                 "x", "y", "entity", "direction", "item", "misc", "eot_prob",
+                # The throughput rides along so the readout can track a
+                # held-`a` build without a request of its own.
+                "thput", "note",
             }
             assert 0 <= result["x"] < 4
             assert 0 <= result["y"] < 4
@@ -539,10 +545,7 @@ class TestPredictSchema:
             compact = fb._predict_action(grid)
             detailed = fb._predict(grid)
             assert compact == {
-                key: detailed[key]
-                for key in (
-                    "x", "y", "entity", "direction", "item", "misc", "eot_prob",
-                )
+                key: detailed[key] for key in compact
             }
         finally:
             path.unlink(missing_ok=True)
@@ -982,6 +985,88 @@ class TestRenderIndexScanTab:
             path.unlink(missing_ok=True)
         result = next(e for e in events if e["type"] == "result")
         assert read_fields <= set(result), read_fields - set(result)
+
+
+class TestThroughputReadout:
+    """The number above the grid is what a newbie reads to tell a working
+    factory from a broken one, so it must be right and must not wait on the
+    graph image."""
+
+    def test_reports_the_engines_number(self):
+        factory, _seed = fb._build_with_retry(LessonKind.SPLITTER_SPLIT, 11, 3)
+        grid = fb.world_CWH_to_grid(factory.world_CWH)
+        out = fb._throughput(fb.build_world(grid))
+        want, unreachable = factorion_rs.simulate_throughput(
+            fb.build_world(grid).numpy().astype(np.int64)
+        )
+        assert out == {"thput": want, "unreachable": unreachable}
+        assert out["thput"] > 0  # a solved lesson flows
+
+    def test_empty_grid_is_neutral_not_blocked(self):
+        """Zero and "nothing here yet" look identical in a number but not to
+        a user: a blank grid must not be flagged as a broken factory."""
+        out = fb._throughput(fb.build_world(_empty_grid(5)))
+        assert out["thput"] is None and out["note"]
+
+    def test_disconnected_factory_reads_as_blocked(self):
+        grid = _empty_grid(5)
+        grid[0][0] = {"entity": "stack_inserter", "direction": "EAST",
+                      "item": "copper_cable", "misc": "NONE",
+                      "footprint": "AVAILABLE"}
+        grid[4][4] = {"entity": "bulk_inserter", "direction": "EAST",
+                      "item": "copper_cable", "misc": "NONE",
+                      "footprint": "AVAILABLE"}
+        assert fb._throughput(fb.build_world(grid))["thput"] == 0
+
+    def test_rides_on_both_prediction_paths(self):
+        """Both are the responses that already built the world, so neither
+        should make the readout pay for a request of its own."""
+        path = _make_tiny_checkpoint(size=4, chan=8)
+        try:
+            fb._load_checkpoint(str(path))
+            grid = _empty_grid(4)
+            assert "thput" in fb._predict(grid)
+            assert "thput" in fb._predict_action(grid)
+        finally:
+            path.unlink(missing_ok=True)
+
+
+class TestRenderIndexThroughput:
+    def test_readout_sits_above_the_grid(self):
+        html = fb.render_index(default_size=11)
+        assert html.index('id="thput"') < html.index('id="grid-host"')
+        # Both verdicts, and the spinner for the wait in between.
+        assert "=&gt;&gt;=" in html and "=X=" in html
+        assert "factory throughput: calculating…" in html
+        assert "class=\"spinner\"" in html
+
+    def test_readout_never_queues_behind_the_graph_image(self):
+        """The whole point of the split: the graph call is ~1 s of matplotlib
+        and the server answers one request at a time, so a readout that waited
+        on it would be ~10000x slower than the number costs to compute."""
+        html = fb.render_index(default_size=11)
+        assert "setTimeout(computePrediction, 25)" in html
+        assert "setTimeout(computeGraph, 1000)" in html
+        # computeGraph must not be the thing that feeds the readout.
+        graph_fn = html.split("async function computeGraph(")[1].split("\n}")[0]
+        assert "showThput" not in graph_fn
+
+    def test_held_apply_updates_the_readout_as_it_builds(self):
+        html = fb.render_index(default_size=11)
+        loop = html.split("async function runAutoApply(")[1].split("\n}")[0]
+        assert "showThput(action)" in loop
+
+    def test_falls_back_to_its_own_endpoint_with_no_model(self):
+        """Without a checkpoint nothing else asks the server anything, and
+        hand-building a factory is exactly when the readout matters most."""
+        html = fb.render_index(default_size=11)
+        assert "fetch('/throughput'" in html
+        assert "/throughput" in inspect.getsource(fb.Handler.do_POST)
+        # The body up to the first `return;` is the no-model early exit.
+        fn = html.split("async function computePrediction(")[1].split("\n}")[0]
+        early_exit = fn.split("return;")[0]
+        assert "!modelLoaded" in early_exit
+        assert "computeThroughput()" in early_exit
 
 
 class TestFactoryYaml:

--- a/tests/test_factory_builder.py
+++ b/tests/test_factory_builder.py
@@ -1042,6 +1042,9 @@ class TestRenderIndexThroughput:
         assert "<svg" in fb.OK_ICON and "<svg" in fb.BAD_ICON
         assert "factory throughput:" in html
         assert "calculating…" in html
+        # The card itself carries the verdict, not just the icon.
+        assert ".thput.ok" in html and ".thput.bad" in html
+        assert "'thput ok' : 'thput bad'" in html
         assert 'class="spinner"' in html
         assert "items per second" in html
 

--- a/tests/test_factory_builder.py
+++ b/tests/test_factory_builder.py
@@ -1035,10 +1035,15 @@ class TestRenderIndexThroughput:
     def test_readout_sits_above_the_grid(self):
         html = fb.render_index(default_size=11)
         assert html.index('id="thput"') < html.index('id="grid-host"')
-        # Both verdicts, and the spinner for the wait in between.
-        assert "=&gt;&gt;=" in html and "=X=" in html
-        assert "factory throughput: calculating…" in html
-        assert "class=\"spinner\"" in html
+        # Both verdicts, and the spinner for the wait in between. The icons
+        # are inline SVG so a viewer without the right font still gets one.
+        assert f"const OK_ICON = '{fb.OK_ICON}'" in html
+        assert f"const BAD_ICON = '{fb.BAD_ICON}'" in html
+        assert "<svg" in fb.OK_ICON and "<svg" in fb.BAD_ICON
+        assert "factory throughput:" in html
+        assert "calculating…" in html
+        assert 'class="spinner"' in html
+        assert "items per second" in html
 
     def test_readout_never_queues_behind_the_graph_image(self):
         """The whole point of the split: the graph call is ~1 s of matplotlib


### PR DESCRIPTION
Makes it obvious whether a factory works, and stops the answer waiting on the
graph image.

## The readout

Moved out of the graph panel to directly above the grid. The label leads in all
three states so the line keeps its shape whether the answer is in yet or not:

| state | reads |
|---|---|
| flowing | `factory throughput:` ✓ **15.00 items per second** → |
| blocked | `factory throughput:` ✗ **0.00 items per second** · *nothing reaches a sink* |
| waiting | `factory throughput:` ◌ *calculating…* |
| empty grid | `factory throughput:` *nothing placed yet* |

An empty grid deliberately does **not** read as blocked: zero and "nothing here
yet" are the same number but not the same situation, and flagging a blank grid
as a broken factory is noise.

Icons are inline SVG rather than emoji — this glyph *is* the answer, so it
can't depend on the viewer having an emoji font (emoji rendered as tofu in the
browser used to verify this).

`simulate_throughput` is a power-mean of the per-sink rates, so "items per
second" is the correct unit (a mean across sinks, not a total).

## Why it was slow

Measured on an 11×11 `FACTORY_1_INGREDIENT`:

| | cost |
|---|---|
| `simulate_throughput` | **0.12 ms** |
| `render_graph_png` (matplotlib + PNG) | **1178 ms** |
| PNG payload | 214 KB base64, ~1 ms over localhost |

So it was the matplotlib *render* blocking the number, not the transfer — and
the two were bundled in one `/graph` response behind a 1 s debounce. Roughly
2.2 s of waiting for something that costs 0.12 ms.

At that price the throughput doesn't need a request of its own: it now rides on
the `/predict` responses, which have **already built the world tensor**, so it
costs nothing extra. Both prediction paths carry it, including the fast one the
held-`a` loop uses — so the readout tracks a build as it happens (one placement
behind) instead of going stale until the key is released.

Measured end to end through a real browser against `h76h80yb`: generate, hold
`a` to build, release — the readout settles in **73–77 ms**, down from ~2.2 s.

`/throughput` exists as a standalone endpoint for the one case where nothing
else asks the server anything: no checkpoint loaded. Hand-building a factory
without a model is exactly when the readout matters most.

## Testing

- `TestThroughputReadout` — matches `simulate_throughput` exactly; an empty
  grid is neutral rather than blocked; a disconnected source/sink pair reads
  zero; both prediction paths carry the fields.
- `TestRenderIndexThroughput` — the readout is above `#grid-host` in the
  markup; both icons and the spinner are present; `computeGraph` does **not**
  feed the readout (the regression the split exists to prevent); the held-`a`
  loop updates it; the no-model path falls back to `/throughput`.
- `test_belt_chain_renders_png_and_edges` now asserts throughput is *absent*
  from the graph response, pinning the split from the other side.
- Three stale assertions updated for the intended change (the graph `info`
  string and two `_predict_action` key sets).
- All three states captured from a real browser driving the `h76h80yb`
  checkpoint through generate → hold-`a` → release.
- Full suite: 3306 passed, `ruff check`, `ty check` clean.