### PR TITLE
Arm A.A.C: dense per-step marginal reward (on A + gamma 0.997)

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -544,15 +544,11 @@ def make_env(
     size,
     run_name,
     entity_cost_scale=PpoArgs.entity_cost_scale,
-    reward_symlog_r0=PpoArgs.reward_symlog_r0,
-    dense_reward=PpoArgs.dense_reward,
 ):
     def thunk():
         kwargs: dict[str, Any] = {"render_mode": "rgb_array"} if capture_video else {}
         kwargs.update({'size': size, 'max_steps': size*size, 'idx': idx,
-                       'entity_cost_scale': entity_cost_scale,
-                       'reward_symlog_r0': reward_symlog_r0,
-                       'dense_reward': dense_reward})
+                       'entity_cost_scale': entity_cost_scale})
         env = gym.make(env_id, **kwargs)
         if capture_video:
             env = gym.wrappers.RecordVideo(env, f"videos/{run_name}/env_{idx}", episode_trigger=lambda e: (e+1) % 10 == 0)
@@ -618,17 +614,11 @@ class FactorioEnv(gym.Env):
         idx: Optional[int] = None,
         options: Optional[dict] = None,
         entity_cost_scale: float = PpoArgs.entity_cost_scale,
-        reward_symlog_r0: float = PpoArgs.reward_symlog_r0,
-        dense_reward: bool = PpoArgs.dense_reward,
     ):
         super().__init__()
         if entity_cost_scale < 0:
             raise ValueError("entity_cost_scale must be non-negative")
-        if reward_symlog_r0 < 0:
-            raise ValueError("reward_symlog_r0 must be non-negative")
         self.entity_cost_scale = entity_cost_scale
-        self.reward_symlog_r0 = reward_symlog_r0
-        self.dense_reward = dense_reward
         if render_mode is not None:
             self.metadata = {"render_modes": [render_mode], "render_fps": 2}
             self.render_mode = render_mode
@@ -909,113 +899,72 @@ class FactorioEnv(gym.Env):
         terminated = eot_declared
         truncated = (not terminated) and (self.steps > self.max_steps)
 
-        # The throughput sim + per-step diagnostics below are only *consumed* at
-        # episode end (the terminal reward uses thput_raw; the rollout reads
-        # thput/frac_reachable/num_entities for finished envs) or by callers that
-        # inspect every step (tests, monitoring). Mid-episode they feed neither
-        # the reward (zero until termination) nor any metric the
-        # PPO rollout reads, so when `_full_diagnostics` is off (training rollout
-        # envs) we skip the whole block on non-terminal steps — that's the
-        # ~31%-of-rollout simulate_throughput + numpy diagnostics. The terminal
-        # reward and all episode-end-consumed values are still computed, so the
-        # signature is unchanged.
+        # The dense reward pays the per-step score delta, so the throughput sim
+        # (and the cheap numpy diagnostics that ride along) runs on every step.
         frac_hallucin = 0
-        if terminated or truncated or self._full_diagnostics or self.dense_reward:
-            # thput_raw is items/second; thput_normed in [0, 1] is raw / per-factory
-            # max (a perfectly-rebuilt factory scores 1.0 regardless of belt speed).
-            # self._max_throughput comes from the factory generator — see reset().
-            thput_raw, num_unreachable = factorion_rs.simulate_throughput(self._world_CWH.permute(1, 2, 0).to(torch.int64).numpy())
-            thput_normed = (
-                min(1.0, thput_raw / self._max_throughput)
-                if self._max_throughput > 0
-                else 0.0
-            )
-            # Single zero-copy numpy view of the (torch) world for the per-step
-            # diagnostics. Tiny-grid reductions; numpy on the shared buffer is far
-            # cheaper than the per-op torch dispatch. Current (world just mutated).
-            wnp = self._world_CWH.numpy()
-            ent_np = wnp[_CH_ENT]
-            dir_np = wnp[_CH_DIR]
-            W, H = ent_np.shape
+        # thput_raw is items/second; thput_normed in [0, 1] is raw / per-factory
+        # max (a perfectly-rebuilt factory scores 1.0 regardless of belt speed).
+        # self._max_throughput comes from the factory generator — see reset().
+        thput_raw, num_unreachable = factorion_rs.simulate_throughput(self._world_CWH.permute(1, 2, 0).to(torch.int64).numpy())
+        thput_normed = (
+            min(1.0, thput_raw / self._max_throughput)
+            if self._max_throughput > 0
+            else 0.0
+        )
+        # Single zero-copy numpy view of the (torch) world for the per-step
+        # diagnostics. Tiny-grid reductions; numpy on the shared buffer is far
+        # cheaper than the per-op torch dispatch. Current (world just mutated).
+        wnp = self._world_CWH.numpy()
+        ent_np = wnp[_CH_ENT]
+        dir_np = wnp[_CH_DIR]
+        W, H = ent_np.shape
 
-            # "reachable" fraction: penalise entities disconnected from the graph.
-            num_entities = int(np.count_nonzero(ent_np))
-            frac_reachable = 0 if num_entities == 2 else max(0, 1.0 - (float(num_unreachable) / (num_entities - 2)))
+        # "reachable" fraction: penalise entities disconnected from the graph.
+        num_entities = int(np.count_nonzero(ent_np))
+        frac_reachable = 0 if num_entities == 2 else max(0, 1.0 - (float(num_unreachable) / (num_entities - 2)))
 
-            # Small shaping for a correctly-oriented final belt. Only meaningful
-            # with exactly one sink (MOVE_ONE_ITEM); zeroed otherwise.
-            sink_w, sink_h = np.nonzero(ent_np == self._sink_id)
-            if len(sink_w) == 1:
-                w_sink, h_sink = int(sink_w[0]), int(sink_h[0])
-                w_belt = min(max(w_sink, 1), W - 2)
-                h_belt = min(max(h_sink, 1), H - 2)
-                final_dir_reward = 1.0 if dir_np[w_belt, h_belt] == dir_np[w_sink, h_sink] else 0.0
-            else:
-                final_dir_reward = 0.0
-
-            entity_cost, cost_efficiency = self._world_cost(ent_np)
-
-            # ── Diagnostic tile-match metrics (logged, NOT used in reward) ──
-            if self._sol_n > 0:
-                tile_match_location = float(np.count_nonzero(self._sol_mask & (ent_np != 0))) / self._sol_n
-            else:
-                tile_match_location = 1.0
-            tile_match_entity = float(np.mean(ent_np == self._sol_orig_ent))
-            tile_match_direction = float(np.mean(dir_np == self._sol_orig_dir))
-
-            # ── Delta-based shaping diagnostics (logged, NOT in reward) ──
-            curr_match = self._compute_solution_match()
-            loc_delta = curr_match[0] - self._prev_match[0]
-            ent_delta = curr_match[1] - self._prev_match[1]
-            dir_delta = curr_match[2] - self._prev_match[2]
-            self._prev_match = curr_match
+        # Small shaping for a correctly-oriented final belt. Only meaningful
+        # with exactly one sink (MOVE_ONE_ITEM); zeroed otherwise.
+        sink_w, sink_h = np.nonzero(ent_np == self._sink_id)
+        if len(sink_w) == 1:
+            w_sink, h_sink = int(sink_w[0]), int(sink_h[0])
+            w_belt = min(max(w_sink, 1), W - 2)
+            h_belt = min(max(h_sink, 1), H - 2)
+            final_dir_reward = 1.0 if dir_np[w_belt, h_belt] == dir_np[w_sink, h_sink] else 0.0
         else:
-            # Non-terminal training step: emit placeholders for the logged-only
-            # diagnostics (the rollout never reads these mid-episode).
-            thput_raw = 0.0
-            thput_normed = 0.0
-            num_entities = 0
-            frac_reachable = 0
             final_dir_reward = 0.0
-            entity_cost = 0.0
-            cost_efficiency = 1.0
-            tile_match_location = tile_match_entity = tile_match_direction = 0.0
-            curr_match = self._prev_match
-            loc_delta = ent_delta = dir_delta = 0.0
 
-        reward = 0.0
-        if self.dense_reward:
-            # Telescoped form of the terminal marginal reward: each step pays
-            # the change in ceiling-normalized cost-adjusted throughput, so the
-            # episode's undiscounted sum equals the terminal scheme exactly,
-            # but credit lands on the placement that caused it — improving an
-            # already-working build pays immediately instead of hinging on
-            # when the EOT fires.
-            score = (
-                thput_raw * cost_efficiency / self._max_throughput
-                if self._max_throughput > 0
-                else 0.0
-            )
-            reward = score - self._prev_score
-            self._prev_score = score
-        elif terminated or truncated:
-            # Improvement over the reset state, scaled by the factory's
-            # reference rate. Marginal, so pre-existing protected flow pays
-            # zero and damaging it pays negative (#339). Ceiling-scaled, so
-            # within a lesson reward ratios equal raw throughput ratios —
-            # under γ < 1 a compressed reward makes stopping at a half-build
-            # beat finishing it (the measured lazy equilibrium, #371) — while
-            # lessons whose ceilings differ ~360x still contribute comparable
-            # gradient. Cost stays a multiplier on the achieved score: a
-            # no-output factory earns zero however many entities it contains.
-            if self._max_throughput > 0:
-                reward = (
-                    thput_raw * cost_efficiency - self._reward_baseline
-                ) / self._max_throughput
-            if self.reward_symlog_r0 > 0:
-                reward = math.copysign(
-                    math.log1p(abs(reward) / self.reward_symlog_r0), reward
-                )
+        entity_cost, cost_efficiency = self._world_cost(ent_np)
+
+        # ── Diagnostic tile-match metrics (logged, NOT used in reward) ──
+        if self._sol_n > 0:
+            tile_match_location = float(np.count_nonzero(self._sol_mask & (ent_np != 0))) / self._sol_n
+        else:
+            tile_match_location = 1.0
+        tile_match_entity = float(np.mean(ent_np == self._sol_orig_ent))
+        tile_match_direction = float(np.mean(dir_np == self._sol_orig_dir))
+
+        # ── Delta-based shaping diagnostics (logged, NOT in reward) ──
+        curr_match = self._compute_solution_match()
+        loc_delta = curr_match[0] - self._prev_match[0]
+        ent_delta = curr_match[1] - self._prev_match[1]
+        dir_delta = curr_match[2] - self._prev_match[2]
+        self._prev_match = curr_match
+
+        # Telescoped form of the terminal marginal reward: each step pays the
+        # change in ceiling-normalized cost-adjusted throughput, so the
+        # episode's undiscounted sum is the improvement over the reset state in
+        # units of the factory's reference rate — pre-existing protected flow
+        # pays zero and damaging it pays negative (#339) — but credit lands on
+        # the placement that caused it: improving an already-working build
+        # pays immediately instead of hinging on when the EOT fires.
+        score = (
+            thput_raw * cost_efficiency / self._max_throughput
+            if self._max_throughput > 0
+            else 0.0
+        )
+        reward = score - self._prev_score
+        self._prev_score = score
 
         self._thput_raw = thput_raw
         self._thput_normed = thput_normed
@@ -1962,8 +1911,6 @@ if __name__ == "__main__":
             args.size,
             run_name,
             args.entity_cost_scale,
-            args.reward_symlog_r0,
-            args.dense_reward,
         )
         for i in range(args.num_envs)
     ]
@@ -2582,8 +2529,6 @@ if __name__ == "__main__":
                     args.size,
                     run_name,
                     args.entity_cost_scale,
-                    args.reward_symlog_r0,
-                    args.dense_reward,
                 )
                 for i in range(num_render_envs)
             ])

--- a/ppo.py
+++ b/ppo.py
@@ -738,6 +738,16 @@ class FactorioEnv(gym.Env):
 
         return location_match, entity_match, direction_match
 
+    def _world_cost(self, ent_np):
+        """(entity_cost, cost_efficiency) of a world's entity channel."""
+        counts = np.bincount(
+            np.asarray(ent_np, dtype=np.int64).ravel(),
+            minlength=_N_ENTITIES,
+        )[:_N_ENTITIES]
+        entity_units = counts / _ENTITY_FOOTPRINT_AREAS
+        entity_cost = float(np.dot(entity_units, _ENTITY_UNIT_COSTS))
+        return entity_cost, 1.0 / (1.0 + self.entity_cost_scale * entity_cost)
+
     def _cache_solution_match(self):
         """Precompute the episode-constant pieces of `_compute_solution_match`.
         Called once per `reset`, after `_solved_world_CWH` is set. Cached as
@@ -847,6 +857,15 @@ class FactorioEnv(gym.Env):
 
         self.min_entities_required = min_entities_required
         self._original_world_CWH = torch.clone(self._world_CWH)
+        # Cost-adjusted score of the world as handed to the agent. The terminal
+        # reward pays only the improvement over this, so flow that exists
+        # before the agent acts (a protected obstruction line) earns nothing
+        # and destroying it earns negative (#339).
+        raw0, _ = factorion_rs.simulate_throughput(
+            self._world_CWH.permute(1, 2, 0).to(torch.int64).numpy()
+        )
+        _, ce0 = self._world_cost(self._world_CWH.numpy()[_CH_ENT])
+        self._reward_baseline = raw0 * ce0
         self._prev_match = self._compute_solution_match()
         self.steps = 0
         return self._world_CWH.cpu().numpy(), self._get_info()
@@ -925,15 +944,7 @@ class FactorioEnv(gym.Env):
             else:
                 final_dir_reward = 0.0
 
-            counts = np.bincount(
-                np.asarray(ent_np, dtype=np.int64).ravel(),
-                minlength=_N_ENTITIES,
-            )[:_N_ENTITIES]
-            entity_units = counts / _ENTITY_FOOTPRINT_AREAS
-            entity_cost = float(np.dot(entity_units, _ENTITY_UNIT_COSTS))
-            cost_efficiency = 1.0 / (
-                1.0 + self.entity_cost_scale * entity_cost
-            )
+            entity_cost, cost_efficiency = self._world_cost(ent_np)
 
             # ── Diagnostic tile-match metrics (logged, NOT used in reward) ──
             if self._sol_n > 0:
@@ -965,17 +976,23 @@ class FactorioEnv(gym.Env):
 
         reward = 0.0
         if terminated or truncated:
-            # Multiplication makes cost a secondary modifier of achieved
-            # throughput: a no-output factory always earns zero terminal
-            # throughput reward, however many entities it contains.
-            reward = thput_raw * cost_efficiency
+            # Improvement over the reset state, scaled by the factory's
+            # reference rate. Marginal, so pre-existing protected flow pays
+            # zero and damaging it pays negative (#339). Ceiling-scaled, so
+            # within a lesson reward ratios equal raw throughput ratios —
+            # under γ < 1 a compressed reward makes stopping at a half-build
+            # beat finishing it (the measured lazy equilibrium, #371) — while
+            # lessons whose ceilings differ ~360x still contribute comparable
+            # gradient. Cost stays a multiplier on the achieved score: a
+            # no-output factory earns zero however many entities it contains.
+            if self._max_throughput > 0:
+                reward = (
+                    thput_raw * cost_efficiency - self._reward_baseline
+                ) / self._max_throughput
             if self.reward_symlog_r0 > 0:
-                # Compress so lessons whose ceilings differ by ~360x contribute
-                # comparable gradient. Compressing the cost-adjusted reward
-                # rather than subtracting a log-space cost term keeps zero
-                # throughput at exactly zero; above the knee the two agree to
-                # <0.005 anyway, since log1p(x*ce/r0) -> ln(x/r0) - ln(1/ce).
-                reward = math.log1p(reward / self.reward_symlog_r0)
+                reward = math.copysign(
+                    math.log1p(abs(reward) / self.reward_symlog_r0), reward
+                )
 
         self._thput_raw = thput_raw
         self._thput_normed = thput_normed

--- a/ppo.py
+++ b/ppo.py
@@ -545,12 +545,14 @@ def make_env(
     run_name,
     entity_cost_scale=PpoArgs.entity_cost_scale,
     reward_symlog_r0=PpoArgs.reward_symlog_r0,
+    dense_reward=PpoArgs.dense_reward,
 ):
     def thunk():
         kwargs: dict[str, Any] = {"render_mode": "rgb_array"} if capture_video else {}
         kwargs.update({'size': size, 'max_steps': size*size, 'idx': idx,
                        'entity_cost_scale': entity_cost_scale,
-                       'reward_symlog_r0': reward_symlog_r0})
+                       'reward_symlog_r0': reward_symlog_r0,
+                       'dense_reward': dense_reward})
         env = gym.make(env_id, **kwargs)
         if capture_video:
             env = gym.wrappers.RecordVideo(env, f"videos/{run_name}/env_{idx}", episode_trigger=lambda e: (e+1) % 10 == 0)
@@ -617,6 +619,7 @@ class FactorioEnv(gym.Env):
         options: Optional[dict] = None,
         entity_cost_scale: float = PpoArgs.entity_cost_scale,
         reward_symlog_r0: float = PpoArgs.reward_symlog_r0,
+        dense_reward: bool = PpoArgs.dense_reward,
     ):
         super().__init__()
         if entity_cost_scale < 0:
@@ -625,6 +628,7 @@ class FactorioEnv(gym.Env):
             raise ValueError("reward_symlog_r0 must be non-negative")
         self.entity_cost_scale = entity_cost_scale
         self.reward_symlog_r0 = reward_symlog_r0
+        self.dense_reward = dense_reward
         if render_mode is not None:
             self.metadata = {"render_modes": [render_mode], "render_fps": 2}
             self.render_mode = render_mode
@@ -866,6 +870,11 @@ class FactorioEnv(gym.Env):
         )
         _, ce0 = self._world_cost(self._world_CWH.numpy()[_CH_ENT])
         self._reward_baseline = raw0 * ce0
+        self._prev_score = (
+            self._reward_baseline / self._max_throughput
+            if self._max_throughput > 0
+            else 0.0
+        )
         self._prev_match = self._compute_solution_match()
         self.steps = 0
         return self._world_CWH.cpu().numpy(), self._get_info()
@@ -911,7 +920,7 @@ class FactorioEnv(gym.Env):
         # reward and all episode-end-consumed values are still computed, so the
         # signature is unchanged.
         frac_hallucin = 0
-        if terminated or truncated or self._full_diagnostics:
+        if terminated or truncated or self._full_diagnostics or self.dense_reward:
             # thput_raw is items/second; thput_normed in [0, 1] is raw / per-factory
             # max (a perfectly-rebuilt factory scores 1.0 regardless of belt speed).
             # self._max_throughput comes from the factory generator — see reset().
@@ -975,7 +984,21 @@ class FactorioEnv(gym.Env):
             loc_delta = ent_delta = dir_delta = 0.0
 
         reward = 0.0
-        if terminated or truncated:
+        if self.dense_reward:
+            # Telescoped form of the terminal marginal reward: each step pays
+            # the change in ceiling-normalized cost-adjusted throughput, so the
+            # episode's undiscounted sum equals the terminal scheme exactly,
+            # but credit lands on the placement that caused it — improving an
+            # already-working build pays immediately instead of hinging on
+            # when the EOT fires.
+            score = (
+                thput_raw * cost_efficiency / self._max_throughput
+                if self._max_throughput > 0
+                else 0.0
+            )
+            reward = score - self._prev_score
+            self._prev_score = score
+        elif terminated or truncated:
             # Improvement over the reset state, scaled by the factory's
             # reference rate. Marginal, so pre-existing protected flow pays
             # zero and damaging it pays negative (#339). Ceiling-scaled, so
@@ -1940,6 +1963,7 @@ if __name__ == "__main__":
             run_name,
             args.entity_cost_scale,
             args.reward_symlog_r0,
+            args.dense_reward,
         )
         for i in range(args.num_envs)
     ]
@@ -2559,6 +2583,7 @@ if __name__ == "__main__":
                     run_name,
                     args.entity_cost_scale,
                     args.reward_symlog_r0,
+                    args.dense_reward,
                 )
                 for i in range(num_render_envs)
             ])

--- a/tests/test_ci_gh_command.py
+++ b/tests/test_ci_gh_command.py
@@ -348,7 +348,7 @@ class TestClaudeAuthoredLimits:
             (
                 "/ci ppo --start-from j0s5y2mc --total-timesteps 40000000",
                 "total_timesteps",
-                2_000_000,
+                5_000_000,
                 40000000,
             ),
         ],
@@ -399,7 +399,7 @@ class TestClaudeAuthoredLimits:
 
         specs = [_job_spec(p) for p in gh_ctx["pods"]]
         assert all(s["seeds"] == [1, 2, 3] for s in specs)
-        assert all(s["total_timesteps"] == 2_000_000 for s in specs)
+        assert all(s["total_timesteps"] == 5_000_000 for s in specs)
 
     @pytest.mark.parametrize(
         "run_cap,footer,launches",

--- a/tests/test_early_termination.py
+++ b/tests/test_early_termination.py
@@ -24,9 +24,14 @@ def _make_env(size=5, max_steps=10, **kwargs):
 
 def _expected_reward(env, info):
     """The terminal reward the env's configured scheme should have paid."""
-    reward = info["thput_raw"] * info["cost_efficiency"]
+    score = info["thput_raw"] * info["cost_efficiency"]
+    reward = (
+        (score - env._reward_baseline) / env._max_throughput
+        if env._max_throughput > 0
+        else 0.0
+    )
     if env.reward_symlog_r0 > 0:
-        return math.log1p(reward / env.reward_symlog_r0)
+        return math.copysign(math.log1p(abs(reward) / env.reward_symlog_r0), reward)
     return reward
 
 
@@ -104,13 +109,13 @@ class TestEarlyTermination:
 
 
 class TestReward:
-    """Reward = raw_throughput * cost_efficiency, log-compressed at r0 unless
-    the compression is disabled. The cost multiplier is bounded in (0, 1] and
-    log1p is non-negative on it, so cost can reduce reward but never make it
-    negative under either scheme."""
+    """Terminal reward = (thput_raw * cost_efficiency - reset baseline) /
+    max_throughput: the agent is paid only for improving on the world it was
+    handed, in units of the factory's reference rate."""
 
-    def test_solved_factory_with_eot_pays_raw_throughput_reward(self):
-        """Declaring eot on a solved factory pays cost-adjusted raw throughput."""
+    def test_eot_without_improvement_pays_zero(self):
+        """A factory already solved at reset earns nothing: the baseline
+        absorbs its whole score, so eot-without-acting pays exactly zero."""
         env = _make_env(size=5, max_steps=10)
         env.reset(seed=42, options={"num_missing_entities": 0})
 
@@ -120,7 +125,7 @@ class TestReward:
 
         assert terminated is True
         assert info["thput_normed"] >= 1.0
-        assert reward == pytest.approx(_expected_reward(env, info))
+        assert reward == 0.0
 
     def test_mid_episode_reward_is_zero(self):
         env = _make_env(size=5, max_steps=20)
@@ -163,45 +168,53 @@ class TestReward:
         assert info["thput_normed"] < 1.0  # ended early, not a full solve
         assert reward == pytest.approx(_expected_reward(env, info))
 
-    def test_entity_cost_reduces_reward(self):
-        """A non-zero entity cost lowers the reward below the pure
-        throughput term."""
-        env = _make_env(size=5, max_steps=10)
+    @pytest.mark.parametrize("reward_symlog_r0", [0.0, 0.01])
+    def test_junk_placement_on_unimproved_factory_pays_negative(
+        self, reward_symlog_r0
+    ):
+        """Adding an entity that raises cost without raising throughput drops
+        the score below the reset baseline, so the terminal reward goes
+        negative (and stays negative through the optional compression)."""
+        env = _make_env(size=7, max_steps=10, reward_symlog_r0=reward_symlog_r0)
         env.entity_cost_scale = 0.01
-        env.reset(seed=42, options={"num_missing_entities": 0})
+        env.reset(
+            seed=42,
+            options={"num_missing_entities": 0, "kind": LessonKind.MOVE_ONE_ITEM},
+        )
+
+        # A belt whose four neighbours are all empty cannot touch the solved
+        # route, so it changes cost but not throughput.
+        entity_grid = env._world_CWH[Channel.ENTITIES.value]
+        ent = entity_grid.numpy()
+        x, y = next(
+            (int(x), int(y))
+            for x, y in np.argwhere(ent == 0)
+            if 0 < x < env.size - 1
+            and 0 < y < env.size - 1
+            and ent[x - 1, y] == 0
+            and ent[x + 1, y] == 0
+            and ent[x, y - 1] == 0
+            and ent[x, y + 1] == 0
+        )
+        entity_grid[x, y] = str2ent("transport_belt").value
+        env._world_CWH[Channel.DIRECTION.value, x, y] = Direction.NORTH.value
 
         action = _noop_action()
         action["eot"] = 1
         _, reward, terminated, _, info = env.step(action)
 
         assert terminated is True
+        assert info["thput_normed"] >= 1.0
         assert reward == pytest.approx(_expected_reward(env, info))
-        assert info["entity_cost"] > 0
-        assert reward < math.log1p(info["thput_raw"] / env.reward_symlog_r0)
-
-    def test_entity_cost_reduces_reward_multiplicatively_without_log(self):
-        """With the log transform off, cost is a multiplier bounded in (0, 1]."""
-        env = _make_env(size=5, max_steps=10, reward_symlog_r0=0.0)
-        env.entity_cost_scale = 0.01
-        env.reset(seed=42, options={"num_missing_entities": 0})
-
-        action = _noop_action()
-        action["eot"] = 1
-        _, reward, terminated, _, info = env.step(action)
-
-        assert terminated is True
-        expected = info["thput_raw"] * info["cost_efficiency"]
-        assert reward == pytest.approx(expected)
-        assert info["entity_cost"] > 0
-        assert 0 < info["cost_efficiency"] < 1
-        assert reward < info["thput_raw"]
+        assert reward < 0
 
     @pytest.mark.parametrize("reward_symlog_r0", [0.0, 0.01])
     def test_zero_throughput_cost_penalty_is_never_negative(self, reward_symlog_r0):
         """Entities that deliver nothing must score exactly zero, not negative:
         else an empty grid beats a nearly-complete factory and the policy is
-        rewarded for building nothing. Holds under either scheme because the
-        cost multiplier is bounded in (0, 1] and log1p(0) == 0."""
+        rewarded for building nothing. Holds because cost multiplies the
+        achieved score — zero throughput on a zero-baseline factory stays
+        exactly zero however large the cost."""
         env = FactorioEnv(
             size=5,
             max_steps=10,
@@ -236,33 +249,84 @@ class TestReward:
         assert reward == 0
 
 
-class TestLogRewardScaleCompression:
-    """The point of the log transform: lessons whose achievable items/s differ
-    by orders of magnitude must not differ by orders of magnitude in reward."""
+class TestRewardScaleNormalization:
+    """The point of dividing by the factory's reference rate: lessons whose
+    achievable items/s differ by orders of magnitude must pay near-identical
+    reward for a full solve."""
 
     def _solved_reward(self, kind, size=11):
-        """Terminal reward for eot on an already-solved factory of `kind`."""
+        """Terminal reward for building `kind`'s reference solve from blank."""
         env = _make_env(size=size, max_steps=10)
-        env.reset(seed=7, options={"num_missing_entities": 0, "kind": kind})
+        for seed in range(20):
+            try:
+                env.reset(seed=seed, options={"kind": kind})
+                break
+            except RuntimeError:
+                continue
+        env._world_CWH.copy_(env._solved_world_CWH)
         action = _noop_action()
         action["eot"] = 1
         _, reward, _, _, info = env.step(action)
         return reward, info["thput_raw"]
 
-    def test_belt_and_assembler_rewards_are_within_one_order_of_magnitude(self):
+    def test_belt_and_assembler_solves_pay_the_same(self):
         belt_r, belt_thput = self._solved_reward(LessonKind.MOVE_ONE_ITEM)
         asm_r, asm_thput = self._solved_reward(
             LessonKind.MEMORISE_4_INGREDIENT_RECIPES
         )
 
-        raw_ratio = belt_thput / asm_thput
-        reward_ratio = belt_r / asm_r
-
-        assert raw_ratio > 50, "expected a large raw items/s gap between lessons"
-        assert reward_ratio < 10, (
-            f"log reward still spreads lessons {reward_ratio:.1f}x "
-            f"(raw gap {raw_ratio:.1f}x)"
+        assert belt_thput / asm_thput > 50, (
+            "expected a large raw items/s gap between lessons"
         )
+        assert 0.8 < belt_r <= 1.0
+        assert 0.8 < asm_r <= 1.0
+
+
+class TestMarginalRewardBaseline:
+    """CROSS_UNDER_BELT's protected obstruction line delivers before the agent
+    acts. The reward must not pay for that pre-existing flow (instant EOT would
+    bank it) and must charge for destroying it."""
+
+    def _reset_cross(self, env):
+        for seed in range(20):
+            try:
+                return env.reset(
+                    seed=seed, options={"kind": LessonKind.CROSS_UNDER_BELT}
+                )
+            except RuntimeError:
+                continue
+        pytest.fail("no CROSS_UNDER_BELT factory built in 20 seeds")
+
+    def test_pre_existing_flow_pays_zero(self):
+        env = _make_env(size=11, max_steps=10)
+        self._reset_cross(env)
+
+        action = _noop_action()
+        action["eot"] = 1
+        _, reward, terminated, _, info = env.step(action)
+
+        assert terminated is True
+        assert info["thput_raw"] > 0, "the protected line should deliver"
+        assert reward == 0.0
+
+    def test_destroying_the_protected_line_pays_negative(self):
+        env = _make_env(size=11, max_steps=10)
+        self._reset_cross(env)
+
+        ent = env._world_CWH[Channel.ENTITIES.value].numpy()
+        xs, ys = np.nonzero(ent == str2ent("transport_belt").value)
+        action = _noop_action()
+        action["xy"] = np.array([int(xs[0]), int(ys[0])])
+        _, mid_reward, terminated, truncated, _ = env.step(action)
+        assert not terminated and not truncated and mid_reward == 0
+
+        action = _noop_action()
+        action["eot"] = 1
+        _, reward, terminated, _, info = env.step(action)
+
+        assert terminated is True
+        assert info["thput_raw"] < env._reward_baseline
+        assert reward < 0
 
 
 class TestStepsTaken:

--- a/tests/test_early_termination.py
+++ b/tests/test_early_termination.py
@@ -175,7 +175,10 @@ class TestReward:
         """Adding an entity that raises cost without raising throughput drops
         the score below the reset baseline, so the terminal reward goes
         negative (and stays negative through the optional compression)."""
-        env = _make_env(size=7, max_steps=10, reward_symlog_r0=reward_symlog_r0)
+        env = _make_env(
+            size=7, max_steps=10, reward_symlog_r0=reward_symlog_r0,
+            dense_reward=False,
+        )
         env.entity_cost_scale = 0.01
         env.reset(
             seed=42,
@@ -310,7 +313,7 @@ class TestMarginalRewardBaseline:
         assert reward == 0.0
 
     def test_destroying_the_protected_line_pays_negative(self):
-        env = _make_env(size=11, max_steps=10)
+        env = _make_env(size=11, max_steps=10, dense_reward=False)
         self._reset_cross(env)
 
         ent = env._world_CWH[Channel.ENTITIES.value].numpy()
@@ -373,3 +376,38 @@ class TestStepsTaken:
         # Episode isn't over yet
         assert not terminated and not truncated
         assert "steps_taken" not in info, "steps_taken should not be in info mid-episode"
+
+
+class TestDenseReward:
+    """Dense mode pays the terminal marginal reward in telescoped per-step
+    form: the undiscounted episode sum must equal the terminal scheme on the
+    same trajectory, with credit landing on the step that moved the score."""
+
+    def _destroy_then_eot(self, dense):
+        env = _make_env(size=11, max_steps=10, dense_reward=dense)
+        env.reset(seed=42, options={"kind": LessonKind.CROSS_UNDER_BELT,
+                                    "num_missing_entities": 0})
+        ent = env._world_CWH[Channel.ENTITIES.value].numpy()
+        xs, ys = np.nonzero(ent == str2ent("transport_belt").value)
+        action = _noop_action()
+        action["xy"] = np.array([int(xs[0]), int(ys[0])])
+        rewards = []
+        _, r, *_ = env.step(action)
+        rewards.append(r)
+        action = _noop_action()
+        action["eot"] = 1
+        _, r, terminated, _, _ = env.step(action)
+        rewards.append(r)
+        assert terminated
+        return rewards
+
+    def test_episode_sum_matches_terminal_scheme(self):
+        dense = self._destroy_then_eot(dense=True)
+        terminal = self._destroy_then_eot(dense=False)
+        assert sum(terminal[:-1]) == 0, "terminal scheme pays only at the end"
+        assert sum(dense) == pytest.approx(terminal[-1])
+
+    def test_credit_lands_on_the_causing_step(self):
+        dense = self._destroy_then_eot(dense=True)
+        assert dense[0] < 0, "destroying flow must pay negative immediately"
+        assert dense[1] == pytest.approx(0.0), "the EOT step changed nothing"

--- a/tests/test_early_termination.py
+++ b/tests/test_early_termination.py
@@ -1,6 +1,5 @@
 """Tests for early termination when the agent solves the puzzle."""
 
-import math
 import os
 import sys
 
@@ -22,17 +21,15 @@ def _make_env(size=5, max_steps=10, **kwargs):
     return FactorioEnv(size=size, max_steps=max_steps, idx=0, **kwargs)
 
 
-def _expected_reward(env, info):
-    """The terminal reward the env's configured scheme should have paid."""
+def _expected_total(env, info):
+    """The episode's improvement over reset in reference-rate units — what the
+    dense per-step rewards must sum (or a lone effective step must pay)."""
     score = info["thput_raw"] * info["cost_efficiency"]
-    reward = (
+    return (
         (score - env._reward_baseline) / env._max_throughput
         if env._max_throughput > 0
         else 0.0
     )
-    if env.reward_symlog_r0 > 0:
-        return math.copysign(math.log1p(abs(reward) / env.reward_symlog_r0), reward)
-    return reward
 
 
 def _noop_action():
@@ -149,7 +146,7 @@ class TestReward:
 
         assert truncated is True
         assert terminated is False
-        assert reward == pytest.approx(_expected_reward(env, info))
+        assert reward == pytest.approx(_expected_total(env, info))
 
     def test_eot_action_terminates_episode(self):
         """A non-solved factory ends immediately when the agent declares eot=1,
@@ -166,19 +163,12 @@ class TestReward:
         assert truncated is False
         assert info["frac_invalid_actions"] == 0
         assert info["thput_normed"] < 1.0  # ended early, not a full solve
-        assert reward == pytest.approx(_expected_reward(env, info))
+        assert reward == pytest.approx(_expected_total(env, info))
 
-    @pytest.mark.parametrize("reward_symlog_r0", [0.0, 0.01])
-    def test_junk_placement_on_unimproved_factory_pays_negative(
-        self, reward_symlog_r0
-    ):
+    def test_junk_placement_on_unimproved_factory_pays_negative(self):
         """Adding an entity that raises cost without raising throughput drops
-        the score below the reset baseline, so the terminal reward goes
-        negative (and stays negative through the optional compression)."""
-        env = _make_env(
-            size=7, max_steps=10, reward_symlog_r0=reward_symlog_r0,
-            dense_reward=False,
-        )
+        the score below the reset baseline, so the reward goes negative."""
+        env = _make_env(size=7, max_steps=10)
         env.entity_cost_scale = 0.01
         env.reset(
             seed=42,
@@ -208,11 +198,10 @@ class TestReward:
 
         assert terminated is True
         assert info["thput_normed"] >= 1.0
-        assert reward == pytest.approx(_expected_reward(env, info))
+        assert reward == pytest.approx(_expected_total(env, info))
         assert reward < 0
 
-    @pytest.mark.parametrize("reward_symlog_r0", [0.0, 0.01])
-    def test_zero_throughput_cost_penalty_is_never_negative(self, reward_symlog_r0):
+    def test_zero_throughput_cost_penalty_is_never_negative(self):
         """Entities that deliver nothing must score exactly zero, not negative:
         else an empty grid beats a nearly-complete factory and the policy is
         rewarded for building nothing. Holds because cost multiplies the
@@ -223,7 +212,6 @@ class TestReward:
             max_steps=10,
             idx=0,
             entity_cost_scale=1_000_000.0,
-            reward_symlog_r0=reward_symlog_r0,
         )
         env.reset(seed=42, options={"num_missing_entities": 99})
 
@@ -313,23 +301,25 @@ class TestMarginalRewardBaseline:
         assert reward == 0.0
 
     def test_destroying_the_protected_line_pays_negative(self):
-        env = _make_env(size=11, max_steps=10, dense_reward=False)
+        env = _make_env(size=11, max_steps=10)
         self._reset_cross(env)
 
         ent = env._world_CWH[Channel.ENTITIES.value].numpy()
         xs, ys = np.nonzero(ent == str2ent("transport_belt").value)
         action = _noop_action()
         action["xy"] = np.array([int(xs[0]), int(ys[0])])
-        _, mid_reward, terminated, truncated, _ = env.step(action)
-        assert not terminated and not truncated and mid_reward == 0
+        _, destroy_reward, terminated, truncated, _ = env.step(action)
+        assert not terminated and not truncated
+        assert destroy_reward < 0, "destroying flow must pay negative on that step"
 
         action = _noop_action()
         action["eot"] = 1
-        _, reward, terminated, _, info = env.step(action)
+        _, eot_reward, terminated, _, info = env.step(action)
 
         assert terminated is True
         assert info["thput_raw"] < env._reward_baseline
-        assert reward < 0
+        assert eot_reward == pytest.approx(0.0), "the EOT step changed nothing"
+        assert destroy_reward + eot_reward == pytest.approx(_expected_total(env, info))
 
 
 class TestStepsTaken:
@@ -376,38 +366,3 @@ class TestStepsTaken:
         # Episode isn't over yet
         assert not terminated and not truncated
         assert "steps_taken" not in info, "steps_taken should not be in info mid-episode"
-
-
-class TestDenseReward:
-    """Dense mode pays the terminal marginal reward in telescoped per-step
-    form: the undiscounted episode sum must equal the terminal scheme on the
-    same trajectory, with credit landing on the step that moved the score."""
-
-    def _destroy_then_eot(self, dense):
-        env = _make_env(size=11, max_steps=10, dense_reward=dense)
-        env.reset(seed=42, options={"kind": LessonKind.CROSS_UNDER_BELT,
-                                    "num_missing_entities": 0})
-        ent = env._world_CWH[Channel.ENTITIES.value].numpy()
-        xs, ys = np.nonzero(ent == str2ent("transport_belt").value)
-        action = _noop_action()
-        action["xy"] = np.array([int(xs[0]), int(ys[0])])
-        rewards = []
-        _, r, *_ = env.step(action)
-        rewards.append(r)
-        action = _noop_action()
-        action["eot"] = 1
-        _, r, terminated, _, _ = env.step(action)
-        rewards.append(r)
-        assert terminated
-        return rewards
-
-    def test_episode_sum_matches_terminal_scheme(self):
-        dense = self._destroy_then_eot(dense=True)
-        terminal = self._destroy_then_eot(dense=False)
-        assert sum(terminal[:-1]) == 0, "terminal scheme pays only at the end"
-        assert sum(dense) == pytest.approx(terminal[-1])
-
-    def test_credit_lands_on_the_causing_step(self):
-        dense = self._destroy_then_eot(dense=True)
-        assert dense[0] < 0, "destroying flow must pay negative immediately"
-        assert dense[1] == pytest.approx(0.0), "the EOT step changed nothing"

--- a/tests/test_rl_from_checkpoint.py
+++ b/tests/test_rl_from_checkpoint.py
@@ -150,7 +150,7 @@ class TestEotTerminationAndMetrics:
 
     def test_reward_symlog_r0_default(self):
         a = PpoArgs()
-        assert a.reward_symlog_r0 == 0.01
+        assert a.reward_symlog_r0 == 0.0
 
 
 class TestCriticWarmupParamSplit:

--- a/tests/test_rl_from_checkpoint.py
+++ b/tests/test_rl_from_checkpoint.py
@@ -148,10 +148,6 @@ class TestEotTerminationAndMetrics:
         a = PpoArgs()
         assert a.entity_cost_scale == 0.001
 
-    def test_reward_symlog_r0_default(self):
-        a = PpoArgs()
-        assert a.reward_symlog_r0 == 0.0
-
 
 class TestCriticWarmupParamSplit:
     def _split(self, agent):

--- a/training_config.py
+++ b/training_config.py
@@ -138,17 +138,6 @@ class PpoArgs(SharedArgs):
     """strength of the multiplicative terminal entity-cost penalty. Each
     entity costs its per-output recursively-expanded raw-item count plus
     cumulative craft time."""
-    reward_symlog_r0: float = 0.0
-    """optional compression knee for the terminal reward: when > 0 the
-    ceiling-normalized marginal reward r becomes sign(r) * log1p(|r| / r0).
-    0 disables — the reward is already O(1) for every lesson."""
-    dense_reward: bool = True
-    """pay the terminal marginal reward in telescoped per-step form: each step
-    rewards the change in ceiling-normalized cost-adjusted throughput. The
-    undiscounted episode sum is identical to the terminal scheme; credit lands
-    on the placement that caused it, so improving an already-working build
-    (extra inserter, parallel assembler) pays immediately instead of hinging
-    on EOT timing. Costs a throughput sim per step in the training rollout."""
     max_grad_norm: float = 1.221
     """the maximum norm for the gradient clipping"""
     target_kl: Optional[float] = 0.02

--- a/training_config.py
+++ b/training_config.py
@@ -139,9 +139,10 @@ class PpoArgs(SharedArgs):
     """strength of the multiplicative terminal entity-cost penalty. Each
     entity costs its per-output recursively-expanded raw-item count plus
     cumulative craft time."""
-    reward_symlog_r0: float = 0.01
-    """reference flow (items/s) at which the terminal reward is log-compressed:
-    `log1p(thput_raw * cost_efficiency / r0)`."""
+    reward_symlog_r0: float = 0.0
+    """optional compression knee for the terminal reward: when > 0 the
+    ceiling-normalized marginal reward r becomes sign(r) * log1p(|r| / r0).
+    0 disables — the reward is already O(1) for every lesson."""
     max_grad_norm: float = 1.221
     """the maximum norm for the gradient clipping"""
     target_kl: Optional[float] = 0.02

--- a/training_config.py
+++ b/training_config.py
@@ -142,6 +142,13 @@ class PpoArgs(SharedArgs):
     """optional compression knee for the terminal reward: when > 0 the
     ceiling-normalized marginal reward r becomes sign(r) * log1p(|r| / r0).
     0 disables — the reward is already O(1) for every lesson."""
+    dense_reward: bool = True
+    """pay the terminal marginal reward in telescoped per-step form: each step
+    rewards the change in ceiling-normalized cost-adjusted throughput. The
+    undiscounted episode sum is identical to the terminal scheme; credit lands
+    on the placement that caused it, so improving an already-working build
+    (extra inserter, parallel assembler) pays immediately instead of hinging
+    on EOT timing. Costs a throughput sim per step in the training rollout."""
     max_grad_norm: float = 1.221
     """the maximum norm for the gradient clipping"""
     target_kl: Optional[float] = 0.02

--- a/training_config.py
+++ b/training_config.py
@@ -113,8 +113,7 @@ class PpoArgs(SharedArgs):
     """the number of steps to run in each environment per policy rollout"""
     anneal_lr: bool = True
     """Toggle learning rate annealing for policy and value networks"""
-    # gamma is fine for now, check sweep v3ohvfpl for details
-    gamma: float = 0.9566
+    gamma: float = 0.997
     """the discount factor gamma"""
     gae_lambda: float = 0.9187
     """the lambda for the general advantage estimation"""


### PR DESCRIPTION
# Hypothesis

Behavioral rollouts of #398's checkpoint ([`jgpof5zo`](https://wandb.ai/beyarkay/factorion/runs/jgpof5zo), 120 greedy + 300 sampled episodes/kind) localize the trial/FACTORY ceiling: the policy builds one right-recipe assembler in 84% of TRIAL_1 episodes but **never improves a working build** — zero second inserters/assemblers in 720 episodes, a hard 0.86 ceiling (the single-inserter rate), FACTORY always the minimal `1 asm × 1-in × 1-out` chain (median 0.33), and EOT fired at first success (median 6–11 steps). Under terminal-only reward, an additive improvement is invisible unless the policy delays an EOT it has already learned to fire early — a two-step credit gap PPO can't see across.

Fix: pay the same reward **densely** — each step pays `Δ(cost-adjusted thput / ceiling)`. The undiscounted episode sum telescopes to exactly the current terminal reward (verified by test), so no objective change; but a second output inserter on a 0.86 build now pays +0.14 *on that step*. Stacks on #400's γ=0.997 (this branch = #400 + one commit). Cost: one throughput sim per training step, ≈ −10% sps.

## Predictions (vs [`626ofz10`](https://wandb.ai/beyarkay/factorion/runs/626ofz10) = same config minus density, at matched steps, seed-paired)

1. **The headline gate (user's 20M criterion): `eval/TRIAL_RECIPE_TREE_DEPTH_1/thput` breaks the 0.23 plateau — target ≥ 0.35 by 5M**, driven by multi-inserter builds breaking the 0.86 cap (watch for per-episode normed > 0.86, impossible for single-inserter builds).
2. `eval/FACTORY_1_INGREDIENT/thput` ≥ A.A's (0.78+): dense credit should accelerate, not disturb, the multi-assembler frontier. Any episode > 1.01 normed = super-reference discovery.
3. Lessons stay ≥ A.A within noise (`eval/thput` ≥ 0.9): density adds no new equilibria (sum-preserving), so no regression expected.
4. Kill signature: value-loss instability from the denser reward (critic now fits per-step deltas); if `critic/explained_variance` < 0.3 after warmup or losses NaN, kill and revisit `vf_coef`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111hhnS39Cp9xQHKksp9J2i

---
_Generated by [Claude Code](https://claude.ai/code/session_0111hhnS39Cp9xQHKksp9J2i)_