### PR TITLE
Track the raised Claude timesteps cap in the clamp tests

### DIFF
--- a/tests/test_ci_gh_command.py
+++ b/tests/test_ci_gh_command.py
@@ -348,7 +348,7 @@ class TestClaudeAuthoredLimits:
             (
                 "/ci ppo --start-from j0s5y2mc --total-timesteps 40000000",
                 "total_timesteps",
-                2_000_000,
+                5_000_000,
                 40000000,
             ),
         ],
@@ -399,7 +399,7 @@ class TestClaudeAuthoredLimits:
 
         specs = [_job_spec(p) for p in gh_ctx["pods"]]
         assert all(s["seeds"] == [1, 2, 3] for s in specs)
-        assert all(s["total_timesteps"] == 2_000_000 for s in specs)
+        assert all(s["total_timesteps"] == 5_000_000 for s in specs)
 
     @pytest.mark.parametrize(
         "run_cap,footer,launches",


### PR DESCRIPTION
`3df31bc` raised `CLAUDE_MAX_TOTAL_TIMESTEPS` 2M → 5M directly on main; `tests/test_ci_gh_command.py::TestClaudeAuthoredLimits` pins the capped value in two places, so `python-tests` is red on main and on every branch rebased onto it (first seen on #398). This updates the two literals to 5M.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111hhnS39Cp9xQHKksp9J2i

---
_Generated by [Claude Code](https://claude.ai/code/session_0111hhnS39Cp9xQHKksp9J2i)_