### PR TITLE
Arm C: sample tile actions under the legal mask during training

### DIFF
--- a/ppo.py
+++ b/ppo.py
@@ -1623,7 +1623,7 @@ class AgentCNN(nn.Module):
         x_BCWH,
         *,
         temperature: float = 1.0,
-        legal_mask: bool = False,
+        legal_mask: bool = True,
         eot_threshold: float = 0.5,
         action=None,
         compute_value: bool = True,
@@ -1631,8 +1631,10 @@ class AgentCNN(nn.Module):
         """The one sampler every consumer routes through. temperature=1 is the
         stochastic PPO path (eot ~ Bernoulli); temperature=0 is greedy argmax
         (eot fires at p>eot_threshold) for eval / mod server / builder UI.
-        legal_mask restricts the tile pick to empty+buildable cells; `action`
-        replays a stored action to recompute its log-prob. Returns a dict of
+        The tile pick is restricted to empty+buildable cells — training,
+        eval and inference all act on this masked distribution;
+        legal_mask=False exposes the raw tile head (builder diagnostics only).
+        `action` replays a stored action to recompute its log-prob. Returns a dict of
         action / logp / entropy / value (None if not compute_value) / eot_prob
         / logp_heads (per-head log-probs, so the UI needn't re-derive them)."""
         # Encode input once and reuse for both action and value heads
@@ -1645,9 +1647,12 @@ class AgentCNN(nn.Module):
         tile_logits_B1WH = self.tile_logits(encoded_BCWH)      # (B, 1, W, H)
         tile_logits_BN = tile_logits_B1WH.reshape(B, -1)       # (B, W*H)
         if legal_mask:
-            tile_logits_BN = tile_logits_BN.masked_fill(
-                ~_legal_tile_mask(x_BCWH), float("-inf")
-            )
+            mask_BN = _legal_tile_mask(x_BCWH)
+            # A fully-built grid has no legal tile; leave that row unmasked
+            # rather than softmax over all -inf (the pick is rejected by the
+            # env either way).
+            mask_BN |= ~mask_BN.any(dim=-1, keepdim=True)
+            tile_logits_BN = tile_logits_BN.masked_fill(~mask_BN, float("-inf"))
         tile_logp_all_BN = F.log_softmax(tile_logits_BN, dim=-1)
 
         if action is None:
@@ -1766,7 +1771,8 @@ class AgentCNN(nn.Module):
         }
 
     def get_action_and_value(self, x_BCWH, action=None):
-        """sample_action at temperature 1, projected to the (action, logp,
+        """sample_action at temperature 1 under the legal-tile mask, projected
+        to the (action, logp,
         entropy, value) 4-tuple the ~20 PPO/test callsites already unpack."""
         out = self.sample_action(x_BCWH, temperature=1.0, action=action)
         return out["action"], out["logp"], out["entropy"], out["value"]

--- a/tests/test_rl_from_checkpoint.py
+++ b/tests/test_rl_from_checkpoint.py
@@ -448,3 +448,29 @@ class TestWarmupIterationKl:
         assert max(warmup_iteration["kls"]) < target_kl, (
             "target_kl would break the epoch loop with the actor frozen"
         )
+
+
+class TestTrainingLegalMask:
+    """Training-time sampling is restricted to legal tiles, matching the
+    masked distribution eval/inference always used — invalid placements are
+    unrepresentable rather than cheap no-ops the entropy bonus subsidises."""
+
+    def test_sampled_tiles_are_legal(self, agent, registered_env):
+        env = FactorioEnv(size=5)
+        obs, _ = env.reset(seed=5, options={"kind": LessonKind.MOVE_ONE_ITEM})
+        obs_t = torch.as_tensor(np.asarray(obs), dtype=torch.float32)
+        obs_B = obs_t.unsqueeze(0).expand(64, -1, -1, -1)
+        action, logp, _, _ = agent.get_action_and_value(obs_B)
+        ent = obs_t[Channel.ENTITIES.value]
+        foot = obs_t[Channel.FOOTPRINT.value]
+        for x, y in action["xy"].tolist():
+            assert ent[x, y] == 0, f"sampled occupied tile ({x},{y})"
+            assert foot[x, y] != 0, f"sampled unbuildable tile ({x},{y})"
+        assert torch.isfinite(logp).all()
+
+    def test_full_grid_does_not_nan(self, agent):
+        obs = torch.zeros(2, NUM_CHANNELS, 5, 5)
+        obs[:, Channel.ENTITIES.value] = 1.0  # every tile occupied
+        obs[:, Channel.FOOTPRINT.value] = 1.0
+        _, logp, entropy, _ = agent.get_action_and_value(obs)
+        assert torch.isfinite(logp).all() and torch.isfinite(entropy).all()


### PR DESCRIPTION
# Hypothesis

The owner's builder specimens (TRIAL_1 seeds 41/45/46) show a consistent failure shape: entity/direction/item heads correct, tile head with 75–85% mass on *occupied* cells and the correct empty cell at 5–8%. Root cause chain, verified in code:

1. `get_action_and_value` — the PPO rollout **and** update path — sampled `sample_action` with `legal_mask=False`, while eval (`run_rollout_eval`), the mod server, and greedy inference all mask. One sampler, two distributions: training optimized a policy no consumer deploys.
2. An occupied-tile pick is rejected as a no-op: world unchanged, dense reward delta 0, TD error `(γ−1)·V ≈ −0.003·V` at γ=0.997 — a ~zero gradient against it.
3. The entropy bonus actively subsidizes parking mass on these free no-ops. This explains two previously unexplained observations from the 2026-08-12 session: rising `rollout/invalid_frac` in the γ-family runs (0.3% → 6% → **26%** in [`4v39sxiq`](https://wandb.ai/beyarkay/factorion/runs/4v39sxiq)'s tail) and its never-annealing entropy (3.36 at end; `entropy_tile` 1.47 vs 0.99).

Fix: the legal mask (`empty ∧ buildable`, the same `_legal_tile_mask` eval uses) defaults **on** in `sample_action`, applied identically at sampling and update-time log-prob recomputation (importance ratios stay well-defined; stored actions are legal by construction). All-full grids fall back to unmasked instead of softmaxing over all `-inf`. `legal_mask=False` survives only for the builder's raw-head diagnostics toggle — the one legitimate consumer.

Why masking rather than training-the-head-clean: legality is a two-term boolean of the observation the env computes for free; the "train it out" alternative ran as the status quo for 5M steps × 6 runs this session and lost to the entropy subsidy structurally (equilibrium keeps p(invalid) > 0 at any penalty size). Masking is the standard constrained-action-space treatment and gets exactly zero, tuning-free. Known semantic narrowing: training can no longer sample delete actions (empty-onto-occupied) — eval already couldn't express them, so nothing deployed changes.

Not expected to change SFT anything (its CE loss never samples; its eval already masks).

## Predictions (5M from [`hcozpmwt`](https://wandb.ai/beyarkay/factorion/runs/hcozpmwt), vs merged-main runs [`4v39sxiq`](https://wandb.ai/beyarkay/factorion/runs/4v39sxiq)/[`626ofz10`](https://wandb.ai/beyarkay/factorion/runs/626ofz10) at matched steps, seed-paired)

1. `rollout/invalid_frac` ≈ 0 from step one (only non-tile invalid reasons remain) — structural, not learned.
2. `policy/entropy` anneals properly through the tail (no free-entropy reservoir); `entropy_tile` well below 1.4; the A.A.C-tail destabilization does not reproduce.
3. Sample-efficiency gain from the reallocated exploration budget: `eval/thput` at or above the merged-main trajectory at matched steps, final ≥ 0.94.
4. `rollout/TRIAL_*` sampled metrics improve (trial rollouts currently waste ~18% of actions on invalids); modest `eval/TRIAL_1` gain possible, not promised — the grading-lottery (#411) caps interpretability there.
5. Kill signature: `losses/approx_kl` spiking at the start (masked distribution far from the SFT prior's unmasked one) — if KL-triggered early-stopping thrashes in the first iterations, revisit with a critic-warmup-style ramp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111hhnS39Cp9xQHKksp9J2i

---
_Generated by [Claude Code](https://claude.ai/code/session_0111hhnS39Cp9xQHKksp9J2i)_