### PR TITLE
Arm A (seed-2 replica): normalized marginal reward, seed 2

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -738,6 +738,16 @@ class FactorioEnv(gym.Env):
 
         return location_match, entity_match, direction_match
 
+    def _world_cost(self, ent_np):
+        """(entity_cost, cost_efficiency) of a world's entity channel."""
+        counts = np.bincount(
+            np.asarray(ent_np, dtype=np.int64).ravel(),
+            minlength=_N_ENTITIES,
+        )[:_N_ENTITIES]
+        entity_units = counts / _ENTITY_FOOTPRINT_AREAS
+        entity_cost = float(np.dot(entity_units, _ENTITY_UNIT_COSTS))
+        return entity_cost, 1.0 / (1.0 + self.entity_cost_scale * entity_cost)
+
     def _cache_solution_match(self):
         """Precompute the episode-constant pieces of `_compute_solution_match`.
         Called once per `reset`, after `_solved_world_CWH` is set. Cached as
@@ -847,6 +857,15 @@ class FactorioEnv(gym.Env):
 
         self.min_entities_required = min_entities_required
         self._original_world_CWH = torch.clone(self._world_CWH)
+        # Cost-adjusted score of the world as handed to the agent. The terminal
+        # reward pays only the improvement over this, so flow that exists
+        # before the agent acts (a protected obstruction line) earns nothing
+        # and destroying it earns negative (#339).
+        raw0, _ = factorion_rs.simulate_throughput(
+            self._world_CWH.permute(1, 2, 0).to(torch.int64).numpy()
+        )
+        _, ce0 = self._world_cost(self._world_CWH.numpy()[_CH_ENT])
+        self._reward_baseline = raw0 * ce0
         self._prev_match = self._compute_solution_match()
         self.steps = 0
         return self._world_CWH.cpu().numpy(), self._get_info()
@@ -925,15 +944,7 @@ class FactorioEnv(gym.Env):
             else:
                 final_dir_reward = 0.0
 
-            counts = np.bincount(
-                np.asarray(ent_np, dtype=np.int64).ravel(),
-                minlength=_N_ENTITIES,
-            )[:_N_ENTITIES]
-            entity_units = counts / _ENTITY_FOOTPRINT_AREAS
-            entity_cost = float(np.dot(entity_units, _ENTITY_UNIT_COSTS))
-            cost_efficiency = 1.0 / (
-                1.0 + self.entity_cost_scale * entity_cost
-            )
+            entity_cost, cost_efficiency = self._world_cost(ent_np)
 
             # ── Diagnostic tile-match metrics (logged, NOT used in reward) ──
             if self._sol_n > 0:
@@ -965,17 +976,23 @@ class FactorioEnv(gym.Env):
 
         reward = 0.0
         if terminated or truncated:
-            # Multiplication makes cost a secondary modifier of achieved
-            # throughput: a no-output factory always earns zero terminal
-            # throughput reward, however many entities it contains.
-            reward = thput_raw * cost_efficiency
+            # Improvement over the reset state, scaled by the factory's
+            # reference rate. Marginal, so pre-existing protected flow pays
+            # zero and damaging it pays negative (#339). Ceiling-scaled, so
+            # within a lesson reward ratios equal raw throughput ratios —
+            # under γ < 1 a compressed reward makes stopping at a half-build
+            # beat finishing it (the measured lazy equilibrium, #371) — while
+            # lessons whose ceilings differ ~360x still contribute comparable
+            # gradient. Cost stays a multiplier on the achieved score: a
+            # no-output factory earns zero however many entities it contains.
+            if self._max_throughput > 0:
+                reward = (
+                    thput_raw * cost_efficiency - self._reward_baseline
+                ) / self._max_throughput
             if self.reward_symlog_r0 > 0:
-                # Compress so lessons whose ceilings differ by ~360x contribute
-                # comparable gradient. Compressing the cost-adjusted reward
-                # rather than subtracting a log-space cost term keeps zero
-                # throughput at exactly zero; above the knee the two agree to
-                # <0.005 anyway, since log1p(x*ce/r0) -> ln(x/r0) - ln(1/ce).
-                reward = math.log1p(reward / self.reward_symlog_r0)
+                reward = math.copysign(
+                    math.log1p(abs(reward) / self.reward_symlog_r0), reward
+                )
 
         self._thput_raw = thput_raw
         self._thput_normed = thput_normed

--- a/tests/test_ci_gh_command.py
+++ b/tests/test_ci_gh_command.py
@@ -348,7 +348,7 @@ class TestClaudeAuthoredLimits:
             (
                 "/ci ppo --start-from j0s5y2mc --total-timesteps 40000000",
                 "total_timesteps",
-                2_000_000,
+                5_000_000,
                 40000000,
             ),
         ],
@@ -399,7 +399,7 @@ class TestClaudeAuthoredLimits:
 
         specs = [_job_spec(p) for p in gh_ctx["pods"]]
         assert all(s["seeds"] == [1, 2, 3] for s in specs)
-        assert all(s["total_timesteps"] == 2_000_000 for s in specs)
+        assert all(s["total_timesteps"] == 5_000_000 for s in specs)
 
     @pytest.mark.parametrize(
         "run_cap,footer,launches",

--- a/tests/test_early_termination.py
+++ b/tests/test_early_termination.py
@@ -24,9 +24,14 @@ def _make_env(size=5, max_steps=10, **kwargs):
 
 def _expected_reward(env, info):
     """The terminal reward the env's configured scheme should have paid."""
-    reward = info["thput_raw"] * info["cost_efficiency"]
+    score = info["thput_raw"] * info["cost_efficiency"]
+    reward = (
+        (score - env._reward_baseline) / env._max_throughput
+        if env._max_throughput > 0
+        else 0.0
+    )
     if env.reward_symlog_r0 > 0:
-        return math.log1p(reward / env.reward_symlog_r0)
+        return math.copysign(math.log1p(abs(reward) / env.reward_symlog_r0), reward)
     return reward
 
 
@@ -104,13 +109,13 @@ class TestEarlyTermination:
 
 
 class TestReward:
-    """Reward = raw_throughput * cost_efficiency, log-compressed at r0 unless
-    the compression is disabled. The cost multiplier is bounded in (0, 1] and
-    log1p is non-negative on it, so cost can reduce reward but never make it
-    negative under either scheme."""
+    """Terminal reward = (thput_raw * cost_efficiency - reset baseline) /
+    max_throughput: the agent is paid only for improving on the world it was
+    handed, in units of the factory's reference rate."""
 
-    def test_solved_factory_with_eot_pays_raw_throughput_reward(self):
-        """Declaring eot on a solved factory pays cost-adjusted raw throughput."""
+    def test_eot_without_improvement_pays_zero(self):
+        """A factory already solved at reset earns nothing: the baseline
+        absorbs its whole score, so eot-without-acting pays exactly zero."""
         env = _make_env(size=5, max_steps=10)
         env.reset(seed=42, options={"num_missing_entities": 0})
 
@@ -120,7 +125,7 @@ class TestReward:
 
         assert terminated is True
         assert info["thput_normed"] >= 1.0
-        assert reward == pytest.approx(_expected_reward(env, info))
+        assert reward == 0.0
 
     def test_mid_episode_reward_is_zero(self):
         env = _make_env(size=5, max_steps=20)
@@ -163,45 +168,53 @@ class TestReward:
         assert info["thput_normed"] < 1.0  # ended early, not a full solve
         assert reward == pytest.approx(_expected_reward(env, info))
 
-    def test_entity_cost_reduces_reward(self):
-        """A non-zero entity cost lowers the reward below the pure
-        throughput term."""
-        env = _make_env(size=5, max_steps=10)
+    @pytest.mark.parametrize("reward_symlog_r0", [0.0, 0.01])
+    def test_junk_placement_on_unimproved_factory_pays_negative(
+        self, reward_symlog_r0
+    ):
+        """Adding an entity that raises cost without raising throughput drops
+        the score below the reset baseline, so the terminal reward goes
+        negative (and stays negative through the optional compression)."""
+        env = _make_env(size=7, max_steps=10, reward_symlog_r0=reward_symlog_r0)
         env.entity_cost_scale = 0.01
-        env.reset(seed=42, options={"num_missing_entities": 0})
+        env.reset(
+            seed=42,
+            options={"num_missing_entities": 0, "kind": LessonKind.MOVE_ONE_ITEM},
+        )
+
+        # A belt whose four neighbours are all empty cannot touch the solved
+        # route, so it changes cost but not throughput.
+        entity_grid = env._world_CWH[Channel.ENTITIES.value]
+        ent = entity_grid.numpy()
+        x, y = next(
+            (int(x), int(y))
+            for x, y in np.argwhere(ent == 0)
+            if 0 < x < env.size - 1
+            and 0 < y < env.size - 1
+            and ent[x - 1, y] == 0
+            and ent[x + 1, y] == 0
+            and ent[x, y - 1] == 0
+            and ent[x, y + 1] == 0
+        )
+        entity_grid[x, y] = str2ent("transport_belt").value
+        env._world_CWH[Channel.DIRECTION.value, x, y] = Direction.NORTH.value
 
         action = _noop_action()
         action["eot"] = 1
         _, reward, terminated, _, info = env.step(action)
 
         assert terminated is True
+        assert info["thput_normed"] >= 1.0
         assert reward == pytest.approx(_expected_reward(env, info))
-        assert info["entity_cost"] > 0
-        assert reward < math.log1p(info["thput_raw"] / env.reward_symlog_r0)
-
-    def test_entity_cost_reduces_reward_multiplicatively_without_log(self):
-        """With the log transform off, cost is a multiplier bounded in (0, 1]."""
-        env = _make_env(size=5, max_steps=10, reward_symlog_r0=0.0)
-        env.entity_cost_scale = 0.01
-        env.reset(seed=42, options={"num_missing_entities": 0})
-
-        action = _noop_action()
-        action["eot"] = 1
-        _, reward, terminated, _, info = env.step(action)
-
-        assert terminated is True
-        expected = info["thput_raw"] * info["cost_efficiency"]
-        assert reward == pytest.approx(expected)
-        assert info["entity_cost"] > 0
-        assert 0 < info["cost_efficiency"] < 1
-        assert reward < info["thput_raw"]
+        assert reward < 0
 
     @pytest.mark.parametrize("reward_symlog_r0", [0.0, 0.01])
     def test_zero_throughput_cost_penalty_is_never_negative(self, reward_symlog_r0):
         """Entities that deliver nothing must score exactly zero, not negative:
         else an empty grid beats a nearly-complete factory and the policy is
-        rewarded for building nothing. Holds under either scheme because the
-        cost multiplier is bounded in (0, 1] and log1p(0) == 0."""
+        rewarded for building nothing. Holds because cost multiplies the
+        achieved score — zero throughput on a zero-baseline factory stays
+        exactly zero however large the cost."""
         env = FactorioEnv(
             size=5,
             max_steps=10,
@@ -236,33 +249,84 @@ class TestReward:
         assert reward == 0
 
 
-class TestLogRewardScaleCompression:
-    """The point of the log transform: lessons whose achievable items/s differ
-    by orders of magnitude must not differ by orders of magnitude in reward."""
+class TestRewardScaleNormalization:
+    """The point of dividing by the factory's reference rate: lessons whose
+    achievable items/s differ by orders of magnitude must pay near-identical
+    reward for a full solve."""
 
     def _solved_reward(self, kind, size=11):
-        """Terminal reward for eot on an already-solved factory of `kind`."""
+        """Terminal reward for building `kind`'s reference solve from blank."""
         env = _make_env(size=size, max_steps=10)
-        env.reset(seed=7, options={"num_missing_entities": 0, "kind": kind})
+        for seed in range(20):
+            try:
+                env.reset(seed=seed, options={"kind": kind})
+                break
+            except RuntimeError:
+                continue
+        env._world_CWH.copy_(env._solved_world_CWH)
         action = _noop_action()
         action["eot"] = 1
         _, reward, _, _, info = env.step(action)
         return reward, info["thput_raw"]
 
-    def test_belt_and_assembler_rewards_are_within_one_order_of_magnitude(self):
+    def test_belt_and_assembler_solves_pay_the_same(self):
         belt_r, belt_thput = self._solved_reward(LessonKind.MOVE_ONE_ITEM)
         asm_r, asm_thput = self._solved_reward(
             LessonKind.MEMORISE_4_INGREDIENT_RECIPES
         )
 
-        raw_ratio = belt_thput / asm_thput
-        reward_ratio = belt_r / asm_r
-
-        assert raw_ratio > 50, "expected a large raw items/s gap between lessons"
-        assert reward_ratio < 10, (
-            f"log reward still spreads lessons {reward_ratio:.1f}x "
-            f"(raw gap {raw_ratio:.1f}x)"
+        assert belt_thput / asm_thput > 50, (
+            "expected a large raw items/s gap between lessons"
         )
+        assert 0.8 < belt_r <= 1.0
+        assert 0.8 < asm_r <= 1.0
+
+
+class TestMarginalRewardBaseline:
+    """CROSS_UNDER_BELT's protected obstruction line delivers before the agent
+    acts. The reward must not pay for that pre-existing flow (instant EOT would
+    bank it) and must charge for destroying it."""
+
+    def _reset_cross(self, env):
+        for seed in range(20):
+            try:
+                return env.reset(
+                    seed=seed, options={"kind": LessonKind.CROSS_UNDER_BELT}
+                )
+            except RuntimeError:
+                continue
+        pytest.fail("no CROSS_UNDER_BELT factory built in 20 seeds")
+
+    def test_pre_existing_flow_pays_zero(self):
+        env = _make_env(size=11, max_steps=10)
+        self._reset_cross(env)
+
+        action = _noop_action()
+        action["eot"] = 1
+        _, reward, terminated, _, info = env.step(action)
+
+        assert terminated is True
+        assert info["thput_raw"] > 0, "the protected line should deliver"
+        assert reward == 0.0
+
+    def test_destroying_the_protected_line_pays_negative(self):
+        env = _make_env(size=11, max_steps=10)
+        self._reset_cross(env)
+
+        ent = env._world_CWH[Channel.ENTITIES.value].numpy()
+        xs, ys = np.nonzero(ent == str2ent("transport_belt").value)
+        action = _noop_action()
+        action["xy"] = np.array([int(xs[0]), int(ys[0])])
+        _, mid_reward, terminated, truncated, _ = env.step(action)
+        assert not terminated and not truncated and mid_reward == 0
+
+        action = _noop_action()
+        action["eot"] = 1
+        _, reward, terminated, _, info = env.step(action)
+
+        assert terminated is True
+        assert info["thput_raw"] < env._reward_baseline
+        assert reward < 0
 
 
 class TestStepsTaken:

--- a/tests/test_rl_from_checkpoint.py
+++ b/tests/test_rl_from_checkpoint.py
@@ -150,7 +150,7 @@ class TestEotTerminationAndMetrics:
 
     def test_reward_symlog_r0_default(self):
         a = PpoArgs()
-        assert a.reward_symlog_r0 == 0.01
+        assert a.reward_symlog_r0 == 0.0
 
 
 class TestCriticWarmupParamSplit:

--- a/training_config.py
+++ b/training_config.py
@@ -33,7 +33,7 @@ class SharedArgs:
     between the two so an SFT checkpoint loads into the PPO policy unchanged.
     """
 
-    seed: int = 1
+    seed: int = 2
     """seed of the experiment"""
     size: int = 11
     """the width and height of the factory grid"""

--- a/training_config.py
+++ b/training_config.py
@@ -139,9 +139,10 @@ class PpoArgs(SharedArgs):
     """strength of the multiplicative terminal entity-cost penalty. Each
     entity costs its per-output recursively-expanded raw-item count plus
     cumulative craft time."""
-    reward_symlog_r0: float = 0.01
-    """reference flow (items/s) at which the terminal reward is log-compressed:
-    `log1p(thput_raw * cost_efficiency / r0)`."""
+    reward_symlog_r0: float = 0.0
+    """optional compression knee for the terminal reward: when > 0 the
+    ceiling-normalized marginal reward r becomes sign(r) * log1p(|r| / r0).
+    0 disables — the reward is already O(1) for every lesson."""
     max_grad_norm: float = 1.221
     """the maximum norm for the gradient clipping"""
     target_kl: Optional[float] = 0.02


### PR DESCRIPTION
Identical to #398 except `seed: 1 → 2`. Purpose: `/ci ppo` can't override seeds (only compares can, and full compares double the cost), so this replica checks that #398's deltas aren't a seed-1 artifact. The collapse-prevention effects (CROSS +0.31, MERGE +0.30 at matched steps) are far above the single-seed noise floor, but the headline `eval/thput` delta (+0.09) and the trial drift (−0.01) sit close enough to it that a second seed materially changes confidence.

Not meant to merge — this PR exists to carry the run; it will be closed once read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111hhnS39Cp9xQHKksp9J2i

---
_Generated by [Claude Code](https://claude.ai/code/session_0111hhnS39Cp9xQHKksp9J2i)_